### PR TITLE
Add Circularize segment-length preference

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4225,6 +4225,23 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     margin: 5px;
 }
 
+/* Editing preferences - circularize segment length */
+.editing-options-container .display-control {
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+.editing-options-container .circularize-segment-length-max {
+    font-weight: normal;
+    opacity: 0.5;
+    margin: 5px;
+}
+.editing-options-container .circularize-segment-length-description {
+    margin: 5px;
+    opacity: 0.5;
+    font-style: italic;
+}
+
 .display-control .control-wrap {
     display: flex;
     align-items: center;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1126,6 +1126,13 @@ en:
     title: Preferences
     description: Preferences
     key: P
+    editing:
+      title: Editing
+      circularize_segment_length:
+        title: Circularize segment length
+        meters: "{distance} m"
+        max_segments: "max {count} segments"
+        description: "Target length of the segments created by Circularize. Shorter segments make rounder, more precise circles (more nodes). iD default: 4 m."
     privacy:
       title: Privacy
       privacy_link: View the iD privacy policy

--- a/modules/actions/circularize.js
+++ b/modules/actions/circularize.js
@@ -10,11 +10,26 @@ import { geoVecInterp, geoVecLength } from '../geo';
 import { osmNode } from '../osm/node';
 import { utilArrayUniq } from '../util';
 import { radiansToMeters } from '../ui/panels';
+import { prefs } from '../core/preferences';
 
 
-const MAX_SEGMENT_LENGTH = 4;
+// Target length of the circle segments, in meters. Shorter segments produce a
+// more precise circle (more vertices). Configurable from the Preferences pane
+// between MIN and the iD default; see SEGMENT_LENGTH.pref.
+export const SEGMENT_LENGTH = {
+    min: 1,          // meters, most precise
+    default: 4,      // meters, iD develop default
+    pref: 'preferences.circularize.segment_length'
+};
 export const MIN_VERTICES = 12;
 export const MAX_VERTICES = 32;
+
+/** Effective max segment length (m) from preferences, clamped to the allowed range. */
+function maxSegmentLength() {
+    const raw = parseFloat(prefs(SEGMENT_LENGTH.pref));
+    if (!isFinite(raw)) return SEGMENT_LENGTH.default;
+    return Math.min(SEGMENT_LENGTH.default, Math.max(SEGMENT_LENGTH.min, raw));
+}
 
 export function actionCircularize(wayId, projection) {
 
@@ -202,7 +217,7 @@ export function actionCircularize(wayId, projection) {
     /**
      * Returns the maximum internal angle of a regular polygon with
      * the given centroid and radius such that the length of the segments
-     * are just shorter than approximately MAX_SEGMENT_LENGTH. But
+     * are just shorter than the configured max segment length. But
      * never returns fewer than MIN_VERTICES or more than MAX_VERTICES.
      * #12139
      */
@@ -212,7 +227,7 @@ export function actionCircularize(wayId, projection) {
             projection.invert([centroid[0] + radius, centroid[1]])
         ]}));
         const numberOfPoints = Math.min(MAX_VERTICES, Math.max(MIN_VERTICES,
-            Math.round(radiusM * Math.PI / MAX_SEGMENT_LENGTH) * 2
+            Math.round(radiusM * Math.PI / maxSegmentLength()) * 2
         ));
         return Math.PI * 2 / (numberOfPoints - 1);
     }

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -1,5 +1,6 @@
 import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
+import { uiSectionEditingPreferences } from '../sections/editing_preferences';
 import { uiSectionPrivacy } from '../sections/privacy';
 import { uiSectionShortcutList } from '../sections/shortcut_list';
 
