### PR TITLE
clone: add per-type shortcuts; transition clones placement only

### DIFF
--- a/modules/operations/clone.ts
+++ b/modules/operations/clone.ts
@@ -45,9 +45,7 @@ export const cloneTypes: CloneType[] = [
         'lanes:bus:backward', 'busway:right', 'busway:left', 'routing:bus', 'bus'
     ] },
     { id: 'clone_transition', tags: [
-        'placement', 'placement:start', 'placement:end', 'width:lanes:start', 'width:lanes:end',
-        'placement:forward', 'width:lanes:forward:start', 'width:lanes:forward:end',
-        'placement:backward', 'width:lanes:backward:start', 'width:lanes:backward:end'
+        'placement', 'placement:start', 'placement:end', 'placement:forward', 'placement:backward'
     ] },
     { id: 'clone_maxspeed', tags: ['maxspeed'] },
     { id: 'clone_surface', tags: ['surface'] },

--- a/modules/operations/clone.ts
+++ b/modules/operations/clone.ts
@@ -17,7 +17,7 @@ interface CloneType {
  * just add a `key` here — it is wired automatically through `behaviorOperation`.
  */
 export const cloneTypes: CloneType[] = [
-    { id: 'clone_address', tags: [
+    { id: 'clone_address', key: '&', tags: [
         'addr:housenumber', 'addr:housename', 'addr:street', 'addr:city', 'addr:province',
         'addr:borough', 'addr:postcode', 'addr:source', 'addr:suburb', 'addr:state',
         'addr:place', 'addr:full', 'addr:county', 'addr:district', 'addr:hamlet', 'addr:subdistrict',
@@ -26,14 +26,14 @@ export const cloneTypes: CloneType[] = [
         'contact:place', 'contact:full', 'contact:county', 'contact:district', 'contact:hamlet',
         'contact:subdistrict', 'contact:country'
     ] },
-    { id: 'clone_name', tags: [
+    { id: 'clone_name', key: '%', tags: [
         'name', 'operator', 'alt_name', 'old_name', 'short_name', 'official_name', 'int_name',
         'loc_name', 'name:left', 'name:right', 'nat_name', 'ref_name', 'reg_name', 'sorting_name', 'nickname'
     ], languageSuffixes: ['fr', 'en'] },
     { id: 'clone_lanes', tags: ['lanes', 'lanes:forward', 'lanes:backward'] },
     { id: 'clone_turn_lanes', tags: ['turn:lanes', 'turn:lanes:forward', 'turn:lanes:backward'] },
-    { id: 'clone_sidewalk', tags: ['sidewalk', 'sidewalk:both', 'sidewalk:right', 'sidewalk:left', 'foot'] },
-    { id: 'clone_cycleway', tags: [
+    { id: 'clone_sidewalk', key: '*', tags: ['sidewalk', 'sidewalk:both', 'sidewalk:right', 'sidewalk:left', 'foot'] },
+    { id: 'clone_cycleway', key: '@', tags: [
         'bicycle', 'cycleway', 'cycleway:both', 'cycleway:right', 'cycleway:buffer', 'cycleway:marking',
         'cycleway:right:marking', 'cycleway:left:marking', 'cycleway:separation', 'cycleway:right:separation',
         'cycleway:right:buffer', 'cycleway:right:oneway', 'cycleway:left:separation', 'cycleway:left:buffer',
@@ -44,11 +44,11 @@ export const cloneTypes: CloneType[] = [
         'bus:lanes', 'bus:lanes:forward', 'bus:lanes:backward', 'lanes:bus', 'lanes:bus:forward',
         'lanes:bus:backward', 'busway:right', 'busway:left', 'routing:bus', 'bus'
     ] },
-    { id: 'clone_transition', tags: [
+    { id: 'clone_transition', key: '!', tags: [
         'placement', 'placement:start', 'placement:end', 'placement:forward', 'placement:backward'
     ] },
-    { id: 'clone_maxspeed', tags: ['maxspeed'] },
-    { id: 'clone_surface', tags: ['surface'] },
+    { id: 'clone_maxspeed', key: ')', tags: ['maxspeed'] },
+    { id: 'clone_surface', key: '(', tags: ['surface'] },
     { id: 'clone_dual_carriageway', tags: ['dual_carriageway'] }
 ];
 


### PR DESCRIPTION
## Summary

Two small changes to the clone sub-operations:

1. **`clone_transition` clones only placement tags** — drops the `width:lanes:*` tags; only the `placement` tags are copied.
2. **Per-type keyboard shortcuts** for the most-used clone sub-operations, wired through the existing `CloneType.key` field:

| Sub-operation | Shortcut |
|---|---|
| clone_address | `&` |
| clone_name | `%` |
| clone_sidewalk | `*` |
| clone_cycleway | `@` |
| clone_transition | `!` |
| clone_maxspeed | `)` |
| clone_surface | `(` |

The remaining clone types stay shortcut-less.

### Conflict check
Verified against existing operation keys (`core.yaml`), global bindings and `keybinding.ts`. Two originally-proposed keys were dropped to avoid collisions: `=` (zoom-in / `plusKeys`) and `#` (the `smooth` operation), replaced by `*` and `@`.

## Test plan
- [x] `tsc` / `eslint` pass
- [x] Select two features (first as source) and trigger each shortcut; the matching clone runs