### PR TITLE
Cycleway: write cycleway:both, add shoulder option and a "Both sides" row

### DIFF
--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -44,6 +44,12 @@ export function coreLocalizer() {
     // }
     let _localeStrings = {};
 
+    // Custom strings registered via `localizer.addStrings`, kept separately so
+    // they can be re-applied on top of `_localeStrings` whenever a locale loads
+    // (load order between `addStrings` and `loadLocale` is not guaranteed).
+    // Same shape as `_localeStrings`: scopeId -> locale -> nested string data.
+    let _customStrings = {};
+
     // the current locale
     let _localeCode = 'en-US';
     // `_localeCodes` must contain `_localeCode` first, optionally followed by fallbacks
@@ -226,8 +232,47 @@ export function coreLocalizer() {
             .then(d => {
                 if (!_localeStrings[scopeId]) _localeStrings[scopeId] = {};
                 _localeStrings[scopeId][locale] = d[locale];
+                applyCustomStrings(scopeId, locale);
                 return locale;
             });
+    };
+
+    // Deep-merge `_customStrings[scopeId][locale]` (if any) onto the loaded strings.
+    function applyCustomStrings(scopeId, locale) {
+        const custom = _customStrings[scopeId] && _customStrings[scopeId][locale];
+        if (custom && _localeStrings[scopeId] && _localeStrings[scopeId][locale]) {
+            mergeStrings(_localeStrings[scopeId][locale], custom);
+        }
+    }
+
+    // Recursively merge plain-object `source` into `target`, in place.
+    function mergeStrings(target, source) {
+        for (const key in source) {
+            const value = source[key];
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                if (!target[key] || typeof target[key] !== 'object') target[key] = {};
+                mergeStrings(target[key], value);
+            } else {
+                target[key] = value;
+            }
+        }
+    }
+
+    /**
+     * Register custom translation strings for a scope/locale (e.g. to add an
+     * option label to an existing tagging-schema field). Strings are merged on
+     * top of the loaded data, and re-applied whenever the locale (re)loads, so
+     * this can be safely called before or after `loadLocale`.
+     *
+     * @param {string} scopeId - string scope, e.g. `general` or `tagging`
+     * @param {string} locale  - locale code, e.g. `en` or `fr`
+     * @param {Object} data    - nested string data, same shape as the scope's strings
+     */
+    localizer.addStrings = (scopeId, locale, data) => {
+        if (!_customStrings[scopeId]) _customStrings[scopeId] = {};
+        if (!_customStrings[scopeId][locale]) _customStrings[scopeId][locale] = {};
+        mergeStrings(_customStrings[scopeId][locale], data);
+        applyCustomStrings(scopeId, locale);
     };
 
     localizer.pluralRule = function(number) {

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -5,6 +5,8 @@
 // rather than replacing presets, to avoid conflicts with upstream changes.
 // =============================================================================
 
+import { localizer } from '../core/localizer';
+
 /** Custom field definitions, merged into the preset system at load time. */
 export const customFields = {
     sidewalk: {
@@ -37,6 +39,7 @@ const SIDEWALK_MORE_ONLY = new Set(['motorway', 'motorway_link']);
  */
 export function applyCustomFields(presetManager) {
     presetManager.merge({ fields: customFields });
+    customizeCycleway(presetManager);
 
     presetManager.collection.forEach(preset => {
         const highway = preset.tags && preset.tags.highway;
@@ -70,4 +73,52 @@ export function applyCustomFields(presetManager) {
 function removeField(list, fieldID) {
     const index = list.indexOf(fieldID);
     if (index !== -1) list.splice(index, 1);
+}
+
+// Translations for the extra `shoulder` option added to the cycleway field.
+const CYCLEWAY_SHOULDER_STRINGS = {
+    en: { title: 'Shoulder', description: 'Bikes can use the shoulder, but it has no proper signage' },
+    fr: { title: 'Accotement', description: 'Les vélos peuvent utiliser l\'accotement, sans signalisation propre' }
+};
+
+// Label for the extra "both sides" row added to the cycleway field.
+const CYCLEWAY_BOTH_LABEL = { en: 'Both Sides', fr: 'Les deux côtés' };
+
+/**
+ * Adjust the upstream `cycleway` (directionalCombo) field in two ways:
+ *  - use `cycleway:both` as the common key, so equal left/right sides are
+ *    written as the more explicit `cycleway:both=*` (and left/right removed);
+ *  - add the `shoulder` option (present in our v5 fork, missing upstream).
+ *
+ * Both changes mutate the already-loaded field in place; the field id stays
+ * `cycleway`, so existing option labels keep resolving.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizeCycleway(presetManager) {
+    const field = presetManager.field('cycleway');
+    if (!field || field.type !== 'directionalCombo') return;
+
+    // write equal sides as `cycleway:both` instead of the bare `cycleway`
+    field.key = 'cycleway:both';
+
+    // show an extra "Both sides" row that sets left + right at once
+    field.bothRow = true;
+
+    // add `shoulder` right after `share_busway`, if not already present
+    if (Array.isArray(field.options) && field.options.indexOf('shoulder') === -1) {
+        const after = field.options.indexOf('share_busway');
+        field.options.splice(after === -1 ? field.options.length : after + 1, 0, 'shoulder');
+    }
+
+    // register the labels for the `shoulder` option and the "both sides" row
+    // (resolved from `_tagging.presets.fields.cycleway.{options,types}`)
+    for (const locale in CYCLEWAY_SHOULDER_STRINGS) {
+        localizer.addStrings('tagging', locale, {
+            presets: { fields: { cycleway: {
+                options: { shoulder: CYCLEWAY_SHOULDER_STRINGS[locale] },
+                types: { 'cycleway:both': CYCLEWAY_BOTH_LABEL[locale] }
+            } } }
+        });
+    }
 }

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -22,6 +22,13 @@ export function uiFieldDirectionalCombo(field, context) {
         };
     }
 
+    // Optional extra "both" row (opt-in via `field.bothRow`): lets the user set
+    // both sides at once. Writes the `*:both` tag and clears the per-side tags.
+    const bothTagKey = field.key.includes(':both') ? field.key : `${field.key}:both`;
+    const bareCommonKey = bothTagKey.replace(/:both(:|$)/, '$1');
+    const showBothRow = !!field.bothRow;
+    let _bothCombo = null;
+
     function directionalCombo(selection) {
 
         function stripcolon(s) {
@@ -46,8 +53,10 @@ export function uiFieldDirectionalCombo(field, context) {
             .attr('class', 'rows rows-table')
             .merge(div);
 
+        const rowKeys = showBothRow ? [bothTagKey, ...field.keys] : field.keys;
+
         items = div.selectAll('li')
-            .data(field.keys);
+            .data(rowKeys);
 
         var enter = items.enter()
             .append('li')
@@ -71,8 +80,13 @@ export function uiFieldDirectionalCombo(field, context) {
                     key
                 };
                 const combo = uiFieldCombo(subField, context);
-                combo.on('change', t => change(key, t[key]));
-                _combos[key] = combo;
+                if (showBothRow && key === bothTagKey) {
+                    combo.on('change', t => changeBoth(t[key]));
+                    _bothCombo = combo;
+                } else {
+                    combo.on('change', t => change(key, t[key]));
+                    _combos[key] = combo;
+                }
                 d3_select(this).call(combo);
             });
 
@@ -124,6 +138,22 @@ export function uiFieldDirectionalCombo(field, context) {
                 delete tags[otherCommonKey];
                 tags[otherKey] = otherValue;
             }
+            return tags;
+        });
+    }
+
+
+    // Set both sides at once from the "both" row: write `*:both` and clear the
+    // per-side tags (and the bare common tag) so the value is unambiguous.
+    function changeBoth(newValue) {
+        dispatch.call('change', this, tags => {
+            if (newValue) {
+                tags[bothTagKey] = newValue;
+            } else {
+                delete tags[bothTagKey];
+            }
+            field.keys.forEach(key => delete tags[key]);
+            if (bareCommonKey !== bothTagKey) delete tags[bareCommonKey];
             return tags;
         });
     }
@@ -185,6 +215,15 @@ export function uiFieldDirectionalCombo(field, context) {
         for (const key in _combos) {
             const uniqueValues = [...combinedTags[key]];
             _combos[key].tags({ [key]: uniqueValues.length > 1 ? uniqueValues : uniqueValues[0] });
+        }
+
+        if (_bothCombo) {
+            // the "both" row shows a value only when every side has the same single value
+            const sideValues = field.keys.map(key => [...combinedTags[key]]);
+            const common = sideValues[0][0];
+            const allEqual = common !== undefined &&
+                sideValues.every(values => values.length === 1 && values[0] === common);
+            _bothCombo.tags({ [bothTagKey]: allEqual ? common : '' });
         }
     };
 


### PR DESCRIPTION
## Summary

Improves the existing `cycleway` (directionalCombo) field for Québec mapping, building on the schema's generic component rather than forking it.

- **Write `cycleway:both`**: equal left/right sides are now written as the more explicit `cycleway:both=*` (and the per-side / bare `cycleway` tags removed). Reading still understands the bare `cycleway` and `cycleway:both` forms. Implemented by setting the field's common key to `cycleway:both`; the generic `directionalCombo` already collapses/splits accordingly.
- **`shoulder` option**: added (present in our v5 fork, missing upstream), placed right after *Bike Lane Shared With Bus*.
- **"Both sides" row**: new opt-in `bothRow` option on `directionalCombo` renders a third row that sets both sides at once (writes `cycleway:both`, clears per-side tags) and only shows a value when both sides currently share one.

### New reusable infrastructure
- `localizer.addStrings(scopeId, locale, data)`: register custom translation strings (merged onto loaded data, re-applied on locale load). Used here for the `shoulder` label/description and the "Both sides" row label (en + fr). Reusable for future custom field options/rows.

### Notes
- The `bothRow` behaviour is opt-in; other `directionalCombo` fields are unchanged (existing spec: 16/16 passing).
- The richer **lane-associated sub-fields** (marking / separation / buffer / oneway, conditional on the cycleway value) are intentionally **left out of this PR** and will follow in a dedicated one.

## Test plan

- [ ] Both sides set to the same value → tag is `cycleway:both=<v>` (no `:left`/`:right`, no bare `cycleway`).
- [ ] Left ≠ Right → `cycleway:left` + `cycleway:right`; "Both sides" row is empty.
- [ ] Set the "Both sides" row → writes `cycleway:both`, clears per-side tags; both sides reflect it.
- [ ] Existing `cycleway=track` / `cycleway:both=track` data displays on both sides (read back-compat).
- [ ] `Shoulder` shows with a proper label/description after *Bike Lane Shared With Bus*.