### PR TITLE
Add preference to delete features outside the view

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4236,10 +4236,14 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     opacity: 0.5;
     margin: 5px;
 }
-.editing-options-container .circularize-segment-length-description {
+.editing-options-container .editing-option-description {
     margin: 5px;
     opacity: 0.5;
     font-style: italic;
+}
+/* Editing preferences - allow deleting features outside the view */
+.editing-options-container .delete-outside-view-control input {
+    margin: 5px;
 }
 
 .display-control .control-wrap {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1139,6 +1139,10 @@ en:
         meters: "{distance} m"
         max_segments: "max {count} segments"
         description: "Target length of the segments created by Circularize. Shorter segments make rounder, more precise circles (more nodes). iD default: 4 m."
+      delete_outside_view:
+        title: Allow deleting features outside the view
+        description: Lets the Delete operation work even when a feature extends beyond the visible map area.
+        warning: For advanced users only. Deleting features you can't fully see may remove more than you intend.
     privacy:
       title: Privacy
       privacy_link: View the iD privacy policy

--- a/modules/operations/delete.js
+++ b/modules/operations/delete.js
@@ -1,4 +1,5 @@
 import { t } from '../core/localizer';
+import { prefs } from '../core/preferences';
 import { actionDeleteMultiple } from '../actions/delete_multiple';
 import { behaviorOperation } from '../behavior/operation';
 import { geoSphericalDistance } from '../geo';
@@ -6,6 +7,12 @@ import { modeBrowse } from '../modes/browse';
 import { modeSelect } from '../modes/select';
 import { uiCmd } from '../ui/cmd';
 import { utilGetAllNodes, utilTotalExtent } from '../util';
+
+
+// Preference key: when set to 'true', deletion is allowed even when the feature
+// extends outside the current view (normally blocked as 'too_large'). Opt-in,
+// intended for advanced users (see the Editing preferences section).
+export const DELETE_OUTSIDE_VIEW = 'preferences.editing.delete_outside_view';
 
 
 export function operationDelete(context, selectedIDs) {
@@ -70,7 +77,8 @@ export function operationDelete(context, selectedIDs) {
 
 
     operation.disabled = function() {
-        if (extent.percentContainedIn(context.map().extent()) < 0.8) {
+        if (extent.percentContainedIn(context.map().extent()) < 0.8 &&
+            prefs(DELETE_OUTSIDE_VIEW) !== 'true') {
             return 'too_large';
         } else if (someMissing()) {
             return 'not_downloaded';

--- a/modules/ui/sections/editing_preferences.js
+++ b/modules/ui/sections/editing_preferences.js
@@ -6,6 +6,7 @@ import { t, localizer } from '../../core/localizer';
 import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 import { SEGMENT_LENGTH, MAX_VERTICES } from '../../actions/circularize';
+import { DELETE_OUTSIDE_VIEW } from '../../operations/delete';
 
 
 /**
@@ -33,6 +34,11 @@ export function uiSectionEditingPreferences(context) {
     function setSegmentLength(val) {
         prefs(SEGMENT_LENGTH.pref, clamp(+val, SEGMENT_LENGTH.min, SEGMENT_LENGTH.default));
         section.reRender();
+    }
+
+    /** Whether deleting features extending outside the view is allowed. */
+    function deleteOutsideView() {
+        return prefs(DELETE_OUTSIDE_VIEW) === 'true';
     }
 
     function renderDisclosureContent(selection) {
@@ -88,11 +94,48 @@ export function uiSectionEditingPreferences(context) {
 
         controlEnter
             .append('div')
-            .attr('class', 'circularize-segment-length-description')
+            .attr('class', 'editing-option-description')
             .call(t.append('preferences.editing.circularize_segment_length.description'));
+
+        // delete-outside-view toggle: clicking the label flips the preference
+        const deleteControlEnter = containerEnter
+            .append('label')
+            .attr('class', 'display-control delete-outside-view-control');
+
+        deleteControlEnter
+            .append('input')
+            .attr('type', 'checkbox')
+            .attr('class', 'delete-outside-view-input')
+            .on('change', function() {
+                prefs(DELETE_OUTSIDE_VIEW, d3_select(this).property('checked') ? 'true' : 'false');
+            });
+
+        deleteControlEnter
+            .call(t.append('preferences.editing.delete_outside_view.title'));
+
+        // description and an advanced-user warning sit outside the label so they
+        // are not clickable toggles
+        containerEnter
+            .append('div')
+            .attr('class', 'editing-option-description')
+            .call(t.append('preferences.editing.delete_outside_view.description'));
+
+        const warnEnter = containerEnter
+            .append('div')
+            .attr('class', 'field-warning delete-outside-view-warning');
+
+        warnEnter
+            .call(svgIcon('#iD-icon-alert', 'inline'));
+
+        warnEnter
+            .append('span')
+            .call(t.append('preferences.editing.delete_outside_view.warning'));
 
         // update
         container = containerEnter.merge(container);
+
+        container.selectAll('.delete-outside-view-input')
+            .property('checked', deleteOutsideView());
 
         container.selectAll('.circularize-segment-length-input')
             .property('value', segmentLength());
@@ -105,6 +148,7 @@ export function uiSectionEditingPreferences(context) {
     }
 
     prefs.onChange(SEGMENT_LENGTH.pref, section.reRender);
+    prefs.onChange(DELETE_OUTSIDE_VIEW, section.reRender);
 
     return section;
 }


### PR DESCRIPTION
## Summary

Adds an opt-in **Editing** preference that lets the **Delete** operation work on features extending beyond the visible map area — normally blocked by the `too_large` guard. Off by default; a warning marks it as advanced-users-only.

- `operations/delete.js`: the `too_large` check is skipped when `preferences.editing.delete_outside_view === 'true'`. Scope limited to **Delete** — move/rotate/reflect/circularize keep their guard.
- `ui/sections/editing_preferences.js`: a checkbox in the Editing section, with a description and a `field-warning` block (alert icon) reusing existing patterns. Synced via `prefs.onChange`.
- `data/core.yaml`: strings under `preferences.editing.delete_outside_view` (title / description / warning).
- `css/80_app.css`: unified the two preference descriptions under a single `editing-option-description` class.

## Test plan
- [x] `npx tsc` clean
- [x] `npx eslint` clean on changed files
- [x] `npm run build:data` clean (strings present in generated locale)
- [ ] Manual: Preferences (P) → Editing → enable "Allow deleting features outside the view"
- [ ] Select a feature extending well outside the view → Delete is no longer disabled
- [ ] Disable the preference → the `too_large` guard returns