### PR TITLE
Move custom field strings to locale JSON files

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -1,0 +1,62 @@
+{
+    "presets": {
+        "fields": {
+            "sidewalk": {
+                "label": "Sidewalk"
+            },
+            "cycleway": {
+                "types": {
+                    "cycleway:both": "Both Sides"
+                },
+                "options": {
+                    "shoulder": {
+                        "title": "Shoulder",
+                        "description": "Bikes can use the shoulder, but it has no proper signage"
+                    }
+                }
+            },
+            "cycleway_buffer": { "label": "Both: Cycleway buffer width (m)" },
+            "cycleway_separation": {
+                "label": "Both: Cycleway separation",
+                "options": {
+                    "no": "None",
+                    "flex_post": "Flex posts",
+                    "parking_lane": "Parking lane",
+                    "bollard": "Bollards (fixed)",
+                    "bump": "Bumps",
+                    "studs": "Studs",
+                    "fence": "Fence",
+                    "planter": "Planters (flower boxes)",
+                    "jersey_barrier": "Jersey concrete barriers",
+                    "guard_rail": "Guard rail",
+                    "structure": "Structure (bridge)",
+                    "vertical_panel": "Vertical panel"
+                }
+            },
+            "cycleway_marking": {
+                "label": "Both: Cycleway marking",
+                "options": {
+                    "no": "None",
+                    "solid_line": "Solid line",
+                    "dashed_line": "Dashed line",
+                    "dotted_line": "Dotted line",
+                    "double_solid_line": "Double solid line",
+                    "barred_area": "Buffer / Barred area",
+                    "pictogram": "Pictogram",
+                    "surface": "Change of surface"
+                }
+            },
+            "cycleway_left_buffer": { "label": "Left: Cycleway buffer width (m)" },
+            "cycleway_left_separation": { "label": "Left: Cycleway separation" },
+            "cycleway_left_marking": { "label": "Left: Cycleway marking" },
+            "cycleway_left_oneway": {
+                "label": "Left: Bicycle one way",
+                "options": { "yes": "Yes", "no": "No" }
+            },
+            "cycleway_right_buffer": { "label": "Right: Cycleway buffer width (m)" },
+            "cycleway_right_separation": { "label": "Right: Cycleway separation" },
+            "cycleway_right_marking": { "label": "Right: Cycleway marking" },
+            "cycleway_right_oneway": { "label": "Right: Bicycle one way" }
+        }
+    }
+}

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -1,0 +1,62 @@
+{
+    "presets": {
+        "fields": {
+            "sidewalk": {
+                "label": "Trottoir"
+            },
+            "cycleway": {
+                "types": {
+                    "cycleway:both": "Les deux côtés"
+                },
+                "options": {
+                    "shoulder": {
+                        "title": "Accotement",
+                        "description": "Les vélos peuvent utiliser l'accotement, sans signalisation propre"
+                    }
+                }
+            },
+            "cycleway_buffer": { "label": "Les deux côtés : Largeur de la zone tampon cyclable (m)" },
+            "cycleway_separation": {
+                "label": "Les deux côtés : Séparation cyclable",
+                "options": {
+                    "no": "Aucune",
+                    "flex_post": "Balises flexibles",
+                    "parking_lane": "Voie de stationnement",
+                    "bollard": "Bornes (fixes)",
+                    "bump": "Bosses",
+                    "studs": "Clous",
+                    "fence": "Clôture",
+                    "planter": "Jardinières",
+                    "jersey_barrier": "Glissières en béton (Jersey)",
+                    "guard_rail": "Glissière de sécurité",
+                    "structure": "Structure (pont)",
+                    "vertical_panel": "Panneau vertical"
+                }
+            },
+            "cycleway_marking": {
+                "label": "Les deux côtés : Marquage cyclable",
+                "options": {
+                    "no": "Aucun",
+                    "solid_line": "Ligne pleine",
+                    "dashed_line": "Ligne tiretée",
+                    "dotted_line": "Ligne pointillée",
+                    "double_solid_line": "Double ligne pleine",
+                    "barred_area": "Zone tampon / hachurée",
+                    "pictogram": "Pictogramme",
+                    "surface": "Changement de surface"
+                }
+            },
+            "cycleway_left_buffer": { "label": "Côté gauche : Largeur de la zone tampon cyclable (m)" },
+            "cycleway_left_separation": { "label": "Côté gauche : Séparation cyclable" },
+            "cycleway_left_marking": { "label": "Côté gauche : Marquage cyclable" },
+            "cycleway_left_oneway": {
+                "label": "Côté gauche : Sens unique vélo",
+                "options": { "yes": "Oui", "no": "Non" }
+            },
+            "cycleway_right_buffer": { "label": "Côté droit : Largeur de la zone tampon cyclable (m)" },
+            "cycleway_right_separation": { "label": "Côté droit : Séparation cyclable" },
+            "cycleway_right_marking": { "label": "Côté droit : Marquage cyclable" },
+            "cycleway_right_oneway": { "label": "Côté droit : Sens unique vélo" }
+        }
+    }
+}

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -6,7 +6,8 @@
 // =============================================================================
 
 import { localizer } from '../core/localizer';
