### PR TITLE
Add clone operation with a cascading submenu

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -6080,6 +6080,31 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     width: 200px; /* see also edit_menu.js */
 }
 
+/* Cascading flyout (e.g. clone types); positioned beside the menu in edit_menu.js */
+.edit-menu-submenu {
+    box-shadow: 0 0 12px 2px rgba(0, 0, 0, 0.2);
+    z-index: 1;
+}
+/* Keep each submenu label on one line; the panel widens to fit the longest */
+.edit-menu-submenu .edit-menu-item .label {
+    max-width: none;
+    white-space: nowrap;
+}
+.edit-menu-submenu-header {
+    max-width: 220px;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.3);
+}
+.edit-menu-submenu-title {
+    font-weight: bold;
+}
+.edit-menu-submenu-description {
+    margin-top: 2px;
+    font-size: 11px;
+    line-height: 1.2em;
+    opacity: 0.7;
+}
+
 .edit-menu-item {
     display: flex;
     align-items: center;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -135,6 +135,58 @@ en:
       already_circular:
         single: This can't be made more circular than it already is.
         multiple: These can't be made more circular than they already are.
+    clone:
+      title: Clone tags
+      description: Clone tags from the first selected feature onto the others.
+      annotation: Clone tags.
+    clone_address:
+      title: Clone address tags
+      description: Clone address tags from the first selected feature.
+      annotation: Clone the address tags.
+    clone_name:
+      title: Clone name and operator tags
+      description: Clone name and operator tags from the first selected feature.
+      annotation: Clone the name and operator tags.
+    clone_lanes:
+      title: Clone lanes tags
+      description: Clone lanes tags from the first selected feature.
+      annotation: Clone the lanes tags.
+    clone_turn_lanes:
+      title: Clone turn lanes tags
+      description: Clone turn lanes tags from the first selected feature.
+      annotation: Clone the turn lanes tags.
+    clone_sidewalk:
+      title: Clone sidewalk tags
+      description: Clone sidewalk tags from the first selected feature.
+      annotation: Clone the sidewalk tags.
+    clone_cycleway:
+      title: Clone cycleway tags
+      description: Clone cycleway tags from the first selected feature.
+      annotation: Clone the cycleway tags.
+    clone_bicycle_tag:
+      title: Clone bicycle tag
+      description: Clone bicycle tag from the first selected feature.
+      annotation: Clone the bicycle tag.
+    clone_bus_lanes:
+      title: Clone bus lanes tags
+      description: Clone bus lanes tags from the first selected feature.
+      annotation: Clone the bus lanes tags.
+    clone_transition:
+      title: Clone road transition tags
+      description: Clone road transition tags from the first selected feature.
+      annotation: Clone the road transition tags.
+    clone_maxspeed:
+      title: Clone maxspeed tag
+      description: Clone maxspeed tag from the first selected feature.
+      annotation: Clone the maxspeed tag.
+    clone_surface:
+      title: Clone surface tag
+      description: Clone surface tag from the first selected feature.
+      annotation: Clone the surface tag.
+    clone_dual_carriageway:
+      title: Clone dual carriageway tags
+      description: Clone dual carriageway tags from the first selected feature.
+      annotation: Clone the dual carriageway tags.
     curverize:
       title: Curve
       description:

--- a/modules/actions/clone.ts
+++ b/modules/actions/clone.ts
@@ -1,0 +1,50 @@
+// =============================================================================
+// CLONE - Copy a set of tags from the first selected entity onto the others
+// =============================================================================
+
+/**
+ * Build an action that copies the given tags from the first selected entity
+ * (the source) onto every other selected entity (the targets).
+ *
+ * Only tags present on the source are copied; existing target tags are kept and
+ * never cleared. When `languageSuffixes` is provided, the `<tag>:<suffix>`
+ * variants (e.g. `name:fr`, `name:en`) are copied too when present on the source.
+ *
+ * @param selectedIds - selected entity ids; `selectedIds[0]` is the source
+ * @param cloneTags - tag keys to copy from the source
+ * @param languageSuffixes - optional language suffixes to also copy per tag
+ * @returns an iD action of the form (graph) => graph
+ */
+export function actionClone(selectedIds: EntityID[], cloneTags: string[], languageSuffixes: string[] = []) {
+
+    function action(graph: iD.Graph): iD.Graph {
+        const entities = selectedIds.map((selectedID) => graph.entity(selectedID));
+        const sourceTags = entities[0].tags;
+
+        for (let i = 1; i < entities.length; i++) {
+            const tags = Object.assign({}, entities[i].tags);
+            for (const cloneTag of cloneTags) {
+                if (sourceTags[cloneTag] !== undefined) {
+                    tags[cloneTag] = sourceTags[cloneTag];
+                }
+                for (const suffix of languageSuffixes) {
+                    const suffixedTag = cloneTag + ':' + suffix;
+                    if (sourceTags[suffixedTag] !== undefined) {
+                        tags[suffixedTag] = sourceTags[suffixedTag];
+                    }
+                }
+            }
+            graph = graph.replace(entities[i].update({ tags }));
+        }
+
+        return graph;
+    }
+
+    action.disabled = function (): boolean {
+        return false;
+    };
+
+    action.transitionable = true;
+
+    return action;
+}

--- a/modules/operations/clone.ts
+++ b/modules/operations/clone.ts
@@ -1,0 +1,173 @@
+import { t } from '../core/localizer';
+import { actionClone } from '../actions/clone';
+import { behaviorOperation } from '../behavior/operation';
+
+/** A clone type: the menu/i18n id, the tags it copies, and optional extras. */
+interface CloneType {
+    id: string;
+    tags: string[];
+    /** Language suffixes (e.g. ['fr','en']) whose `<tag>:<suffix>` variants are also copied. */
+    languageSuffixes?: string[];
+    /** Keyboard shortcut. Left undefined for now; set it to enable a per-type shortcut. */
+    key?: string;
+}
+
+/**
+ * Clone types. To give a type its own keyboard shortcut later,
+ * just add a `key` here — it is wired automatically through `behaviorOperation`.
+ */
+export const cloneTypes: CloneType[] = [
+    { id: 'clone_address', tags: [
+        'addr:housenumber', 'addr:housename', 'addr:street', 'addr:city', 'addr:province',
+        'addr:borough', 'addr:postcode', 'addr:source', 'addr:suburb', 'addr:state',
+        'addr:place', 'addr:full', 'addr:county', 'addr:district', 'addr:hamlet', 'addr:subdistrict',
+        'contact:housenumber', 'contact:housename', 'contact:street', 'contact:city', 'contact:province',
+        'contact:borough', 'contact:postcode', 'contact:source', 'contact:suburb', 'contact:state',
+        'contact:place', 'contact:full', 'contact:county', 'contact:district', 'contact:hamlet',
+        'contact:subdistrict', 'contact:country'
+    ] },
+    { id: 'clone_name', tags: [
+        'name', 'operator', 'alt_name', 'old_name', 'short_name', 'official_name', 'int_name',
+        'loc_name', 'name:left', 'name:right', 'nat_name', 'ref_name', 'reg_name', 'sorting_name', 'nickname'
+    ], languageSuffixes: ['fr', 'en'] },
+    { id: 'clone_lanes', tags: ['lanes', 'lanes:forward', 'lanes:backward'] },
+    { id: 'clone_turn_lanes', tags: ['turn:lanes', 'turn:lanes:forward', 'turn:lanes:backward'] },
+    { id: 'clone_sidewalk', tags: ['sidewalk', 'sidewalk:both', 'sidewalk:right', 'sidewalk:left', 'foot'] },
+    { id: 'clone_cycleway', tags: [
+        'bicycle', 'cycleway', 'cycleway:both', 'cycleway:right', 'cycleway:buffer', 'cycleway:marking',
+        'cycleway:right:marking', 'cycleway:left:marking', 'cycleway:separation', 'cycleway:right:separation',
+        'cycleway:right:buffer', 'cycleway:right:oneway', 'cycleway:left:separation', 'cycleway:left:buffer',
+        'cycleway:left:oneway', 'cycleway:left', 'oneway:bicycle', 'lcn'
+    ] },
+    { id: 'clone_bicycle_tag', tags: ['bicycle'] },
+    { id: 'clone_bus_lanes', tags: [
+        'bus:lanes', 'bus:lanes:forward', 'bus:lanes:backward', 'lanes:bus', 'lanes:bus:forward',
+        'lanes:bus:backward', 'busway:right', 'busway:left', 'routing:bus', 'bus'
+    ] },
+    { id: 'clone_transition', tags: [
+        'placement', 'placement:start', 'placement:end', 'width:lanes:start', 'width:lanes:end',
+        'placement:forward', 'width:lanes:forward:start', 'width:lanes:forward:end',
+        'placement:backward', 'width:lanes:backward:start', 'width:lanes:backward:end'
+    ] },
+    { id: 'clone_maxspeed', tags: ['maxspeed'] },
+    { id: 'clone_surface', tags: ['surface'] },
+    { id: 'clone_dual_carriageway', tags: ['dual_carriageway'] }
+];
+
+/** True when at least one of `tags` is set on the source (first selected) entity. */
+function sourceHasAnyTag(context: iD.Context, selectedIDs: EntityID[], tags: string[]): boolean {
+    if (selectedIDs.length < 2) return false;
+    const source = context.hasEntity(selectedIDs[0]);
+    return !!source && tags.some((tag) => source.tags[tag] !== undefined);
+}
+
+/**
+ * Build a clone sub-operation for one `CloneType`. These are hidden from the
+ * edit menu's top level (`hiddenFromEditMenu`) and surfaced inside the `clone`
+ * submenu, but they are still registered so their (future) shortcut works.
+ *
+ * @param type - the clone type configuration
+ * @returns an operation factory `(context, selectedIDs) => operation`
+ */
+function makeCloneOperation(type: CloneType) {
+    return function (context: iD.Context, selectedIDs: EntityID[]) {
+
+        const action = actionClone(selectedIDs, type.tags, type.languageSuffixes);
+
+        function operation() {
+            context.perform(action, operation.annotation());
+
+            window.setTimeout(function () {
+                context.validator().validate();
+            }, 300);  // after any transition
+        }
+
+        operation.available = function (): boolean {
+            return sourceHasAnyTag(context, selectedIDs, type.tags);
+        };
+
+        operation.disabled = function (): boolean {
+            return false;
+        };
+
+        operation.tooltip = function () {
+            return t.append('operations.' + type.id + '.description');
+        };
+
+        operation.annotation = function (): string {
+            return t('operations.' + type.id + '.annotation');
+        };
+
+        operation.id = type.id;
+        operation.keys = (type.key ? [type.key] : []) as string[];
+        operation.title = t.append('operations.' + type.id + '.title');
+        operation.icon = function (): string {
+            return '#iD-operation-clone';
+        };
+        operation.hiddenFromEditMenu = true;
+        operation.behavior = behaviorOperation(context).which(operation);
+
+        return operation;
+    };
+}
+
+/**
+ * Container operation shown in the edit menu. Clicking it opens a submenu (see
+ * `uiEditMenu`) listing the available clone sub-operations. It performs nothing
+ * on its own.
+ *
+ * @param context - the iD application context
+ * @param selectedIDs - currently selected entity ids
+ * @returns the container operation, with `subOperations()` for the submenu
+ */
+export function operationClone(context: iD.Context, selectedIDs: EntityID[]) {
+
+    function operation() {
+        // no-op: the edit menu opens the submenu via operation.subOperations()
+    }
+
+    operation.available = function (): boolean {
+        return cloneTypes.some((type) => sourceHasAnyTag(context, selectedIDs, type.tags));
+    };
+
+    operation.disabled = function (): boolean {
+        return false;
+    };
+
+    operation.tooltip = function () {
+        return t.append('operations.clone.description');
+    };
+
+    operation.annotation = function (): string {
+        return t('operations.clone.annotation');
+    };
+
+    operation.id = 'clone';
+    operation.keys = [] as string[];
+    operation.title = t.append('operations.clone.title');
+    operation.behavior = behaviorOperation(context).which(operation);
+
+    /** Available clone sub-operations, listed in the submenu. */
+    operation.subOperations = function () {
+        return cloneTypes
+            .map((type) => makeCloneOperation(type)(context, selectedIDs))
+            .filter((subOp) => subOp.available());
+    };
+
+    return operation;
+}
+
+// Individual sub-operations, exported so the mode installs their keybindings.
+// They stay hidden from the edit menu's top level and appear in the clone submenu.
+export const operationCloneAddress = makeCloneOperation(cloneTypes[0]);
+export const operationCloneName = makeCloneOperation(cloneTypes[1]);
+export const operationCloneLanes = makeCloneOperation(cloneTypes[2]);
+export const operationCloneTurnLanes = makeCloneOperation(cloneTypes[3]);
+export const operationCloneSidewalk = makeCloneOperation(cloneTypes[4]);
+export const operationCloneCycleway = makeCloneOperation(cloneTypes[5]);
+export const operationCloneBicycleTag = makeCloneOperation(cloneTypes[6]);
+export const operationCloneBusLanes = makeCloneOperation(cloneTypes[7]);
+export const operationCloneTransition = makeCloneOperation(cloneTypes[8]);
+export const operationCloneMaxspeed = makeCloneOperation(cloneTypes[9]);
+export const operationCloneSurface = makeCloneOperation(cloneTypes[10]);
+export const operationCloneDualCarriageway = makeCloneOperation(cloneTypes[11]);

--- a/modules/operations/index.js
+++ b/modules/operations/index.js
@@ -1,4 +1,19 @@
 export { operationCircularize } from './circularize';
+export {
+    operationClone,
+    operationCloneAddress,
+    operationCloneName,
+    operationCloneLanes,
+    operationCloneTurnLanes,
+    operationCloneSidewalk,
+    operationCloneCycleway,
+    operationCloneBicycleTag,
+    operationCloneBusLanes,
+    operationCloneTransition,
+    operationCloneMaxspeed,
+    operationCloneSurface,
+    operationCloneDualCarriageway
+} from './clone';
 export { operationContinue } from './continue';
 export { operationCopy } from './copy';
 export { operationCurverize } from './curverize';

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -28,6 +28,12 @@ export function uiEditMenu(context) {
     var _menuTop = false;
     var _menuHeight;
     var _menuWidth;
+    // whether the menu is displayed on the left of the anchor (near the right edge)
+    var _menuLeft = false;
+
+    // the cascading submenu flyout (e.g. clone types) and its delayed-close timer
+    var _submenu = d3_select(null);
+    var _submenuTimer;
 
     // hardcode these values to make menu positioning easier
     var _verticalPadding = 4;
@@ -44,13 +50,14 @@ export function uiEditMenu(context) {
 
         var isTouchMenu = _triggerType.includes('touch') || _triggerType.includes('pen');
 
-        var ops = _operations.filter(function(op) {
-            return !isTouchMenu || !op.mouseOnly;
+        // Operations flagged `hiddenFromEditMenu` don't appear at the top level;
+        // they are surfaced inside a submenu opened by a container operation
+        // (e.g. the clone types under the `clone` operation).
+        var topOps = _operations.filter(function(op) {
+            return !op.hiddenFromEditMenu && (!isTouchMenu || !op.mouseOnly);
         });
 
-        if (!ops.length) return;
-
-        _tooltips = [];
+        if (!topOps.length) return;
 
         // Position the menu above the anchor for stylus and finger input
         // since the mapper's hand likely obscures the screen below the anchor
@@ -58,18 +65,18 @@ export function uiEditMenu(context) {
 
         // Show labels for touch input since there aren't hover tooltips
         var showLabels = isTouchMenu;
-
         var buttonHeight = showLabels ? 32 : 34;
         if (showLabels) {
             // Get a general idea of the width based on the length of the label
-            _menuWidth = 52 + Math.min(120, 6 * Math.max.apply(Math, ops.map(function(op) {
-                return op.title.length;
+            _menuWidth = 52 + Math.min(120, 6 * Math.max.apply(Math, topOps.map(function(op) {
+                return (op.title && op.title.length) || 10;
             })));
         } else {
             _menuWidth = 44;
         }
 
-        _menuHeight = _verticalPadding * 2 + ops.length * buttonHeight;
+        _menuHeight = _verticalPadding * 2 + topOps.length * buttonHeight;
+        _tooltips = [];
 
         _menu = selection
             .append('div')
@@ -77,70 +84,7 @@ export function uiEditMenu(context) {
             .classed('touch-menu', isTouchMenu)
             .style('padding', _verticalPadding + 'px 0');
 
-        var buttons = _menu.selectAll('.edit-menu-item')
-            .data(ops);
-
-        // enter
-        var buttonsEnter = buttons.enter()
-            .append('button')
-            .attr('class', function (d) { return 'edit-menu-item edit-menu-item-' + d.id; })
-            .style('height', buttonHeight + 'px')
-            .on('click', click)
-            // don't listen for `mouseup` because we only care about non-mouse pointer types
-            .on('pointerup', pointerup)
-            .on('pointerdown mousedown', function pointerdown(d3_event) {
-                // don't let button presses also act as map input - #1869
-                d3_event.stopPropagation();
-            })
-            .on('mouseenter.highlight', function(d3_event, d) {
-                if (d3_select(this).classed('disabled')) return;
-
-                if (d.relatedEntityIds) {
-                    utilHighlightEntities(d.relatedEntityIds(), true, context);
-                }
-
-                if (d.getAuxiliaryGeometry) {
-                    drawAuxiliaryGeometry(context, d.getAuxiliaryGeometry());
-                }
-            })
-            .on('mouseleave.highlight', function(d3_event, d) {
-                if (d.relatedEntityIds) {
-                    utilHighlightEntities(d.relatedEntityIds(), false, context);
-                }
-
-                if (d.getAuxiliaryGeometry) {
-                    drawAuxiliaryGeometry(context, []);
-                }
-            });
-
-        buttonsEnter.each(function(d) {
-            var tooltip = uiTooltip()
-                .scrollContainer(context.container().select('.over-map'))
-                .heading(() => d.title)
-                .title(d.tooltip)
-                .keys([d.keys[0]]);
-
-            _tooltips.push(tooltip);
-
-            d3_select(this)
-                .call(tooltip)
-                .append('div')
-                .attr('class', 'icon-wrap')
-                .call(svgIcon(d.icon && d.icon() || '#iD-operation-' + d.id, 'operation'));
-        });
-
-        if (showLabels) {
-            buttonsEnter.append('span')
-                .attr('class', 'label')
-                .each(function(d) {
-                    d3_select(this).call(d.title);
-                });
-        }
-
-        // update
-        buttonsEnter
-            .merge(buttons)
-            .classed('disabled', function(d) { return d.disabled(); });
+        renderButtons(_menu, topOps, showLabels, true);
 
         updatePosition();
 
@@ -155,6 +99,147 @@ export function uiEditMenu(context) {
                 if (info.full) updatePosition();
             });
 
+        dispatch.call('toggled', this, true);
+
+
+        // Render operation buttons into `container`. `withLabels` adds text
+        // labels; `isMainMenu` adds tooltips and the submenu hover handling.
+        function renderButtons(container, ops, withLabels, isMainMenu) {
+
+            var height = withLabels ? 32 : 34;
+
+            var buttons = container.selectAll('.edit-menu-item')
+                .data(ops, function(d) { return d.id; });
+
+            buttons.exit().remove();
+
+            // enter
+            var buttonsEnter = buttons.enter()
+                .append('button')
+                .attr('class', function (d) { return 'edit-menu-item edit-menu-item-' + d.id; })
+                .style('height', height + 'px')
+                .on('click', click)
+                // don't listen for `mouseup` because we only care about non-mouse pointer types
+                .on('pointerup', pointerup)
+                .on('pointerdown mousedown', function pointerdown(d3_event) {
+                    // don't let button presses also act as map input - #1869
+                    d3_event.stopPropagation();
+                })
+                .on('mouseenter.highlight', function(d3_event, d) {
+                    if (d3_select(this).classed('disabled')) return;
+
+                    if (d.relatedEntityIds) {
+                        utilHighlightEntities(d.relatedEntityIds(), true, context);
+                    }
+
+                    if (d.getAuxiliaryGeometry) {
+                        drawAuxiliaryGeometry(context, d.getAuxiliaryGeometry());
+                    }
+                })
+                .on('mouseleave.highlight', function(d3_event, d) {
+                    if (d.relatedEntityIds) {
+                        utilHighlightEntities(d.relatedEntityIds(), false, context);
+                    }
+
+                    if (d.getAuxiliaryGeometry) {
+                        drawAuxiliaryGeometry(context, []);
+                    }
+                });
+
+            if (isMainMenu) {
+                buttonsEnter.on('mouseenter.submenu', function(d3_event, d) {
+                    // Container ops (e.g. clone) open a flyout beside the menu;
+                    // other items close any open flyout.
+                    if (d.subOperations) {
+                        openSubmenu(this, d);
+                    } else {
+                        closeSubmenu();
+                    }
+                });
+            }
+
+            buttonsEnter.each(function(d) {
+                var sel = d3_select(this);
+
+                // Container ops show their title/description in the submenu header
+                // instead of a hover tooltip that would overlap the flyout.
+                if (isMainMenu && !d.subOperations) {
+                    var tooltip = uiTooltip()
+                        .scrollContainer(context.container().select('.over-map'))
+                        .heading(() => d.title)
+                        .title(d.tooltip)
+                        .keys(d.keys && d.keys.length ? [d.keys[0]] : []);
+
+                    _tooltips.push(tooltip);
+                    sel.call(tooltip);
+                }
+
+                sel.append('div')
+                    .attr('class', 'icon-wrap')
+                    .call(svgIcon(d.icon && d.icon() || '#iD-operation-' + d.id, 'operation'));
+            });
+
+            if (withLabels) {
+                buttonsEnter.append('span')
+                    .attr('class', 'label')
+                    .each(function(d) {
+                        d3_select(this).call(d.title);
+                    });
+            }
+
+            // update
+            buttonsEnter
+                .merge(buttons)
+                .classed('disabled', function(d) { return d.disabled(); });
+        }
+
+
+        // Open the cascading flyout for a container operation, anchored to the
+        // right (or left near the viewport edge) of the hovered button.
+        function openSubmenu(buttonNode, operation) {
+            closeSubmenu();
+
+            _submenu = _menu
+                .append('div')
+                .attr('class', 'edit-menu edit-menu-submenu')
+                .style('padding', _verticalPadding + 'px 0')
+                .style('top', (buttonNode.offsetTop - _verticalPadding) + 'px')
+                .on('mouseenter', cancelCloseSubmenu)
+                .on('mouseleave', scheduleCloseSubmenu);
+
+            // grow rightward when the menu sits on the right of the anchor, else leftward
+            _submenu.style(_menuLeft ? 'right' : 'left', _menuWidth + 'px');
+
+            // header: container title + description (replaces the hover tooltip)
+            var header = _submenu.append('div').attr('class', 'edit-menu-submenu-header');
+            header.append('div').attr('class', 'edit-menu-submenu-title').call(operation.title);
+            header.append('div').attr('class', 'edit-menu-submenu-description').call(operation.tooltip());
+
+            renderButtons(_submenu, operation.subOperations(), true, false);
+        }
+
+        function closeSubmenu() {
+            cancelCloseSubmenu();
+            if (!_submenu.empty()) {
+                _submenu.remove();
+                _submenu = d3_select(null);
+            }
+        }
+
+        // Delay closing so the pointer can travel from the button to the flyout.
+        function scheduleCloseSubmenu() {
+            cancelCloseSubmenu();
+            _submenuTimer = window.setTimeout(closeSubmenu, 120);
+        }
+
+        function cancelCloseSubmenu() {
+            if (_submenuTimer) {
+                window.clearTimeout(_submenuTimer);
+                _submenuTimer = null;
+            }
+        }
+
+
         var lastPointerUpType;
         // `pointerup` is always called before `click`
         function pointerup(d3_event) {
@@ -163,6 +248,13 @@ export function uiEditMenu(context) {
 
         function click(d3_event, operation) {
             d3_event.stopPropagation();
+
+            // Container operation: open its flyout submenu instead of performing
+            // (handles touch input, where there is no hover).
+            if (operation.subOperations) {
+                openSubmenu(this, operation);
+                return;
+            }
 
             if (operation.relatedEntityIds) {
                 utilHighlightEntities(operation.relatedEntityIds(), false, context);
@@ -193,8 +285,6 @@ export function uiEditMenu(context) {
             }
             lastPointerUpType = null;
         }
-
-        dispatch.call('toggled', this, true);
     };
 
     function updatePosition() {
@@ -216,6 +306,8 @@ export function uiEditMenu(context) {
         }
 
         var menuLeft = displayOnLeft(viewport);
+        // remember the side so the submenu flyout grows away from the viewport edge
+        _menuLeft = menuLeft;
 
         var offset = [0, 0];
 
@@ -304,7 +396,13 @@ export function uiEditMenu(context) {
             .on('move.edit-menu', null)
             .on('drawn.edit-menu', null);
 
+        if (_submenuTimer) {
+            window.clearTimeout(_submenuTimer);
+            _submenuTimer = null;
+        }
+        // the submenu is a child of _menu, so removing _menu drops it too
         _menu.remove();
+        _submenu = d3_select(null);
         _tooltips = [];
 
         // Clean up any auxiliary overlays

--- a/svg/iD-sprite/operations/operation-clone.svg
+++ b/svg/iD-sprite/operations/operation-clone.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="20" viewBox="0 0 20 20">
+    <rect x="2.5" y="2.5" width="10" height="10" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.4"/>
+    <rect x="7.5" y="7.5" width="10" height="10" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+</svg>


### PR DESCRIPTION
## Summary

Ports the v5 `clone` family to v6 (TypeScript) and surfaces it through a single **Clone** entry in the edit menu that expands into a cascading flyout submenu.

- **Generic action** `actionClone(selectedIds, cloneTags, languageSuffixes?)`: copies a configured set of tags from the first selected feature onto the others (tags present on the source only; existing target tags are kept). Replaces ~13 near-duplicate v5 actions.
- **Config-driven operations**: each clone type (lanes, turn lanes, sidewalk, cycleway, bicycle, bus lanes, transition, maxspeed, surface, dual carriageway, name, address) is generated from a `cloneTypes` table. `clone_address` includes the `addr:*` and `contact:*` tags.
- **Edit-menu submenu**: operations flagged `hiddenFromEditMenu` are hidden from the top level; a container operation exposing `subOperations()` opens a flyout beside the menu on hover (or tap), aligned to the hovered item and flipped near the viewport edge. The container's title/description render in the flyout header.

### Notes
- No keyboard shortcuts for the clone types yet, by design. Adding a `key` to a `cloneTypes` entry wires one automatically through `behaviorOperation` (each type is exported, so the mode installs its keybinding).
- `edit_menu.js` is kept in JS (not converted to TS) to minimize the diff and avoid recurring upstream merge conflicts.

## Test plan

- [ ] Select ≥2 ways (source first, with relevant tags) → **Clone** appears in the edit menu.
- [ ] Hover **Clone** → flyout opens to the right, header shows title + description, available types listed.
- [ ] Near the right viewport edge → flyout opens to the left.
- [ ] Move pointer from button into the flyout without it closing; hovering another top item closes it.
- [ ] Click a type → tags are cloned onto the other selected features; menu closes.
- [ ] Touch/pen: tapping **Clone** opens the flyout.