### PR TITLE
Warn about redundant plain cycleway/sidewalk tags

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -1,62 +1,74 @@
 {
-    "presets": {
-        "fields": {
-            "sidewalk": {
-                "label": "Sidewalk"
-            },
-            "cycleway": {
-                "types": {
-                    "cycleway:both": "Both Sides"
+    "tagging": {
+        "presets": {
+            "fields": {
+                "sidewalk": {
+                    "label": "Sidewalk"
                 },
-                "options": {
-                    "shoulder": {
-                        "title": "Shoulder",
-                        "description": "Bikes can use the shoulder, but it has no proper signage"
+                "cycleway": {
+                    "types": {
+                        "cycleway:both": "Both Sides"
+                    },
+                    "options": {
+                        "shoulder": {
+                            "title": "Shoulder",
+                            "description": "Bikes can use the shoulder, but it has no proper signage"
+                        }
                     }
-                }
-            },
-            "cycleway_buffer": { "label": "Both: Cycleway buffer width (m)" },
-            "cycleway_separation": {
-                "label": "Both: Cycleway separation",
-                "options": {
-                    "no": "None",
-                    "flex_post": "Flex posts",
-                    "parking_lane": "Parking lane",
-                    "bollard": "Bollards (fixed)",
-                    "bump": "Bumps",
-                    "studs": "Studs",
-                    "fence": "Fence",
-                    "planter": "Planters (flower boxes)",
-                    "jersey_barrier": "Jersey concrete barriers",
-                    "guard_rail": "Guard rail",
-                    "structure": "Structure (bridge)",
-                    "vertical_panel": "Vertical panel"
-                }
-            },
-            "cycleway_marking": {
-                "label": "Both: Cycleway marking",
-                "options": {
-                    "no": "None",
-                    "solid_line": "Solid line",
-                    "dashed_line": "Dashed line",
-                    "dotted_line": "Dotted line",
-                    "double_solid_line": "Double solid line",
-                    "barred_area": "Buffer / Barred area",
-                    "pictogram": "Pictogram",
-                    "surface": "Change of surface"
-                }
-            },
-            "cycleway_left_buffer": { "label": "Left: Cycleway buffer width (m)" },
-            "cycleway_left_separation": { "label": "Left: Cycleway separation" },
-            "cycleway_left_marking": { "label": "Left: Cycleway marking" },
-            "cycleway_left_oneway": {
-                "label": "Left: Bicycle one way",
-                "options": { "yes": "Yes", "no": "No" }
-            },
-            "cycleway_right_buffer": { "label": "Right: Cycleway buffer width (m)" },
-            "cycleway_right_separation": { "label": "Right: Cycleway separation" },
-            "cycleway_right_marking": { "label": "Right: Cycleway marking" },
-            "cycleway_right_oneway": { "label": "Right: Bicycle one way" }
+                },
+                "cycleway_buffer": { "label": "Both: Cycleway buffer width (m)" },
+                "cycleway_separation": {
+                    "label": "Both: Cycleway separation",
+                    "options": {
+                        "no": "None",
+                        "flex_post": "Flex posts",
+                        "parking_lane": "Parking lane",
+                        "bollard": "Bollards (fixed)",
+                        "bump": "Bumps",
+                        "studs": "Studs",
+                        "fence": "Fence",
+                        "planter": "Planters (flower boxes)",
+                        "jersey_barrier": "Jersey concrete barriers",
+                        "guard_rail": "Guard rail",
+                        "structure": "Structure (bridge)",
+                        "vertical_panel": "Vertical panel"
+                    }
+                },
+                "cycleway_marking": {
+                    "label": "Both: Cycleway marking",
+                    "options": {
+                        "no": "None",
+                        "solid_line": "Solid line",
+                        "dashed_line": "Dashed line",
+                        "dotted_line": "Dotted line",
+                        "double_solid_line": "Double solid line",
+                        "barred_area": "Buffer / Barred area",
+                        "pictogram": "Pictogram",
+                        "surface": "Change of surface"
+                    }
+                },
+                "cycleway_left_buffer": { "label": "Left: Cycleway buffer width (m)" },
+                "cycleway_left_separation": { "label": "Left: Cycleway separation" },
+                "cycleway_left_marking": { "label": "Left: Cycleway marking" },
+                "cycleway_left_oneway": {
+                    "label": "Left: Bicycle one way",
+                    "options": { "yes": "Yes", "no": "No" }
+                },
+                "cycleway_right_buffer": { "label": "Right: Cycleway buffer width (m)" },
+                "cycleway_right_separation": { "label": "Right: Cycleway separation" },
+                "cycleway_right_marking": { "label": "Right: Cycleway marking" },
+                "cycleway_right_oneway": { "label": "Right: Bicycle one way" }
+            }
+        }
+    },
+    "general": {
+        "issues": {
+            "redundant_directional_tag": {
+                "title": "Redundant Plain Tag",
+                "tip": "Find features where a plain tag is overridden by its directional variants.",
+                "message": "{feature} has a plain \"{tag}\" tag alongside its directional variants",
+                "reference": "The plain \"{tag}\" tag is made redundant by its directional variants (\"{tag}:both\", or \"{tag}:left\" and \"{tag}:right\"). The plain tag should be removed to avoid ambiguity."
+            }
         }
     }
 }

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -1,62 +1,74 @@
 {
-    "presets": {
-        "fields": {
-            "sidewalk": {
-                "label": "Trottoir"
-            },
-            "cycleway": {
-                "types": {
-                    "cycleway:both": "Les deux côtés"
+    "tagging": {
+        "presets": {
+            "fields": {
+                "sidewalk": {
+                    "label": "Trottoir"
                 },
-                "options": {
-                    "shoulder": {
-                        "title": "Accotement",
-                        "description": "Les vélos peuvent utiliser l'accotement, sans signalisation propre"
+                "cycleway": {
+                    "types": {
+                        "cycleway:both": "Les deux côtés"
+                    },
+                    "options": {
+                        "shoulder": {
+                            "title": "Accotement",
+                            "description": "Les vélos peuvent utiliser l'accotement, sans signalisation propre"
+                        }
                     }
-                }
-            },
-            "cycleway_buffer": { "label": "Les deux côtés : Largeur de la zone tampon cyclable (m)" },
-            "cycleway_separation": {
-                "label": "Les deux côtés : Séparation cyclable",
-                "options": {
-                    "no": "Aucune",
-                    "flex_post": "Balises flexibles",
-                    "parking_lane": "Voie de stationnement",
-                    "bollard": "Bornes (fixes)",
-                    "bump": "Bosses",
-                    "studs": "Clous",
-                    "fence": "Clôture",
-                    "planter": "Jardinières",
-                    "jersey_barrier": "Glissières en béton (Jersey)",
-                    "guard_rail": "Glissière de sécurité",
-                    "structure": "Structure (pont)",
-                    "vertical_panel": "Panneau vertical"
-                }
-            },
-            "cycleway_marking": {
-                "label": "Les deux côtés : Marquage cyclable",
-                "options": {
-                    "no": "Aucun",
-                    "solid_line": "Ligne pleine",
-                    "dashed_line": "Ligne tiretée",
-                    "dotted_line": "Ligne pointillée",
-                    "double_solid_line": "Double ligne pleine",
-                    "barred_area": "Zone tampon / hachurée",
-                    "pictogram": "Pictogramme",
-                    "surface": "Changement de surface"
-                }
-            },
-            "cycleway_left_buffer": { "label": "Côté gauche : Largeur de la zone tampon cyclable (m)" },
-            "cycleway_left_separation": { "label": "Côté gauche : Séparation cyclable" },
-            "cycleway_left_marking": { "label": "Côté gauche : Marquage cyclable" },
-            "cycleway_left_oneway": {
-                "label": "Côté gauche : Sens unique vélo",
-                "options": { "yes": "Oui", "no": "Non" }
-            },
-            "cycleway_right_buffer": { "label": "Côté droit : Largeur de la zone tampon cyclable (m)" },
-            "cycleway_right_separation": { "label": "Côté droit : Séparation cyclable" },
-            "cycleway_right_marking": { "label": "Côté droit : Marquage cyclable" },
-            "cycleway_right_oneway": { "label": "Côté droit : Sens unique vélo" }
+                },
+                "cycleway_buffer": { "label": "Les deux côtés : Largeur de la zone tampon cyclable (m)" },
+                "cycleway_separation": {
+                    "label": "Les deux côtés : Séparation cyclable",
+                    "options": {
+                        "no": "Aucune",
+                        "flex_post": "Balises flexibles",
+                        "parking_lane": "Voie de stationnement",
+                        "bollard": "Bornes (fixes)",
+                        "bump": "Bosses",
+                        "studs": "Clous",
+                        "fence": "Clôture",
+                        "planter": "Jardinières",
+                        "jersey_barrier": "Glissières en béton (Jersey)",
+                        "guard_rail": "Glissière de sécurité",
+                        "structure": "Structure (pont)",
+                        "vertical_panel": "Panneau vertical"
+                    }
+                },
+                "cycleway_marking": {
+                    "label": "Les deux côtés : Marquage cyclable",
+                    "options": {
+                        "no": "Aucun",
+                        "solid_line": "Ligne pleine",
+                        "dashed_line": "Ligne tiretée",
+                        "dotted_line": "Ligne pointillée",
+                        "double_solid_line": "Double ligne pleine",
+                        "barred_area": "Zone tampon / hachurée",
+                        "pictogram": "Pictogramme",
+                        "surface": "Changement de surface"
+                    }
+                },
+                "cycleway_left_buffer": { "label": "Côté gauche : Largeur de la zone tampon cyclable (m)" },
+                "cycleway_left_separation": { "label": "Côté gauche : Séparation cyclable" },
+                "cycleway_left_marking": { "label": "Côté gauche : Marquage cyclable" },
+                "cycleway_left_oneway": {
+                    "label": "Côté gauche : Sens unique vélo",
+                    "options": { "yes": "Oui", "no": "Non" }
+                },
+                "cycleway_right_buffer": { "label": "Côté droit : Largeur de la zone tampon cyclable (m)" },
+                "cycleway_right_separation": { "label": "Côté droit : Séparation cyclable" },
+                "cycleway_right_marking": { "label": "Côté droit : Marquage cyclable" },
+                "cycleway_right_oneway": { "label": "Côté droit : Sens unique vélo" }
+            }
+        }
+    },
+    "general": {
+        "issues": {
+            "redundant_directional_tag": {
+                "title": "Tag simple redondant",
+                "tip": "Repérer les objets où un tag simple est supplanté par ses variantes directionnelles.",
+                "message": "{feature} a un tag « {tag} » simple en plus de ses variantes directionnelles",
+                "reference": "Le tag simple « {tag} » est rendu redondant par ses variantes directionnelles (« {tag}:both », ou « {tag}:left » et « {tag}:right »). Le tag simple devrait être retiré pour éviter l'ambiguïté."
+            }
         }
     }
 }

--- a/modules/presets/custom_strings.js
+++ b/modules/presets/custom_strings.js
@@ -1,9 +1,11 @@
 // =============================================================================
-// Translations for the custom Québec fields (sidewalk, cycleway and its lane
-// sub-fields). Kept in plain locale JSON files under `data/locales/custom/` so
-// they live next to the other translations and can be edited without touching
-// field logic. They are injected into the `tagging` scope at load time because
-// the tagging schema itself comes from the npm package, not a local build.
+// Translations for the custom Québec additions (sidewalk / cycleway fields and
+// their sub-fields, plus custom validator messages). Kept in plain locale JSON
+// files under `data/locales/custom/` so they live next to the other
+// translations and can be edited without touching logic. They are injected at
+// load time, keyed by scope (`tagging` for preset fields, `general` for core
+// UI / validator strings), because the tagging schema comes from the npm
+// package rather than a local build.
 // =============================================================================
 
 import en from '../../data/locales/custom/en.json';
@@ -12,11 +14,14 @@ import fr from '../../data/locales/custom/fr.json';
 const customStrings = { en, fr };
 
 /**
- * Register the custom field translations (all locales) into the localizer.
+ * Register the custom translations (all locales, all scopes) into the localizer.
+ * Each locale file is `{ <scopeId>: <strings> }`.
  * @param {Object} localizer - the localizer with `addStrings`
  */
 export function registerCustomStrings(localizer) {
     for (const locale in customStrings) {
-        localizer.addStrings('tagging', locale, customStrings[locale]);
+        for (const scopeId in customStrings[locale]) {
+            localizer.addStrings(scopeId, locale, customStrings[locale][scopeId]);
+        }
     }
 }

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -14,5 +14,6 @@ export { validationMutuallyExclusiveTags } from './mutually_exclusive_tags';
 export { validationOsmApiLimits } from './osm_api_limits';
 export { validationOutdatedTags } from './outdated_tags';
 export { validationPrivateData } from './private_data';
+export { validationRedundantDirectionalTag } from './redundant_directional_tag';
 export { validationSuspiciousName } from './suspicious_name';
 export { validationUnsquareWay } from './unsquare_way';

--- a/modules/validations/redundant_directional_tag.js
+++ b/modules/validations/redundant_directional_tag.js
@@ -1,0 +1,70 @@
+import { actionChangeTags } from '../actions/change_tags';
+import { t } from '../core/localizer';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
+import { validationIssue, validationIssueFix } from '../core/validation';
+
+// Base keys whose directional variants make the plain tag redundant: once a
+// side is described per-direction (`<base>:both`, or both `<base>:left` and
+// `<base>:right`), a leftover plain `<base>=*` is ambiguous and should be
+// removed. Only flags pre-existing data — editing through the fields already
+// clears the plain tag.
+const DIRECTIONAL_BASE_KEYS = ['cycleway', 'sidewalk'];
+
+export function validationRedundantDirectionalTag(/* context */) {
+    const type = 'redundant_directional_tag';
+
+    const validation = function checkRedundantDirectionalTag(entity /*, graph */) {
+        const tags = entity.tags || {};
+        return DIRECTIONAL_BASE_KEYS
+            .filter(base => isRedundant(tags, base))
+            .map(base => makeIssue(entity, base));
+    };
+
+    /** Plain `base` tag coexists with `base:both`, or with both `base:left` and `base:right`. */
+    function isRedundant(tags, base) {
+        if (!(base in tags)) return false;
+        return `${base}:both` in tags ||
+            (`${base}:left` in tags && `${base}:right` in tags);
+    }
+
+    function makeIssue(entity, base) {
+        return new validationIssue({
+            type,
+            severity: 'warning',
+            message: function(context) {
+                const current = context.hasEntity(this.entityIds[0]);
+                return current ? t.append(`issues.${type}.message`, {
+                    feature: utilDisplayLabel(current, context.graph()),
+                    tag: base
+                }) : '';
+            },
+            reference: selection => selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .call(t.append(`issues.${type}.reference`, { tag: base })),
+            entityIds: [entity.id],
+            dynamicFixes: () => [removeTagFix(base)]
+        });
+    }
+
+    function removeTagFix(base) {
+        return new validationIssueFix({
+            icon: 'iD-operation-delete',
+            title: t.append('issues.fix.remove_named_tag.title', { tag: base }),
+            onClick: function(context) {
+                const entityID = this.issue.entityIds[0];
+                const tags = Object.assign({}, context.entity(entityID).tags);   // shallow copy
+                delete tags[base];
+                context.perform(
+                    actionChangeTags(entityID, tags),
+                    t('issues.fix.remove_named_tag.annotation', { tag: base })
+                );
+            }
+        });
+    }
+
+    validation.type = type;
+    return validation;
+}

--- a/test/spec/validations/redundant_directional_tag.js
+++ b/test/spec/validations/redundant_directional_tag.js
@@ -1,0 +1,56 @@
+import { setTimeout } from 'node:timers/promises';
+
+describe('iD.validations.redundant_directional_tag', function () {
+    var context;
+
+    beforeEach(function() {
+        context = iD.coreContext().init();
+    });
+
+    function createWay(tags) {
+        context.perform(
+            iD.actionAddEntity({ id: 'n-1', loc: [4, 4] }),
+            iD.actionAddEntity({ id: 'n-2', loc: [4, 5] }),
+            iD.actionAddEntity({ id: 'w-1', nodes: ['n-1', 'n-2'], tags: tags })
+        );
+    }
+
+    function validate() {
+        var validator = iD.validationRedundantDirectionalTag(context);
+        var changes = context.history().changes();
+        var entities = changes.modified.concat(changes.created);
+        var issues = [];
+        entities.forEach(function(entity) {
+            issues = issues.concat(validator(entity, context.graph()));
+        });
+        return issues;
+    }
+
+    // [name, tags, expected number of issues]
+    var cases = [
+        ['no directional tags', { highway: 'residential', cycleway: 'lane' }, 0],
+        ['directional only (no plain)', { highway: 'residential', 'cycleway:both': 'lane' }, 0],
+        ['plain only (no directional)', { highway: 'residential', sidewalk: 'both' }, 0],
+        ['plain + :both', { highway: 'residential', cycleway: 'lane', 'cycleway:both': 'track' }, 1],
+        ['plain + :left only', { highway: 'residential', cycleway: 'lane', 'cycleway:left': 'track' }, 0],
+        ['plain + :left + :right', { highway: 'residential', cycleway: 'anything', 'cycleway:left': 'track', 'cycleway:right': 'no' }, 1],
+        ['sidewalk plain + :both', { highway: 'residential', sidewalk: 'both', 'sidewalk:both': 'yes' }, 1],
+        ['sidewalk plain + :left + :right', { highway: 'residential', sidewalk: 'left', 'sidewalk:left': 'yes', 'sidewalk:right': 'no' }, 1],
+        ['both cycleway and sidewalk redundant', { cycleway: 'lane', 'cycleway:both': 'track', sidewalk: 'both', 'sidewalk:both': 'yes' }, 2]
+    ];
+
+    cases.forEach(function(testCase) {
+        var name = testCase[0], tags = testCase[1], expected = testCase[2];
+        it(`${name} -> ${expected} issue(s)`, async () => {
+            createWay(tags);
+            await setTimeout(20);
+            var issues = validate();
+            expect(issues).to.have.lengthOf(expected);
+            issues.forEach(function(issue) {
+                expect(issue.type).to.eql('redundant_directional_tag');
+                expect(issue.severity).to.eql('warning');
+                expect(issue.entityIds).to.eql(['w-1']);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds a validator that flags a plain `cycleway` / `sidewalk` tag left alongside its directional variants, which makes the plain tag ambiguous.

- **New** `modules/validations/redundant_directional_tag.js` (severity `warning`): fires when a plain `<base>` tag coexists with `<base>:both`, or with both `<base>:left` and `<base>:right`, for `cycleway` and `sidewalk`.
- One-click fix removes the plain tag (reuses the existing `issues.fix.remove_named_tag` strings).
- Auto-registered through `modules/validations/index.js`.
- Editing through the cycleway/sidewalk fields already clears the plain tag; this validator catches **pre-existing** data.

### i18n
The custom locale files (`data/locales/custom/{en,fr}.json`) are now keyed by scope (`tagging` for preset fields, `general` for the validator messages), and `custom_strings.js` injects each scope. `core.yaml` is left untouched. Validator messages are provided in both English and French.

## Test plan
- [x] `tsc` / `eslint` pass
- [x] esbuild + data build OK
- [x] new parametric spec (9 cases: cycleway/sidewalk, :both, :left+:right, negatives, multi-issue) — 9/9 pass
- [x] UI: warning shows (in French) on a way with e.g. `cycleway=lane` + `cycleway:both=track`, with a fix to remove the plain tag