### PR TITLE
Add sidewalk preset field for roads

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -1,0 +1,73 @@
+// =============================================================================
+// Custom preset fields (Québec-specific), kept separate from the upstream
+// id-tagging-schema data so they survive schema updates. Fields are attached
+// to existing presets additively (by pushing field ids into their field lists)
+// rather than replacing presets, to avoid conflicts with upstream changes.
+// =============================================================================
+
+/** Custom field definitions, merged into the preset system at load time. */
+export const customFields = {
+    sidewalk: {
+        key: 'sidewalk',
+        keys: ['sidewalk', 'sidewalk:both', 'sidewalk:left', 'sidewalk:right'],
+        type: 'sidewalk',
+        geometry: ['line'],
+        overrideLabel: 'Sidewalk'
+    }
+};
+
+// highway=* values that should offer the sidewalk field
+const SIDEWALK_HIGHWAYS = new Set([
+    'motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link',
+    'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'unclassified',
+    'residential', 'living_street', 'service', 'road', 'busway'
+]);
+
+// roads where the sidewalk field is available but not shown by default
+const SIDEWALK_MORE_ONLY = new Set(['motorway', 'motorway_link']);
+
+/**
+ * Register the custom fields and attach them to the relevant presets.
+ *
+ * The attachment is additive: it pushes field ids into each preset's
+ * `originalFields` / `originalMoreFields` list (read by `resolveFields`),
+ * so no upstream preset is replaced.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+export function applyCustomFields(presetManager) {
+    presetManager.merge({ fields: customFields });
+
+    presetManager.collection.forEach(preset => {
+        const highway = preset.tags && preset.tags.highway;
+        if (typeof highway !== 'string' || !SIDEWALK_HIGHWAYS.has(highway)) return;
+        if (!preset.geometry || preset.geometry.indexOf('line') === -1) return;
+
+        const fields = preset.originalFields;
+        const moreFields = preset.originalMoreFields;
+
+        // Only touch "base" presets that list their fields literally (they include
+        // `structure`). Presets that reference a parent (e.g. `{highway/primary}`)
+        // are skipped: they inherit the field from the parent we modify here.
+        if (fields.indexOf('structure') === -1) return;
+
+        // drop any pre-existing entry (upstream lists `sidewalk` in some moreFields)
+        // so we control its position and avoid duplicates
+        removeField(fields, 'sidewalk');
+        removeField(moreFields, 'sidewalk');
+
+        if (SIDEWALK_MORE_ONLY.has(highway)) {
+            // motorways: available via "+ add field", not shown by default
+            moreFields.push('sidewalk');
+        } else {
+            // other roads: shown by default, just before the Structure field
+            fields.splice(fields.indexOf('structure'), 0, 'sidewalk');
+        }
+    });
+}
+
+/** Remove `fieldID` from a preset field-id list, if present. */
+function removeField(list, fieldID) {
+    const index = list.indexOf(fieldID);
+    if (index !== -1) list.splice(index, 1);
+}

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -7,6 +7,7 @@ import { locationManager } from '../core/location_manager';
 import { osmNodeGeometriesForTags, osmSetAreaKeys, osmSetLineTags, osmSetPointTags, osmSetVertexTags } from '../osm/tags';
 import { presetCategory } from './category';
 import { presetCollection } from './collection';
+import { applyCustomFields } from './custom_fields';
 import { presetField } from './field';
 import { presetPreset } from './preset';
 import { utilArrayUniq, utilRebind } from '../util';
@@ -77,6 +78,8 @@ export function presetIndex() {
           presets: vals[2],
           fields: vals[3]
         });
+        // attach custom (Québec-specific) fields on top of the schema data
+        applyCustomFields(_this);
         osmSetAreaKeys(_this.areaKeys());
         osmSetLineTags(_this.lineTags());
         osmSetPointTags(_this.pointTags());

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -9,6 +9,7 @@ export * from './localized';
 export * from './roadheight';
 export * from './roadspeed';
 export * from './radio';
+export * from './sidewalk';
 export * from './restrictions';
 export * from './textarea';
 export * from './wikidata';
@@ -53,6 +54,7 @@ import { uiFieldLocalized } from './localized';
 import { uiFieldRoadheight } from './roadheight';
 import { uiFieldRoadspeed } from './roadspeed';
 import { uiFieldRestrictions } from './restrictions';
+import { uiFieldSidewalk } from './sidewalk';
 import { uiFieldTextarea } from './textarea';
 import { uiFieldWikidata } from './wikidata';
 import { uiFieldWikipedia } from './wikipedia';
