### PR TITLE
Allow field prerequisiteTag to be an array (OR semantics)

### DIFF
--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -13,6 +13,34 @@ import { uiTagReference } from './tag_reference';
 import { utilRebind, utilUniqueDomId } from '../util';
 
 
+/**
+ * Evaluate a field's `prerequisiteTag` against a set of OSM tags.
+ *
+ * Accepts a single condition object or an array of conditions matched with OR
+ * semantics (the field shows if any condition is satisfied). A condition uses
+ * `key` with `value` / `values` / `valueNot` / `valuesNot`, or `keyNot`.
+ *
+ * @param {Object|Object[]} prerequisiteTag - a condition or an array of conditions
+ * @param {Object} tags - the entity tags to test against
+ * @returns {boolean} whether the prerequisite is satisfied
+ */
+export function prerequisiteTagSatisfied(prerequisiteTag, tags) {
+    const conditions = Array.isArray(prerequisiteTag) ? prerequisiteTag : [prerequisiteTag];
+    return conditions.some(function(condition) {
+        if (condition.key) {
+            const value = tags[condition.key] || '';
+            if (condition.valuesNot) return !condition.valuesNot.includes(value);
+            if (condition.valueNot) return condition.valueNot !== value;
+            if (condition.values) return condition.values.includes(value);
+            if (condition.value) return condition.value === value;
+            return !!value;   // bare `key`: satisfied if any value is present
+        }
+        if (condition.keyNot) return !tags[condition.keyNot];
+        return true;
+    });
+}
+
+
 export function uiField(context, presetField, entityIDs, options) {
     options = Object.assign({
         show: true,
@@ -338,26 +366,7 @@ export function uiField(context, presetField, entityIDs, options) {
 
             if (!entityIDs.every(function(entityID) {
                 var entity = context.graph().entity(entityID);
-                if (prerequisiteTag.key) {
-                    var value = entity.tags[prerequisiteTag.key] || '';
-
-                    if (prerequisiteTag.valuesNot) {
-                        return !prerequisiteTag.valuesNot.includes(value);
-                    }
-                    if (prerequisiteTag.valueNot) {
-                        return prerequisiteTag.valueNot !== value;
-                    }
-                    if (prerequisiteTag.values) {
-                        return prerequisiteTag.values.includes(value);
-                    }
-                    if (prerequisiteTag.value) {
-                        return prerequisiteTag.value === value;
-                    }
-                    if (!value) return false;
-                } else if (prerequisiteTag.keyNot) {
-                    if (entity.tags[prerequisiteTag.keyNot]) return false;
-                }
-                return true;
+                return prerequisiteTagSatisfied(prerequisiteTag, entity.tags);
             })) return false;
         }
 

--- a/modules/ui/index.js
+++ b/modules/ui/index.js
@@ -17,7 +17,7 @@ export { uiEditMenu } from './edit_menu';
 export { uiEntityEditor } from './entity_editor';
 export { uiFeatureInfo } from './feature_info';
 export { uiFeatureList } from './feature_list';
-export { uiField } from './field';
+export { uiField, prerequisiteTagSatisfied } from './field';
 export { uiFieldHelp } from './field_help';
 export { uiFlash } from './flash';
 export { uiFormFields } from './form_fields';

--- a/test/spec/ui/field.js
+++ b/test/spec/ui/field.js
@@ -1,0 +1,27 @@
+describe('iD.prerequisiteTagSatisfied', () => {
+
+    describe.each([
+        // [description, prerequisiteTag, tags, expected]
+        ['value: match', { key: 'a', value: 'lane' }, { a: 'lane' }, true],
+        ['value: mismatch', { key: 'a', value: 'lane' }, { a: 'track' }, false],
+        ['value: absent', { key: 'a', value: 'lane' }, {}, false],
+        ['values: includes', { key: 'a', values: ['lane', 'share_busway'] }, { a: 'share_busway' }, true],
+        ['values: excludes', { key: 'a', values: ['lane', 'share_busway'] }, { a: 'track' }, false],
+        ['valueNot: differs', { key: 'a', valueNot: 'no' }, { a: 'lane' }, true],
+        ['valueNot: equals', { key: 'a', valueNot: 'no' }, { a: 'no' }, false],
+        ['valuesNot: excluded', { key: 'a', valuesNot: ['no'] }, { a: 'lane' }, true],
+        ['valuesNot: included', { key: 'a', valuesNot: ['no'] }, { a: 'no' }, false],
+        ['bare key: present', { key: 'a' }, { a: 'whatever' }, true],
+        ['bare key: absent', { key: 'a' }, {}, false],
+        ['keyNot: absent', { keyNot: 'a' }, {}, true],
+        ['keyNot: present', { keyNot: 'a' }, { a: 'x' }, false],
+        // array of conditions => OR semantics
+        ['OR: first matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { a: 'lane' }, true],
+        ['OR: second matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { b: 'lane' }, true],
+        ['OR: none matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { c: 'lane' }, false]
+    ])('%s', (_desc, prerequisiteTag, tags, expected) => {
+        it(`returns ${expected}`, () => {
+            expect(iD.prerequisiteTagSatisfied(prerequisiteTag, tags)).toBe(expected);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Lets a field's `prerequisiteTag` be **either a single condition (unchanged) or an array of conditions** evaluated with **OR** semantics. Needed so a single field can be shown by alternative tags (e.g. `cycleway:left=lane` OR `cycleway:both=lane`) instead of declaring duplicate field entries on the same key (which v6 would both show once the tag is present).

- Extracts the condition evaluation into a pure, exported helper `prerequisiteTagSatisfied(prerequisiteTag, tags)`.
- `field.isAllowed()` now calls the helper; an array of conditions passes if any condition matches (per entity), preserving the existing AND-across-entities behaviour.
- Fully backward compatible: a single condition object behaves exactly as before.

## Test plan

- [x] New parametric spec covers `value` / `values` / `valueNot` / `valuesNot` / bare `key` / `keyNot`, and array (OR) cases.
- [x] `directional_combo` spec still green (16/16); typecheck + lint pass.