### PR TITLE
Add follow-segment edit operation (with closed-way fix)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -438,6 +438,17 @@ en:
           area: This feature can't follow the area because it is only connected at a single point. Add another point manually to continue.
           generic: This feature can't follow the other feature because they are only connected at a single point. Add another point manually to continue.
         unknown: This feature can't follow another feature.
+    follow_segment:
+      title: Follow Segment
+      description:
+        points: Replace the segment between two shared nodes with the source way's geometry.
+      key: L
+      annotation:
+        points: Followed a line.
+      nodes_are_not_shared_by_both_ways: The two nodes are not shared by both the source and target ways.
+      source_or_target_way_is_closed_but_has_less_than_4_nodes: The source or target way is closed but has fewer than 4 nodes.
+      connected_to_hidden: This can't be followed because it is connected to a hidden feature.
+      not_downloaded: This can't be followed because parts of it have not yet been downloaded.
     reflect:
       title:
         long: Flip Long

--- a/modules/actions/follow_segment.ts
+++ b/modules/actions/follow_segment.ts
@@ -1,0 +1,257 @@
+// =============================================================================
+// FOLLOW SEGMENT - Replace a portion of a target way (between two nodes shared
+// with a source way) by the matching portion of the source way, so the target
+// "follows" the source geometry between those two nodes.
+//
+// Named "follow segment" to avoid clashing with iD's built-in draw-mode
+// "follow" (operations.follow, key F).
+//
+// Works for open ways and for closed ways (rings). A ring has two arcs between
+// the start and end nodes: one arc is replaced by the source path, the other is
+// kept, and the result is reassembled so the ring always stays closed,
+// regardless of the node order. Intersection nodes (shared with other ways or
+// carrying tags) on the replaced part are snapped onto the new path instead of
+// being dropped.
+// =============================================================================
+
+import { actionDeleteNode } from './delete_node';
+
+/** Index after `i`, wrapping on a closed way; `null` past an open way's end. */
+function nextNodeIdx(nodes: string[], closed: boolean, i: number): number | null {
+    if (closed) {
+        if (nodes.length < 3) return null;
+        return i === nodes.length - 1 ? 1 : i + 1;   // skip index 0 (duplicate of last)
+    }
+    return i === nodes.length - 1 ? null : i + 1;
+}
+
+/** True when `i` is the (duplicated) first/last node of a closed way. */
+function indexIsFirstOrLastOfClosed(nodes: string[], closed: boolean, i: number): boolean {
+    return closed && (i === 0 || i === nodes.length - 1);
+}
+
+/**
+ * Node ids walked from `startIdx` to `endIdx`, both included. A closed way walks
+ * forward (wrapping); an open way walks in natural order and is always returned
+ * oriented start -> end.
+ */
+function nodesBetween(nodes: string[], closed: boolean, startIdx: number, endIdx: number): string[] {
+    if (nodes.length < 2 || startIdx < 0 || endIdx < 0 || startIdx === endIdx ||
+        (indexIsFirstOrLastOfClosed(nodes, closed, startIdx) && indexIsFirstOrLastOfClosed(nodes, closed, endIdx))) {
+        return [];
+    }
+    let reverse = false;
+    if (!closed && startIdx > endIdx) {
+        [startIdx, endIdx] = [endIdx, startIdx];
+        reverse = true;
+    }
+    let idx: number | null = startIdx;
+    const between = [nodes[startIdx]];
+    const endIsFirstOrLast = indexIsFirstOrLastOfClosed(nodes, closed, endIdx);
+    while (idx !== endIdx) {
+        idx = nextNodeIdx(nodes, closed, idx);
+        if (idx === null || !nodes[idx]) return [];
+        between.push(nodes[idx]);
+        if (endIsFirstOrLast && (idx === 0 || idx === nodes.length - 1)) break;
+    }
+    return reverse ? between.reverse() : between;
+}
+
+type Loc = [number, number];
+
+/** Location of a node id (the union entity type hides `loc`, so narrow it here). */
+function nodeLoc(graph: iD.Graph, id: string): Loc {
+    return (graph.entity(id) as { loc: Loc }).loc;
+}
+
+/** Closest point on segment [a, b] to `p`, with its parameter `t` and distance. */
+function closestPointOnSegment(p: Loc, a: Loc, b: Loc): { point: Loc; t: number; distance: number } {
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    const lengthSq = dx * dx + dy * dy;
+    if (lengthSq === 0) {
+        return { point: a, t: 0, distance: Math.hypot(p[0] - a[0], p[1] - a[1]) };
+    }
+    let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / lengthSq;
+    t = Math.max(0, Math.min(1, t));
+    const point: Loc = [a[0] + t * dx, a[1] + t * dy];
+    return { point, t, distance: Math.hypot(p[0] - point[0], p[1] - point[1]) };
+}
+
+/** Closest point on the polyline `nodeIds` to `p`, with the segment it lands on. */
+function closestPointOnPath(graph: iD.Graph, p: Loc, nodeIds: string[]) {
+    let best: { point: Loc; segmentIndex: number; t: number; distance: number } | null = null;
+    let bestDistance = Infinity;
+    for (let i = 0; i < nodeIds.length - 1; i++) {
+        const r = closestPointOnSegment(p, nodeLoc(graph, nodeIds[i]), nodeLoc(graph, nodeIds[i + 1]));
+        if (r.distance < bestDistance) {
+            bestDistance = r.distance;
+            best = { point: r.point, segmentIndex: i, t: r.t, distance: r.distance };
+        }
+    }
+    return best;
+}
+
+/**
+ * Average distance of an arc's interior nodes to the source path. Used to pick
+ * which target arc the source is meant to replace, independently of the order in
+ * which the two shared nodes were selected. An arc with no interior (a direct
+ * edge between the two shared nodes) counts as closest.
+ */
+function arcDistanceToPath(graph: iD.Graph, arc: string[], path: string[]): number {
+    const interior = arc.slice(1, -1);
+    if (interior.length === 0) return 0;
+    let sum = 0;
+    for (const id of interior) {
+        const closest = closestPointOnPath(graph, nodeLoc(graph, id), path);
+        sum += closest ? closest.distance : 0;
+    }
+    return sum / interior.length;
+}
+
+export function actionFollowSegment(selectedIDs: EntityID[], reverse = false) {
+
+    /** First target node that is also on the source way (or the explicit one). */
+    function getStartNodeId(explicit: EntityID | undefined, tgtNodes: string[], srcNodes: string[]): string | null {
+        if (explicit) return explicit;
+        return tgtNodes.find(id => srcNodes.indexOf(id) >= 0) ?? null;
+    }
+
+    /** Next shared node after the start (or the explicit one). */
+    function getEndNodeId(startNodeId: string | null, explicit: EntityID | undefined, tgtNodes: string[], srcNodes: string[]): string | null {
+        if (explicit) return explicit;
+        return tgtNodes.find(id => srcNodes.indexOf(id) >= 0 && id !== startNodeId) ?? null;
+    }
+
+    /**
+     * Replace the interior of `replacedArc` (an oriented run of target node ids,
+     * endpoints included) with `orientedSrc` (the source path, same endpoints and
+     * orientation). Intersection nodes on the replaced interior are snapped onto
+     * the new path and kept. Returns the new run (endpoints included), the updated
+     * graph, and the set of preserved node ids.
+     */
+    function replaceArc(graph: iD.Graph, replacedArc: string[], orientedSrc: string[]) {
+        const interior = replacedArc.slice(1, -1);
+
+        // intersection nodes: connected to another way or carrying tags
+        const intersections = interior
+            .map(id => graph.entity(id) as any)
+            .filter(node => graph.parentWays(node).length > 1 || node.hasNonGeometryTags());
+
+        const toInsert: { segmentIndex: number; t: number; nodeId: string }[] = [];
+        for (const node of intersections) {
+            const closest = closestPointOnPath(graph, node.loc, orientedSrc);
+            if (!closest) continue;
+            graph = graph.replace((graph.entity(node.id) as any).move(closest.point));
+            toInsert.push({ segmentIndex: closest.segmentIndex, t: closest.t, nodeId: node.id });
+        }
+        toInsert.sort((a, b) => a.segmentIndex !== b.segmentIndex ? a.segmentIndex - b.segmentIndex : a.t - b.t);
+
+        // weave the snapped intersection nodes into the source path
+        const seq: string[] = [];
+        let k = 0;
+        for (let i = 0; i < orientedSrc.length; i++) {
+            seq.push(orientedSrc[i]);
+            while (k < toInsert.length && toInsert[k].segmentIndex === i) {
+                seq.push(toInsert[k].nodeId);
+                k++;
+            }
+        }
+        return { seq, graph, preserved: new Set(intersections.map(n => n.id)) };
+    }
+
+    /** Delete the replaced interior nodes that became orphan and tagless. */
+    function deleteOrphans(graph: iD.Graph, interior: string[], preserved: Set<string>): iD.Graph {
+        for (const nodeId of interior) {
+            if (preserved.has(nodeId) || !graph.hasEntity(nodeId)) continue;
+            const node = graph.entity(nodeId);
+            if (!node.hasNonGeometryTags() && !graph.isShared(node) && graph.parentWays(node).length === 0) {
+                graph = actionDeleteNode(node.id)(graph);
+            }
+        }
+        return graph;
+    }
+
+    const action = function (graph: iD.Graph): iD.Graph {
+        const tgtWay = graph.entity(selectedIDs[0]) as any;
+        const tgtClosed = tgtWay.isClosed();
+        const tgtNodes: string[] = tgtWay.nodes.slice();
+        const srcWay = graph.entity(selectedIDs[1]) as any;
+        const srcClosed = srcWay.isClosed();
+        const srcNodes: string[] = srcWay.nodes.slice();
+
+        const startNodeId = getStartNodeId(selectedIDs[2], tgtNodes, srcNodes);
+        const endNodeId = getEndNodeId(startNodeId, selectedIDs[3], tgtNodes, srcNodes);
+
+        const startTgt = tgtNodes.indexOf(startNodeId as string);
+        const endTgt = tgtNodes.indexOf(endNodeId as string);
+        const startSrc = srcNodes.indexOf(startNodeId as string);
+        const endSrc = srcNodes.indexOf(endNodeId as string);
+
+        // source geometry oriented from the start node to the end node
+        const srcPath = nodesBetween(srcNodes, srcClosed, startSrc, endSrc);
+        if (srcPath.length === 0) return graph;
+
+        if (!tgtClosed) {
+            // open way: replace the [start, end] run in place, keeping the rest
+            let lo = startTgt, hi = endTgt;
+            if (lo > hi) [lo, hi] = [hi, lo];
+            const replacedArc = tgtNodes.slice(lo, hi + 1);
+            const orientedSrc = tgtNodes[lo] === srcPath[0] ? srcPath : [...srcPath].reverse();
+
+            const r = replaceArc(graph, replacedArc, orientedSrc);
+            graph = r.graph;
+            const newNodes = [...tgtNodes.slice(0, lo), ...r.seq, ...tgtNodes.slice(hi + 1)];
+            graph = graph.replace(tgtWay.update({ nodes: newNodes }));
+            return deleteOrphans(graph, replacedArc.slice(1, -1), r.preserved);
+        }
+
+        // closed way: pick the arc to replace, keep the other, reassemble closed
+        const arc1 = nodesBetween(tgtNodes, true, startTgt, endTgt);   // start -> end
+        const arc2 = nodesBetween(tgtNodes, true, endTgt, startTgt);   // end -> start
+        if (arc1.length === 0 || arc2.length === 0) return graph;
+
+        // Replace the arc closest to the source path (order-independent); `reverse`
+        // flips the choice to the far arc.
+        let replaceArc1 = arcDistanceToPath(graph, arc1, srcPath) <= arcDistanceToPath(graph, arc2, srcPath);
+        if (reverse) replaceArc1 = !replaceArc1;
+        const replacedArc = replaceArc1 ? arc1 : arc2;
+        const keptArc = replaceArc1 ? arc2 : arc1;
+        // source path oriented to match the replaced arc's endpoints
+        const orientedSrc = replacedArc[0] === srcPath[0] ? srcPath : [...srcPath].reverse();
+
+        const r = replaceArc(graph, replacedArc, orientedSrc);
+        graph = r.graph;
+        // replaced run, then the kept arc without its shared joint -> closed ring
+        const ring = [...r.seq, ...keptArc.slice(1)];
+        graph = graph.replace(tgtWay.update({ nodes: ring }));
+        return deleteOrphans(graph, replacedArc.slice(1, -1), r.preserved);
+    };
+
+    action.disabled = function (graph: iD.Graph): string | false {
+        const tgtWay = graph.entity(selectedIDs[0]) as any;
+        const tgtNodes: string[] = tgtWay.nodes.slice();
+        const srcWay = graph.entity(selectedIDs[1]) as any;
+        const srcNodes: string[] = srcWay.nodes.slice();
+        const startNodeId = getStartNodeId(selectedIDs[2], tgtNodes, srcNodes);
+        const endNodeId = getEndNodeId(startNodeId, selectedIDs[3], tgtNodes, srcNodes);
+
+        const startTgt = tgtNodes.indexOf(startNodeId as string);
+        const endTgt = tgtNodes.indexOf(endNodeId as string);
+        const startSrc = srcNodes.indexOf(startNodeId as string);
+        const endSrc = srcNodes.indexOf(endNodeId as string);
+
+        if (startTgt === -1 || endTgt === -1 || startSrc === -1 || endSrc === -1) {
+            return 'nodes_are_not_shared_by_both_ways';
+        }
+        // a closed way repeats its first node, so it needs at least 4 entries here
+        if ((tgtWay.isClosed() && tgtNodes.length < 4) || (srcWay.isClosed() && srcNodes.length < 4)) {
+            return 'source_or_target_way_is_closed_but_has_less_than_4_nodes';
+        }
+        return false;
+    };
+
+    action.transitionable = true;
+
+    return action;
+}