@@ -82,6 +84,7 @@ export var uiFields = {
     restrictions: uiFieldRestrictions,
     schedule: uiFieldSchedule,
     semiCombo: uiFieldSemiCombo,
+    sidewalk: uiFieldSidewalk,
     structureRadio: uiFieldStructureRadio,
     tel: uiFieldTel,
     text: uiFieldText,

--- a/modules/ui/fields/sidewalk.ts
+++ b/modules/ui/fields/sidewalk.ts
@@ -1,0 +1,171 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { uiCombobox } from '../combobox';
+import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
+
+// =============================================================================
+// SIDEWALK - a single selector that reads/writes the combination of
+// `sidewalk`, `sidewalk:both`, `sidewalk:left`, `sidewalk:right`, `foot` and
+// `dual_carriageway` tags used to describe sidewalks along a road.
+// =============================================================================
+
+/** Tags written for each selectable value. Keys absent here are cleared on write. */
+const VALUE_TAGS: Record<string, Record<string, string>> = {
+    both: { sidewalk: 'both' },
+    left: { sidewalk: 'left' },
+    right: { sidewalk: 'right' },
+    no: { sidewalk: 'no' },
+    none: { sidewalk: 'none' }, // deprecated in osm wiki
+    separate_both: { 'sidewalk:both': 'separate', foot: 'use_sidepath' },
+    shared_both: { 'sidewalk:both': 'shared' },
+    separate_left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no', foot: 'use_sidepath' },
+    shared_left: { 'sidewalk:left': 'shared', 'sidewalk:right': 'no' },
+    separate_right: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate', foot: 'use_sidepath' },
+    shared_right: { 'sidewalk:left': 'no', 'sidewalk:right': 'shared' },
+    shared_left_separate_right: { 'sidewalk:left': 'shared', 'sidewalk:right': 'separate' },
+    shared_right_separate_left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'shared' },
+    opposite_use_sidepath: { sidewalk: 'no', foot: 'use_sidepath', dual_carriageway: 'yes' }
+};
+
+// Keys reset on every write so switching values never leaves stale tags behind.
+// `dual_carriageway` is only written when a value sets it, never cleared.
+const RESET_KEYS = ['sidewalk', 'sidewalk:both', 'sidewalk:left', 'sidewalk:right', 'foot'];
+
+// Human-readable labels for the combobox, in menu order.
+const OPTIONS: { value: string; title: string }[] = [
+    { value: 'both', title: 'Both sides' },
+    { value: 'left', title: 'Left side' },
+    { value: 'right', title: 'Right side' },
+    { value: 'no', title: 'None (sidewalk=no)' },
+    { value: 'none', title: 'None (sidewalk=none)' },
+    { value: 'separate_both', title: 'Separate, both sides' },
+    { value: 'separate_left', title: 'Separate, left side' },
+    { value: 'separate_right', title: 'Separate, right side' },
+    { value: 'shared_both', title: 'Shared, both sides' },
+    { value: 'shared_left', title: 'Shared, left side' },
+    { value: 'shared_right', title: 'Shared, right side' },
+    { value: 'shared_left_separate_right', title: 'Shared left, separate right' },
+    { value: 'shared_right_separate_left', title: 'Separate left, shared right' },
+    { value: 'opposite_use_sidepath', title: 'Opposite (use_sidepath, dual carriageway)' }
+];
+
+/** Resolve the selector value from a left/right sidewalk pair (and `foot`). */
+function readLeftRight(left: string, right: string, foot: string): string {
+    const sidepath = foot === 'use_sidepath';
+    const isClear = (v: string) => v === 'no' || v === 'none';
+
+    // separate variants are only meaningful with foot=use_sidepath
+    if (sidepath) {
+        if (left === 'separate' && right === 'separate') return 'separate_both';
+        if (isClear(left) && right === 'separate') return 'separate_right';
+        if (left === 'separate' && isClear(right)) return 'separate_left';
+    }
+    if (left === 'shared' && right === 'shared') return 'shared_both';
+    if (isClear(left) && right === 'shared') return 'shared_right';
+    if (left === 'shared' && isClear(right)) return 'shared_left';
+    if (left === 'shared' && right === 'separate') return 'shared_left_separate_right';
+    if (left === 'separate' && right === 'shared') return 'shared_right_separate_left';
+    if (left === 'no' && right === 'no') return 'no';
+    if (isClear(left) && right === 'none') return 'none';
+    if (left === 'none' && right === 'no') return 'none';
+    return '';  // anything else is an unsupported (invalid) combination
+}
+
+/** Resolve the selector value from the full set of sidewalk-related tags. */
+function readValue(tags: Record<string, string>): string {
+    const sidewalk = tags['sidewalk'];
+    const both = tags['sidewalk:both'];
+    const left = tags['sidewalk:left'];
+    const right = tags['sidewalk:right'];
+    const foot = tags['foot'];
+    const dual = tags['dual_carriageway'];
+
+    // mixing single/both with left/right (or sidewalk with sidewalk:both) is invalid
+    if ((left || right) && (both || sidewalk)) return '';
+    if (sidewalk && both) return '';
+
+    if (sidewalk) {
+        if (sidewalk === 'no' && foot === 'use_sidepath' && dual === 'yes') return 'opposite_use_sidepath';
+        if (sidewalk === 'no') return 'no';
+        if (sidewalk === 'left' || sidewalk === 'right' || sidewalk === 'both' || sidewalk === 'none') return sidewalk;
+        return '';  // 'yes' or anything unexpected
+    }
+
+    if (both) {
+        const byBoth: Record<string, string> = {
+            separate: 'separate_both', shared: 'shared_both', no: 'no', none: 'none', yes: 'both'
+        };
+        return byBoth[both] || '';
+    }
+
+    if (left && right) return readLeftRight(left, right, foot);
+
+    return '';
+}
+
+/**
+ * Sidewalk preset field: a single combobox mapping to the sidewalk tag family.
+ *
+ * @param field - the preset field definition (decorated by `presetField`)
+ * @param context - the iD application context
+ * @returns the field component (callable on a d3 selection)
+ */
+export function uiFieldSidewalk(field: { type: string }, context: iD.Context) {
+    const dispatch = d3_dispatch('change');
+    // d3 selections are loosely typed here, like the sibling field components
+    let input: any = d3_select(null);
+    let wrap: any = d3_select(null);
+    let _tags: Record<string, string> = {};
+
+    function sidewalk(selection: any) {
+        wrap = selection.selectAll('.form-field-input-wrap')
+            .data([0]);
+
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
+            .merge(wrap);
+
+        input = wrap.selectAll('input')
+            .data([0]);
+
+        input = input.enter()
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'preset-input-sidewalk')
+            .call(utilNoAuto)
+            .call(uiCombobox(context, 'sidewalk').data(OPTIONS))
+            .merge(input);
+
+        input
+            .on('change', change)
+            .on('blur', change);
+
+        sidewalk.tags(_tags);
+    }
+
+    function change(d3_event: any) {
+        const value = utilGetSetValue(d3_select(d3_event.currentTarget));
+        const mapping = VALUE_TAGS[value];
+        if (!mapping) return;  // ignore free-text / invalid entries
+
+        const tag: Record<string, string | undefined> = {};
+        RESET_KEYS.forEach((key) => { tag[key] = mapping[key]; });
+        if (mapping['dual_carriageway']) tag['dual_carriageway'] = mapping['dual_carriageway'];
+
+        dispatch.call('change', d3_event.currentTarget, tag);
+    }
+
+    sidewalk.tags = function(tags: Record<string, string>) {
+        _tags = tags || {};
+        utilGetSetValue(input, readValue(_tags));
+    };
+
+    sidewalk.focus = function() {
+        const node = wrap.selectAll('input').node();
+        if (node) node.focus();
+    };
+
+    return utilRebind(sidewalk, dispatch, 'on');
+}