-import { cyclewaySubFields, cyclewaySubFieldOrder, registerCyclewaySubFieldStrings } from './cycleway_fields';
+import { cyclewaySubFields, cyclewaySubFieldOrder } from './cycleway_fields';
+import { registerCustomStrings } from './custom_strings';
 
 /** Custom field definitions, merged into the preset system at load time. */
 export const customFields = {
@@ -14,8 +15,7 @@ export const customFields = {
         key: 'sidewalk',
         keys: ['sidewalk', 'sidewalk:both', 'sidewalk:left', 'sidewalk:right'],
         type: 'sidewalk',
-        geometry: ['line'],
-        overrideLabel: 'Sidewalk'
+        geometry: ['line']
     }
 };
 
@@ -49,7 +49,7 @@ export function applyCustomFields(presetManager) {
     presetManager.merge({ fields: customFields });
     presetManager.merge({ fields: cyclewaySubFields });
     customizeCycleway(presetManager);
-    registerCyclewaySubFieldStrings(localizer);
+    registerCustomStrings(localizer);
 
     presetManager.collection.forEach(preset => {
         const highway = preset.tags && preset.tags.highway;
@@ -94,15 +94,6 @@ function removeField(list, fieldID) {
     if (index !== -1) list.splice(index, 1);
 }
 
-// Translations for the extra `shoulder` option added to the cycleway field.
-const CYCLEWAY_SHOULDER_STRINGS = {
-    en: { title: 'Shoulder', description: 'Bikes can use the shoulder, but it has no proper signage' },
-    fr: { title: 'Accotement', description: 'Les vélos peuvent utiliser l\'accotement, sans signalisation propre' }
-};
-
-// Label for the extra "both sides" row added to the cycleway field.
-const CYCLEWAY_BOTH_LABEL = { en: 'Both Sides', fr: 'Les deux côtés' };
-
 /**
  * Adjust the upstream `cycleway` (directionalCombo) field in two ways:
  *  - use `cycleway:both` as the common key, so equal left/right sides are
@@ -110,7 +101,8 @@ const CYCLEWAY_BOTH_LABEL = { en: 'Both Sides', fr: 'Les deux côtés' };
  *  - add the `shoulder` option (present in our v5 fork, missing upstream).
  *
  * Both changes mutate the already-loaded field in place; the field id stays
- * `cycleway`, so existing option labels keep resolving.
+ * `cycleway`, so existing option labels keep resolving. The labels for the
+ * `shoulder` option and the "both sides" row live in the custom locale files.
  *
  * @param {Object} presetManager - the preset system (`presetManager`)
  */
@@ -128,16 +120,5 @@ function customizeCycleway(presetManager) {
     if (Array.isArray(field.options) && field.options.indexOf('shoulder') === -1) {
         const after = field.options.indexOf('share_busway');
         field.options.splice(after === -1 ? field.options.length : after + 1, 0, 'shoulder');
-    }
-
-    // register the labels for the `shoulder` option and the "both sides" row
-    // (resolved from `_tagging.presets.fields.cycleway.{options,types}`)
-    for (const locale in CYCLEWAY_SHOULDER_STRINGS) {
-        localizer.addStrings('tagging', locale, {
-            presets: { fields: { cycleway: {
-                options: { shoulder: CYCLEWAY_SHOULDER_STRINGS[locale] },
-                types: { 'cycleway:both': CYCLEWAY_BOTH_LABEL[locale] }
-            } } }
-        });
     }
 }

--- a/modules/presets/custom_strings.js
+++ b/modules/presets/custom_strings.js
@@ -1,0 +1,22 @@
+// =============================================================================
+// Translations for the custom Québec fields (sidewalk, cycleway and its lane
+// sub-fields). Kept in plain locale JSON files under `data/locales/custom/` so
+// they live next to the other translations and can be edited without touching
+// field logic. They are injected into the `tagging` scope at load time because
+// the tagging schema itself comes from the npm package, not a local build.
+// =============================================================================
+
+import en from '../../data/locales/custom/en.json';
+import fr from '../../data/locales/custom/fr.json';
+
+const customStrings = { en, fr };
+
+/**
+ * Register the custom field translations (all locales) into the localizer.
+ * @param {Object} localizer - the localizer with `addStrings`
+ */
+export function registerCustomStrings(localizer) {
+    for (const locale in customStrings) {
+        localizer.addStrings('tagging', locale, customStrings[locale]);
+    }
+}

--- a/modules/presets/cycleway_fields.js
+++ b/modules/presets/cycleway_fields.js
@@ -9,7 +9,8 @@
 // array prerequisiteTag (OR semantics) so each tag is owned by a single field
 // (two fields on the same key would both show once the tag is present).
 //
-// Option labels are shared across the side variants via `stringsCrossReference`
+// Labels and option labels live in `data/locales/custom/{en,fr}.json`; option
+// labels are shared across the side variants via `stringsCrossReference`
 // (pointing at the canonical field), so they are only declared once.
 // =============================================================================
 
@@ -22,43 +23,14 @@ const SEPARATION_OPTIONS = [
     'planter', 'jersey_barrier', 'guard_rail', 'structure', 'vertical_panel'
 ];
 
-// Option labels, keyed by attribute then locale. Declared once on the canonical
-// field of each attribute; side variants reference it via stringsCrossReference.
-const OPTION_STRINGS = {
-    marking: {
-        en: { no: 'None', solid_line: 'Solid line', dashed_line: 'Dashed line',
-            dotted_line: 'Dotted line', double_solid_line: 'Double solid line',
-            barred_area: 'Buffer / Barred area', pictogram: 'Pictogram', surface: 'Change of surface' },
-        fr: { no: 'Aucun', solid_line: 'Ligne pleine', dashed_line: 'Ligne tiretée',
-            dotted_line: 'Ligne pointillée', double_solid_line: 'Double ligne pleine',
-            barred_area: 'Zone tampon / hachurée', pictogram: 'Pictogramme', surface: 'Changement de surface' }
-    },
-    separation: {
-        en: { no: 'None', flex_post: 'Flex posts', parking_lane: 'Parking lane',
-            bollard: 'Bollards (fixed)', bump: 'Bumps', studs: 'Studs', fence: 'Fence',
-            planter: 'Planters (flower boxes)', jersey_barrier: 'Jersey concrete barriers',
-            guard_rail: 'Guard rail', structure: 'Structure (bridge)', vertical_panel: 'Vertical panel' },
-        fr: { no: 'Aucune', flex_post: 'Balises flexibles', parking_lane: 'Voie de stationnement',
-            bollard: 'Bornes (fixes)', bump: 'Bosses', studs: 'Clous', fence: 'Clôture',
-            planter: 'Jardinières', jersey_barrier: 'Glissières en béton (Jersey)',
-            guard_rail: 'Glissière de sécurité', structure: 'Structure (pont)', vertical_panel: 'Panneau vertical' }
-    }
-};
-const ONEWAY_OPTION_STRINGS = { en: { yes: 'Yes', no: 'No' }, fr: { yes: 'Oui', no: 'Non' } };
+// Per-side tag prefix (the localized side label is part of each field's JSON label).
+const SIDE_TAGS = { both: 'cycleway:both', left: 'cycleway:left', right: 'cycleway:right' };
 
-// Per-side tag prefix and localized side label (prefixed to each field label,
-// so the direction reads first, e.g. "Left: Cycleway marking").
-const SIDES = {
-    both:  { tag: 'cycleway:both',  label: { en: 'Both',  fr: 'Les deux côtés' } },
-    left:  { tag: 'cycleway:left',  label: { en: 'Left',  fr: 'Côté gauche' } },
-    right: { tag: 'cycleway:right', label: { en: 'Right', fr: 'Côté droit' } }
-};
-
-// Attribute config: combo options + base label (the side label is appended).
+// Attribute config: field type + combo options (option labels live in the JSON).
 const ATTRS = {
-    buffer:     { type: 'number', label: { en: 'Cycleway buffer width (m)', fr: 'Largeur de la zone tampon cyclable (m)' } },
-    separation: { type: 'combo', options: SEPARATION_OPTIONS, label: { en: 'Cycleway separation', fr: 'Séparation cyclable' } },
-    marking:    { type: 'combo', options: MARKING_OPTIONS, label: { en: 'Cycleway marking', fr: 'Marquage cyclable' } }
+    buffer:     { type: 'number' },
+    separation: { type: 'combo', options: SEPARATION_OPTIONS },
+    marking:    { type: 'combo', options: MARKING_OPTIONS }
 };
 
 /** Build a `prerequisiteTag` matching `values` on `side` (left/right also OR the `both` side). */
@@ -66,37 +38,22 @@ function prereq(side, values) {
     const condition = key => values.length > 1 ? { key, values } : { key, value: values[0] };
     return side === 'both'
         ? condition('cycleway:both')
-        : [condition(SIDES[side].tag), condition('cycleway:both')];
+        : [condition(SIDE_TAGS[side]), condition('cycleway:both')];
 }
 
-/** Build all sub-field definitions, their display order, and i18n strings. */
+/** Build all sub-field definitions and their display order. */
 function build() {
     const fields = {};
-    const strings = { en: {}, fr: {} };
-
-    const setLabel = (id, base, side) => {
-        for (const locale of ['en', 'fr']) {
-            strings[locale][id] = strings[locale][id] || {};
-            strings[locale][id].label = `${SIDES[side].label[locale]}: ${base[locale]}`;
-        }
-    };
-    const setOptions = (id, optionStrings) => {
-        for (const locale of ['en', 'fr']) {
-            strings[locale][id] = strings[locale][id] || {};
-            strings[locale][id].options = optionStrings[locale];
-        }
-    };
 
     // marking / separation / buffer (both, left, right)
     for (const attr of ['buffer', 'separation', 'marking']) {
         const cfg = ATTRS[attr];
         const canonicalId = `cycleway_${attr}`;
-        if (cfg.type === 'combo') setOptions(canonicalId, OPTION_STRINGS[attr]);
 
         for (const side of ['both', 'left', 'right']) {
             const id = side === 'both' ? canonicalId : `cycleway_${side}_${attr}`;
             const def = {
-                key: `${SIDES[side].tag}:${attr}`,
+                key: `${SIDE_TAGS[side]}:${attr}`,
                 type: cfg.type,
                 geometry: ['line'],
                 prerequisiteTag: prereq(side, ['lane'])
@@ -107,17 +64,15 @@ function build() {
             }
             if (cfg.type === 'number') def.minValue = 0;
             fields[id] = def;
-            setLabel(id, cfg.label, side);
         }
     }
 
     // oneway (radio): left/right only, shown for lane + share_busway
     const onewayCanonical = 'cycleway_left_oneway';
-    setOptions(onewayCanonical, ONEWAY_OPTION_STRINGS);
     for (const side of ['left', 'right']) {
         const id = `cycleway_${side}_oneway`;
         const def = {
-            key: `${SIDES[side].tag}:oneway`,
+            key: `${SIDE_TAGS[side]}:oneway`,
             type: 'radio',
             geometry: ['line'],
             options: ['yes', 'no'],
@@ -125,7 +80,6 @@ function build() {
         };
         if (id !== onewayCanonical) def.stringsCrossReference = `{${onewayCanonical}}`;
         fields[id] = def;
-        setLabel(id, { en: 'Bicycle one way', fr: 'Sens unique vélo' }, side);
     }
 
     // display order: both first, then each side (oneway, buffer, separation, marking)
@@ -135,7 +89,7 @@ function build() {
         'cycleway_right_oneway', 'cycleway_right_buffer', 'cycleway_right_separation', 'cycleway_right_marking'
     ];
 
-    return { fields, order, strings };
+    return { fields, order };
 }
 
 const built = build();
@@ -145,13 +99,3 @@ export const cyclewaySubFields = built.fields;
 
 /** Sub-field ids in display order (to insert into road preset field lists). */
 export const cyclewaySubFieldOrder = built.order;
-
-/**
- * Register the labels/options for the cycleway sub-fields (en + fr).
- * @param {Object} localizer - the localizer with `addStrings`
- */
-export function registerCyclewaySubFieldStrings(localizer) {
-    for (const locale of ['en', 'fr']) {
-        localizer.addStrings('tagging', locale, { presets: { fields: built.strings[locale] } });
-    }
-}


### PR DESCRIPTION
## Summary

Externalizes the en/fr strings for the custom Québec fields out of the field-logic modules and into dedicated locale JSON files, so translations can be edited (or extended to new locales) without touching code.

- **New** `data/locales/custom/{en,fr}.json`: all custom strings under the `tagging` scope shape — `sidewalk` label, the `cycleway` `shoulder` option and `cycleway:both` "Both Sides" row label, and the 11 cycleway lane sub-field labels/options (full labels, e.g. `"Left: Cycleway marking"`).
- **New** `modules/presets/custom_strings.js`: imports both JSON files and injects them via `localizer.addStrings`. They are injected at runtime because the tagging schema comes from the npm package, not a local build.
- `cycleway_fields.js`: now holds **structure only** (keys, types, options, prerequisiteTag) — all label/option strings removed.
- `custom_fields.js`: drops the inline string constants and the `addStrings` loop; calls `registerCustomStrings` instead.

### Side fix
`sidewalk` is now localized (`Sidewalk` / `Trottoir`) instead of an English-only `overrideLabel`.

## Test plan
- [x] `tsc` passes
- [x] `eslint` passes
- [x] esbuild bundle OK (JSON imports resolve)
- [x] UI: sidewalk label, `shoulder` option, "Both Sides" row and lane sub-fields all still render (en + fr)