--- a/modules/actions/index.js
+++ b/modules/actions/index.js
@@ -16,6 +16,7 @@ export { actionDeleteWay } from './delete_way';
 export { actionDiscardTags } from './discard_tags';
 export { actionDisconnect } from './disconnect';
 export { actionExtract } from './extract';
+export { actionFollowSegment } from './follow_segment';
 export { actionJoin } from './join';
 export { actionMerge } from './merge';
 export { actionMergeNodes } from './merge_nodes';

--- a/modules/operations/follow_segment.ts
+++ b/modules/operations/follow_segment.ts
@@ -1,0 +1,100 @@
+import { t } from '../core/localizer';
+import { actionFollowSegment } from '../actions/follow_segment';
+import { behaviorOperation } from '../behavior/operation';
+import { utilGetAllNodes } from '../util';
+
+/**
+ * Operation that makes a target way "follow" a source way between two shared
+ * nodes: the matching portion of the target is replaced by the source geometry.
+ *
+ * Named "follow segment" to avoid clashing with iD's built-in draw-mode "follow"
+ * (operations.follow, key F).
+ *
+ * Selection is, in order: the target way, the source way, then optionally the
+ * start node and the end node (both shared by the two ways). With no nodes
+ * given, the two first shared nodes are used.
+ *
+ * @param context - the iD application context
+ * @param selectedIDs - currently selected entity ids
+ * @returns the operation function, with the usual operation metadata attached
+ */
+export function operationFollowSegment(context: iD.Context, selectedIDs: EntityID[]) {
+
+    const action = actionFollowSegment(selectedIDs);
+    const nodes = utilGetAllNodes(selectedIDs, context.graph());
+    const coords = nodes.map((n) => n.loc);
+
+    function operation() {
+        context.perform(action, operation.annotation());
+
+        window.setTimeout(function () {
+            context.validator().validate();
+        }, 300);  // after any transition
+    }
+
+
+    operation.available = function (): boolean {
+        if (selectedIDs.length < 2 || selectedIDs.length > 4) {
+            return false;
+        }
+        const entities = selectedIDs.map((selectedID) => context.entity(selectedID));
+        const [tgt, src, startNode, endNode] = entities;
+
+        const waysSelected = tgt.type === 'way' && src.type === 'way';
+        const nodesValid =
+            (startNode && startNode.type === 'node' && endNode && endNode.type === 'node') ||
+            (startNode && startNode.type === 'node' && !endNode) ||
+            (!startNode && !endNode);
+
+        return Boolean(waysSelected && nodesValid);
+    };
+
+
+    // don't cache this because the visible extent could change
+    operation.disabled = function () {
+        const actionDisabled = action.disabled(context.graph());
+        if (actionDisabled) {
+            return actionDisabled;
+        } else if (someMissing()) {
+            return 'not_downloaded';
+        } else if (selectedIDs.some(context.hasHiddenConnections)) {
+            return 'connected_to_hidden';
+        }
+        return false;
+
+
+        function someMissing(): boolean {
+            if (context.inIntro()) return false;
+            const osm = context.connection();
+            if (osm) {
+                const missing = coords.filter((loc) => !osm.isDataLoaded(loc));
+                if (missing.length) {
+                    missing.forEach((loc) => context.loadTileAtLoc(loc));
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+
+
+    operation.tooltip = function () {
+        const disable = operation.disabled();
+        return disable ?
+            t.append('operations.follow_segment.' + disable) :
+            t.append('operations.follow_segment.description.points');
+    };
+
+
+    operation.annotation = function (): string {
+        return t('operations.follow_segment.annotation.points');
+    };
+
+
+    operation.id = 'follow_segment';
+    operation.keys = [t('operations.follow_segment.key')];
+    operation.title = t.append('operations.follow_segment.title');
+    operation.behavior = behaviorOperation(context).which(operation);
+
+    return operation;
+}

--- a/modules/operations/index.js
+++ b/modules/operations/index.js
@@ -21,6 +21,7 @@ export { operationDelete } from './delete';
 export { operationDisconnect } from './disconnect';
 export { operationDowngrade } from './downgrade';
 export { operationExtract } from './extract';
+export { operationFollowSegment } from './follow_segment';
 export { operationMerge } from './merge';
 export { operationMove } from './move';
 export { operationOrthogonalize } from './orthogonalize';

--- a/svg/iD-sprite/operations/operation-follow_segment.svg
+++ b/svg/iD-sprite/operations/operation-follow_segment.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="20" viewBox="0 0 20 20">
+    <polyline points="2,10 18,10" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" opacity="0.35"/>
+    <path d="M2,10 C7,3 13,3 18,10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    <path d="M8,9 l2,-2 l2,2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" opacity="0.55"/>
+    <path d="M0,10 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0 M16,10 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" fill="currentColor"/>
+</svg>

--- a/test/spec/actions/follow_segment.js
+++ b/test/spec/actions/follow_segment.js
@@ -1,0 +1,148 @@
+describe('iD.actionFollowSegment', function () {
+
+    // Build a graph from compact node and way descriptions.
+    function makeGraph(nodes, ways) {
+        var entities = nodes.map(function (n) {
+            return new iD.osmNode({ id: n.id, loc: n.loc });
+        }).concat(ways.map(function (w) {
+            return new iD.osmWay({ id: w.id, nodes: w.nodes, tags: { highway: 'residential' } });
+        }));
+        return new iD.coreGraph(entities);
+    }
+
+    // Square ring a-b-c-d-a with two shared nodes b, c, plus an outside node x
+    // sitting near the b-c edge (so the b-c arc is the one closest to the source).
+    var ringNodes = [
+        { id: 'a', loc: [0, 0] },
+        { id: 'b', loc: [1, 0] },
+        { id: 'c', loc: [1, 1] },
+        { id: 'd', loc: [0, 1] },
+        { id: 'x', loc: [1.2, 0.5] }
+    ];
+
+    // Parametric cases that assert the resulting target way node order exactly.
+    var cases = [
+        {
+            name: 'open way: inserts the source nodes between the shared nodes',
+            nodes: [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'c', loc: [2, 0] }, { id: 'd', loc: [3, 0] },
+                { id: 'x', loc: [1, 1] }, { id: 'y', loc: [2, 1] }
+            ],
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd'] },
+                { id: 'src', nodes: ['b', 'x', 'y', 'c'] }
+            ],
+            selectedIDs: ['tgt', 'src'],
+            expected: ['a', 'b', 'x', 'y', 'c', 'd']
+        },
+        {
+            name: 'open way: result is independent of the start/end selection order',
+            nodes: [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'c', loc: [2, 0] }, { id: 'd', loc: [3, 0] },
+                { id: 'x', loc: [1, 1] }, { id: 'y', loc: [2, 1] }
+            ],
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd'] },
+                { id: 'src', nodes: ['b', 'x', 'y', 'c'] }
+            ],
+            selectedIDs: ['tgt', 'src', 'c', 'b'],  // end then start
+            expected: ['a', 'b', 'x', 'y', 'c', 'd']
+        },
+        {
+            name: 'closed way: replaces the arc closest to the source, stays closed',
+            nodes: ringNodes,
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
+                { id: 'src', nodes: ['b', 'x', 'c'] }
+            ],
+            selectedIDs: ['tgt', 'src'],
+            expected: ['b', 'x', 'c', 'd', 'a', 'b']
+        },
+        {
+            name: 'closed way: same result whatever the start/end selection order',
+            nodes: ringNodes,
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
+                { id: 'src', nodes: ['b', 'x', 'c'] }
+            ],
+            selectedIDs: ['tgt', 'src', 'c', 'b'],  // end then start
+            expected: ['b', 'x', 'c', 'd', 'a', 'b']
+        },
+        {
+            name: 'closed way: reverse replaces the far arc and stays closed',
+            nodes: ringNodes,
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
+                { id: 'src', nodes: ['b', 'x', 'c'] }
+            ],
+            selectedIDs: ['tgt', 'src'],
+            reverse: true,
+            expected: ['c', 'x', 'b', 'c']
+        }
+    ];
+
+    cases.forEach(function (c) {
+        it(c.name, function () {
+            var graph = makeGraph(c.nodes, c.ways);
+            graph = iD.actionFollowSegment(c.selectedIDs, c.reverse || false)(graph);
+            expect(graph.entity('tgt').nodes).to.eql(c.expected);
+            // a closed result must keep its first node repeated at the end
+            var nodes = graph.entity('tgt').nodes;
+            if (c.ways[0].nodes[0] === c.ways[0].nodes[c.ways[0].nodes.length - 1]) {
+                expect(nodes[0]).to.equal(nodes[nodes.length - 1]);
+            }
+        });
+    });
+
+    it('reverse on a closed way deletes the orphan tagless nodes of the replaced arc', function () {
+        var graph = makeGraph(ringNodes, [
+            { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
+            { id: 'src', nodes: ['b', 'x', 'c'] }
+        ]);
+        graph = iD.actionFollowSegment(['tgt', 'src'], true)(graph);
+        expect(graph.hasEntity('d')).not.to.be.ok;  // far-arc interior, now orphan
+        expect(graph.hasEntity('a')).not.to.be.ok;
+        expect(graph.hasEntity('x')).to.be.ok;       // from the source path
+    });
+
+    it('preserves an intersection node by snapping it onto the new path', function () {
+        // m sits on the replaced segment of the target and is shared with way w2,
+        // so it must survive (moved onto the source path) instead of being deleted.
+        var graph = makeGraph(
+            [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'm', loc: [1.5, 0.1] }, { id: 'c', loc: [2, 0] },
+                { id: 'd', loc: [3, 0] }, { id: 'x', loc: [1.5, 1] },
+                { id: 'n', loc: [1.5, -1] }
+            ],
+            [
+                { id: 'tgt', nodes: ['a', 'b', 'm', 'c', 'd'] },
+                { id: 'src', nodes: ['b', 'x', 'c'] },
+                { id: 'w2', nodes: ['m', 'n'] }  // makes m an intersection node
+            ]
+        );
+        graph = iD.actionFollowSegment(['tgt', 'src'])(graph);
+        var nodes = graph.entity('tgt').nodes;
+        expect(graph.hasEntity('m')).to.be.ok;
+        expect(nodes).to.include('m');
+        expect(nodes).to.include('x');
+        expect(nodes[0]).to.equal('a');
+        expect(nodes[nodes.length - 1]).to.equal('d');
+    });
+
+    it('is disabled when the ways share no nodes', function () {
+        var graph = makeGraph(
+            [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'e', loc: [5, 5] }, { id: 'f', loc: [6, 6] }
+            ],
+            [
+                { id: 'tgt', nodes: ['a', 'b'] },
+                { id: 'src', nodes: ['e', 'f'] }
+            ]
+        );
+        expect(iD.actionFollowSegment(['tgt', 'src']).disabled(graph)).to.equal('nodes_are_not_shared_by_both_ways');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a **follow-segment** edit operation: select a target way, a source way (and optionally the two shared nodes), and the segment of the target between those nodes is replaced by the matching geometry of the source.
- **Fixes the closed-way behavior** that produced reversed arcs / artifacts in the previous prototypes: a ring has two arcs between the shared nodes; the arc **closest to the source path** is replaced and the ring is reassembled so it **always stays closed**, regardless of the order the two nodes were selected. The complementary arc is kept untouched.
- Intersection nodes (shared with other ways or carrying tags) on the replaced part are **snapped onto the new path** instead of being dropped; orphaned tagless nodes are removed.
- Named `follow_segment` (key **L**) to avoid clashing with iD's built-in draw-mode `follow` (`operations.follow`, key F).

## Notes
- Ported to TypeScript and unified into a single robust implementation (replaces the two older `follow` / `follow_old` prototypes from v5).
- Arc helpers are local to the action; `osm/way.js` is untouched.
- `reverse` (replace the far arc) exists in the action but is not yet exposed in the UI.

## Test plan
- [x] `tsc` and `eslint` clean
- [x] 8 parametric specs in `test/spec/actions/follow_segment.js`: open insertion, reversed selection order, closed near-arc, order-independence, `reverse`, orphan deletion, intersection preservation, `disabled`
- [x] Manual UI test: lines, closed polygons/circles, both node-selection orders