### PR DESCRIPTION
## Summary

Ports the v5 custom **sidewalk** field to v6 (TypeScript) and wires it into the schema-based preset system.

- **Field UI** (`modules/ui/fields/sidewalk.ts`): a single combobox mapping to the combination of `sidewalk`, `sidewalk:both`, `sidewalk:left`, `sidewalk:right`, `foot` and `dual_carriageway`. Writes are table-driven (`value -> tags`); reads resolve the selector value from the current tags. Registered as the `sidewalk` field type.
- **Attachment** (`modules/presets/custom_fields.js`): applied once after the tagging-schema data loads. Registers custom fields and attaches them **additively** to presets (inserting field ids into their field lists) rather than replacing presets, so upstream definitions are preserved.
  - Shown by default on road presets, just before the **Structure** field.
  - Offered as an addable "more" field on motorways (not shown by default).
  - Reference-based presets (e.g. `highway/secondary`) inherit the field from the base preset they reference.

## Notes / decisions

- This **overrides the upstream `sidewalk` field** (a simple per-side `directionalCombo`) with the richer Québec model (separate/shared/use_sidepath/dual_carriageway). Intentional: all roads now use this field.
- Field label uses `overrideLabel: 'Sidewalk'` (no `_tagging` i18n entry needed).
- Faithful to v5: selecting a value writes the full controlled tag set, which can clear a previously set `foot` value.
- `edit_menu`/field UI d3 glue is loosely typed (like the sibling `.js` fields); the value-mapping logic is fully typed.

## Test plan

- [ ] Select a normal road (residential/primary/secondary…) → **Sidewalk** appears by default, just before **Structure**.
- [ ] Select a motorway → **Sidewalk** not shown by default, available via **+ add field** (and auto-shown if a `sidewalk*` tag exists).
- [ ] Pick each option → correct tag combination written; reopening shows the matching value.
- [ ] Invalid/free-text entry is ignored (no tag change).