@@ -11,6 +12,7 @@ export function uiPanePreferences(context) {
     .description(t.append('preferences.description'))
     .iconName('fas-user-cog')
     .sections([
+        uiSectionEditingPreferences(context),
         uiSectionShortcutList(context),
         uiSectionPrivacy(context)
     ]);

--- a/modules/ui/sections/editing_preferences.js
+++ b/modules/ui/sections/editing_preferences.js
@@ -1,0 +1,110 @@
+import { select as d3_select } from 'd3-selection';
+import { clamp } from 'es-toolkit/compat';
+
+import { prefs } from '../../core/preferences';
+import { t, localizer } from '../../core/localizer';
+import { svgIcon } from '../../svg/icon';
+import { uiSection } from '../section';
+import { SEGMENT_LENGTH, MAX_VERTICES } from '../../actions/circularize';
+
+
+/**
+ * Preferences section for editing defaults. Currently exposes the target
+ * segment length used by the Circularize operation: shorter segments give a
+ * more precise circle (more vertices). Range is SEGMENT_LENGTH.min..default
+ * metres; the default is iD's built-in value.
+ *
+ * @param {*} context - the iD application context
+ * @returns the section
+ */
+export function uiSectionEditingPreferences(context) {
+
+    const section = uiSection('preferences-editing', context)
+        .label(() => t.append('preferences.editing.title'))
+        .disclosureContent(renderDisclosureContent);
+
+    /** Current segment length (m), read from preferences and clamped to range. */
+    function segmentLength() {
+        const raw = parseFloat(prefs(SEGMENT_LENGTH.pref));
+        if (!isFinite(raw)) return SEGMENT_LENGTH.default;
+        return clamp(raw, SEGMENT_LENGTH.min, SEGMENT_LENGTH.default);
+    }
+
+    function setSegmentLength(val) {
+        prefs(SEGMENT_LENGTH.pref, clamp(+val, SEGMENT_LENGTH.min, SEGMENT_LENGTH.default));
+        section.reRender();
+    }
+
+    function renderDisclosureContent(selection) {
+        let container = selection.selectAll('.editing-options-container')
+            .data([0]);
+
+        const containerEnter = container.enter()
+            .append('div')
+            .attr('class', 'display-options-container editing-options-container controls-list');
+
+        const controlEnter = containerEnter
+            .append('label')
+            .attr('class', 'display-control circularize-segment-length-control');
+
+        controlEnter
+            .call(svgIcon('#iD-operation-circularize', 'inline operation'))
+            .call(t.append('preferences.editing.circularize_segment_length.title'));
+
+        controlEnter
+            .append('span')
+            .attr('class', 'display-option-value circularize-segment-length-value');
+
+        const wrapEnter = controlEnter
+            .append('div')
+            .attr('class', 'control-wrap');
+
+        wrapEnter
+            .append('input')
+            .attr('class', 'display-option-input circularize-segment-length-input')
+            .attr('type', 'range')
+            .attr('min', SEGMENT_LENGTH.min)
+            .attr('max', SEGMENT_LENGTH.default)
+            .attr('step', '0.5')
+            .on('input', function() {
+                setSegmentLength(d3_select(this).property('value'));
+            });
+
+        wrapEnter
+            .append('button')
+            .attr('class', 'display-option-reset circularize-segment-length-reset')
+            .attr('title', () => `${t('background.reset')} ${t('preferences.editing.circularize_segment_length.title')}`)
+            .on('click', function(d3_event) {
+                if (d3_event.button !== 0) return;
+                setSegmentLength(SEGMENT_LENGTH.default);
+            })
+            .call(svgIcon('#iD-icon-' + (localizer.textDirection() === 'rtl' ? 'redo' : 'undo')));
+
+        // node count is capped whatever the length; show it just under the slider
+        controlEnter
+            .append('div')
+            .attr('class', 'circularize-segment-length-max')
+            .call(t.append('preferences.editing.circularize_segment_length.max_segments', { count: MAX_VERTICES }));
+
+        controlEnter
+            .append('div')
+            .attr('class', 'circularize-segment-length-description')
+            .call(t.append('preferences.editing.circularize_segment_length.description'));
+
+        // update
+        container = containerEnter.merge(container);
+
+        container.selectAll('.circularize-segment-length-input')
+            .property('value', segmentLength());
+
+        container.selectAll('.circularize-segment-length-value')
+            .text(t('preferences.editing.circularize_segment_length.meters', { distance: segmentLength() }));
+
+        container.selectAll('.circularize-segment-length-reset')
+            .classed('disabled', segmentLength() === SEGMENT_LENGTH.default);
+    }
+
+    prefs.onChange(SEGMENT_LENGTH.pref, section.reRender);
+
+    return section;
+}

--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -3,6 +3,7 @@ export { uiSectionBackgroundList } from './background_list';
 export { uiSectionBackgroundOffset } from './background_offset';
 export { uiSectionChanges } from './changes';
 export { uiSectionDataLayers } from './data_layers';
+export { uiSectionEditingPreferences } from './editing_preferences';
 export { uiSectionEntityIssues } from './entity_issues';
 export { uiSectionFeatureType } from './feature_type';
 export { uiSectionMapFeatures } from './map_features';


### PR DESCRIPTION
## Summary
- Adds an **Editing** section to the Preferences pane (right menu) with a **Circularize segment length** slider.
- Range **1–4 m**, default **4 m** (iD develop value). Shorter segments produce rounder, more precise circles (more nodes).
- The existing `MAX_VERTICES` cap (32) is unchanged and shown next to the slider, so users know the node count is bounded whatever the length.
- `actionCircularize` reads the preference at run time (clamped to the allowed range); the constant `MAX_SEGMENT_LENGTH` is replaced by a `SEGMENT_LENGTH` config object that is the single source of truth shared with the UI.

## Notes
- Reuses the existing `display-options-container` slider styling; adds a little padding and a bottom separator so further editing preferences can be appended later.
- Persisted in localStorage (`preferences.circularize.segment_length`); no restart needed.

## Test plan
- [x] `tsc`, `eslint` clean; 16 existing `circularize` specs still pass (default 4 m preserves behavior)
- [x] Manual UI: Preferences → Editing, move the slider, run Circularize and compare node density at 4 m vs 1 m