### PR TITLE
Add per-lane width/change/turn fields (laneList widget)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1743,6 +1743,40 @@ button.preset-reset .label.flash-bg {
     border-radius: 0 0 4px 4px;
 }
 
+/* Per-lane fields (laneList): a common-case dropdown stacked over an optional
+   per-lane grid (one numbered cell per lane). */
+.form-field-input-wrap.lane-list {
+    flex-flow: column nowrap;
+}
+.lane-list .lane-dropdown {
+    display: flex;
+    width: 100%;
+}
+.lane-list .lane-dropdown-input {
+    flex: 1 1 auto;
+}
+.lane-list .lane-grid {
+    display: flex;
+    flex-flow: row wrap;
+    width: 100%;
+}
+.lane-list .lane-cell {
+    flex: 1 1 0;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    min-width: 38px;
+}
+.lane-list .lane-cell-label {
+    font-size: 10px;
+    line-height: 16px;
+    opacity: 0.6;
+}
+.lane-list .lane-cell-input {
+    width: 100%;
+    text-align: center;
+}
+
 /* Buttons inside fields */
 .form-field-button {
     flex: 0 0 auto;

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -5,6 +5,23 @@
                 "sidewalk": {
                     "label": "Sidewalk"
                 },
+                "placement": { "label": "Placement" },
+                "placement_forward": { "label": "Placement (forward)" },
+                "placement_backward": { "label": "Placement (backward)" },
+                "lanes_forward": { "label": "Lanes (forward)" },
+                "lanes_backward": { "label": "Lanes (backward)" },
+                "width_lanes_start": { "label": "Lane widths — transition start (m)" },
+                "width_lanes_end": { "label": "Lane widths — transition end (m)" },
+                "width_lanes_forward_start": { "label": "Lane widths, forward — transition start (m)" },
+                "width_lanes_forward_end": { "label": "Lane widths, forward — transition end (m)" },
+                "width_lanes_backward_start": { "label": "Lane widths, backward — transition start (m)" },
+                "width_lanes_backward_end": { "label": "Lane widths, backward — transition end (m)" },
+                "change_lanes": { "label": "Lane change permissions" },
+                "change_lanes_forward": { "label": "Lane change permissions (forward)" },
+                "change_lanes_backward": { "label": "Lane change permissions (backward)" },
+                "turn_lanes": { "label": "Turn indications per lane" },
+                "turn_lanes_forward": { "label": "Turn indications per lane (forward)" },
+                "turn_lanes_backward": { "label": "Turn indications per lane (backward)" },
                 "cycleway": {
                     "types": {
                         "cycleway:both": "Both Sides"
@@ -62,6 +79,9 @@
         }
     },
     "general": {
+        "lanes": {
+            "count_mismatch": "“{tag}” has {actual} lanes, but the road is tagged with {count}."
+        },
         "issues": {
             "redundant_directional_tag": {
                 "title": "Redundant Plain Tag",

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -5,6 +5,23 @@
                 "sidewalk": {
                     "label": "Trottoir"
                 },
+                "placement": { "label": "Placement" },
+                "placement_forward": { "label": "Placement (sens du tracé)" },
+                "placement_backward": { "label": "Placement (sens inverse)" },
+                "lanes_forward": { "label": "Voies (sens du tracé)" },
+                "lanes_backward": { "label": "Voies (sens inverse)" },
+                "width_lanes_start": { "label": "Largeurs de voies — début de transition (m)" },
+                "width_lanes_end": { "label": "Largeurs de voies — fin de transition (m)" },
+                "width_lanes_forward_start": { "label": "Largeurs de voies, sens du tracé — début de transition (m)" },
+                "width_lanes_forward_end": { "label": "Largeurs de voies, sens du tracé — fin de transition (m)" },
+                "width_lanes_backward_start": { "label": "Largeurs de voies, sens inverse — début de transition (m)" },
+                "width_lanes_backward_end": { "label": "Largeurs de voies, sens inverse — fin de transition (m)" },
+                "change_lanes": { "label": "Permissions de changement de voie" },
+                "change_lanes_forward": { "label": "Permissions de changement de voie (sens du tracé)" },
+                "change_lanes_backward": { "label": "Permissions de changement de voie (sens inverse)" },
+                "turn_lanes": { "label": "Indications de direction par voie" },
+                "turn_lanes_forward": { "label": "Indications de direction par voie (sens du tracé)" },
+                "turn_lanes_backward": { "label": "Indications de direction par voie (sens inverse)" },
                 "cycleway": {
                     "types": {
                         "cycleway:both": "Les deux côtés"
@@ -62,6 +79,9 @@
         }
     },
     "general": {
+        "lanes": {
+            "count_mismatch": "« {tag} » a {actual} voies, mais la route est taggée avec {count}."
+        },
         "issues": {
             "redundant_directional_tag": {
                 "title": "Tag simple redondant",

--- a/modules/operations/clone.ts
+++ b/modules/operations/clone.ts
@@ -45,7 +45,9 @@ export const cloneTypes: CloneType[] = [
         'lanes:bus:backward', 'busway:right', 'busway:left', 'routing:bus', 'bus'
     ] },
     { id: 'clone_transition', key: '!', tags: [
-        'placement', 'placement:start', 'placement:end', 'placement:forward', 'placement:backward'
+        'placement', 'placement:start', 'placement:end', 'placement:forward', 'placement:backward',
+        'width:lanes:start', 'width:lanes:end', 'width:lanes:forward:start', 'width:lanes:forward:end',
+        'width:lanes:backward:start', 'width:lanes:backward:end'
     ] },
     { id: 'clone_maxspeed', key: ')', tags: ['maxspeed'] },
     { id: 'clone_surface', key: '(', tags: ['surface'] },

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -7,6 +7,7 @@
 
 import { localizer } from '../core/localizer';
 import { cyclewaySubFields, cyclewaySubFieldOrder } from './cycleway_fields';
+import { laneFields, laneFieldOrder } from './lane_fields';
 import { registerCustomStrings } from './custom_strings';
 
 /** Custom field definitions, merged into the preset system at load time. */
@@ -16,8 +17,57 @@ export const customFields = {
         keys: ['sidewalk', 'sidewalk:both', 'sidewalk:left', 'sidewalk:right'],
         type: 'sidewalk',
         geometry: ['line']
+    },
+    // Roadway placement (Québec "Transition" convention). `placement=transition`
+    // marks a lane-count/width transition segment. Free combo: real-world values
+    // (`transition`, `right_of:1`, …) come from taginfo autocomplete.
+    placement: {
+        key: 'placement',
+        type: 'combo',
+        geometry: ['line']
+    },
+    // Per-direction placement, only on bidirectional ways and hidden once the
+    // segment is a transition (which uses the per-lane width fields instead).
+    placement_forward: {
+        key: 'placement:forward',
+        type: 'combo',
+        geometry: ['line'],
+        prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'placement', valueNot: 'transition' }] }
+    },
+    placement_backward: {
+        key: 'placement:backward',
+        type: 'combo',
+        geometry: ['line'],
+        prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'placement', valueNot: 'transition' }] }
+    },
+    // Per-direction lane counts. Not in the upstream schema; shown only when the
+    // split is ambiguous: two-way roads (`oneway!=yes`) with more than 2 lanes.
+    lanes_forward: {
+        key: 'lanes:forward',
+        type: 'number',
+        minValue: 0,
+        geometry: ['line'],
+        prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
+    },
+    lanes_backward: {
+        key: 'lanes:backward',
+        type: 'number',
+        minValue: 0,
+        geometry: ['line'],
+        prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
     }
 };
+
+// Road lane block, inserted just after the `lanes` field as default fields (see
+// applyCustomFields), in display order: per-direction lane counts, the per-lane
+// fields (turn / change / width), then placement. Prerequisites keep each one
+// hidden until the relevant lane-count / direction tags hold (e.g.
+// lanes_forward/backward show only when lanes>2 and the way is two-way).
+const LANE_BLOCK = [
+    'lanes_forward', 'lanes_backward',
+    ...laneFieldOrder,
+    'placement', 'placement_forward', 'placement_backward'
+];
 
 // highway=* values that should offer the sidewalk field
 const SIDEWALK_HIGHWAYS = new Set([
@@ -49,6 +99,7 @@ const NON_MOTORWAY_HIGHWAYS = new Set([
 export function applyCustomFields(presetManager) {
     presetManager.merge({ fields: customFields });
     presetManager.merge({ fields: cyclewaySubFields });
+    presetManager.merge({ fields: laneFields });
     customizeCycleway(presetManager);
     customizeOnewayBicycle(presetManager);
     registerCustomStrings(localizer);
@@ -79,14 +130,28 @@ export function applyCustomFields(presetManager) {
             fields.splice(fields.indexOf('structure'), 0, 'sidewalk');
         }
 
+        // Lane block (per-direction counts, per-lane turn/change/width, then
+        // placement): default fields inserted right after the `lanes` field, so
+        // they read top-to-bottom as lanes → forward/backward → turn → change →
+        // width → placement. The directional / per-lane fields stay hidden (by
+        // prerequisite) until their lane-count and direction tags hold. Applies
+        // to every road, including motorways. Falls back to before Structure
+        // when a preset has no `lanes` field.
+        LANE_BLOCK.forEach(id => { removeField(fields, id); removeField(moreFields, id); });
+        const afterLanes = fields.indexOf('lanes');
+        const laneInsertAt = afterLanes === -1 ? fields.indexOf('structure') : afterLanes + 1;
+        fields.splice(laneInsertAt, 0, ...LANE_BLOCK);
+
         if (!NON_MOTORWAY_HIGHWAYS.has(highway)) return;
 
-        // cycleway and its lane sub-fields: grouped right after sidewalk as default
-        // fields. `cycleway` is moved out of upstream's moreFields; the sub-fields
-        // stay hidden (by prerequisite) until a cycleway side is a lane.
+        // cycleway and its lane sub-fields: grouped right after the lane block as
+        // default fields. `cycleway` is moved out of upstream's moreFields; the
+        // sub-fields stay hidden (by prerequisite) until a cycleway side is a lane.
         const cyclewayBlock = ['cycleway', ...cyclewaySubFieldOrder];
         cyclewayBlock.forEach(id => { removeField(fields, id); removeField(moreFields, id); });
-        fields.splice(fields.indexOf('structure'), 0, ...cyclewayBlock);
+        const afterBlock = fields.indexOf('placement_backward');
+        const cyclewayAt = afterBlock === -1 ? fields.indexOf('structure') : afterBlock + 1;
+        fields.splice(cyclewayAt, 0, ...cyclewayBlock);
 
         // oneway:bicycle: shown right after the main `oneway` field as a default
         // field (stays hidden until oneway=yes, see customizeOnewayBicycle).

--- a/modules/presets/lane_fields.js
+++ b/modules/presets/lane_fields.js
@@ -1,0 +1,42 @@
+// =============================================================================
+// Per-lane custom fields (Québec "Transition" convention). Each field edits one
+// pipe-separated tag through the `laneList` renderer, which reads the lane count
+// from the matching `lanes*` tag at runtime — so a single field works for any
+// number of lanes (no per-lane-count field definitions to maintain, unlike v5).
+// =============================================================================
+
+// Shared prerequisite conditions.
+const TRANSITION = { key: 'placement', value: 'transition' };
+const ONE_WAY = { key: 'oneway', value: 'yes' };
+const TWO_WAY = { key: 'oneway', valueNot: 'yes' };
+
+/** Build a `laneList` field definition. */
+function laneField(key, prerequisiteTag) {
+    return { key, type: 'laneList', geometry: ['line'], prerequisiteTag };
+}
+
+/**
+ * Per-lane field definitions, merged into the preset system at load time.
+ *
+ * Widths only apply to `placement=transition` segments (their start/end lane
+ * widths); change permissions apply to any road with a lane count. Each field
+ * is shown once both its lane-count tag and its direction condition hold.
+ */
+// Order: turn, then change, then width (widths only on transition segments).
+export const laneFields = {
+    turn_lanes:          laneField('turn:lanes',          { allOf: [ONE_WAY, { key: 'lanes' }] }),
+    turn_lanes_forward:  laneField('turn:lanes:forward',  { allOf: [TWO_WAY, { key: 'lanes:forward' }] }),
+    turn_lanes_backward: laneField('turn:lanes:backward', { allOf: [TWO_WAY, { key: 'lanes:backward' }] }),
+    change_lanes:          laneField('change:lanes',          { allOf: [ONE_WAY, { key: 'lanes' }] }),
+    change_lanes_forward:  laneField('change:lanes:forward',  { allOf: [TWO_WAY, { key: 'lanes:forward' }] }),
+    change_lanes_backward: laneField('change:lanes:backward', { allOf: [TWO_WAY, { key: 'lanes:backward' }] }),
+    width_lanes_start:          laneField('width:lanes:start',          { allOf: [TRANSITION, ONE_WAY, { key: 'lanes' }] }),
+    width_lanes_end:            laneField('width:lanes:end',            { allOf: [TRANSITION, ONE_WAY, { key: 'lanes' }] }),
+    width_lanes_forward_start:  laneField('width:lanes:forward:start',  { allOf: [TRANSITION, TWO_WAY, { key: 'lanes:forward' }] }),
+    width_lanes_forward_end:    laneField('width:lanes:forward:end',    { allOf: [TRANSITION, TWO_WAY, { key: 'lanes:forward' }] }),
+    width_lanes_backward_start: laneField('width:lanes:backward:start', { allOf: [TRANSITION, TWO_WAY, { key: 'lanes:backward' }] }),
+    width_lanes_backward_end:   laneField('width:lanes:backward:end',   { allOf: [TRANSITION, TWO_WAY, { key: 'lanes:backward' }] })
+};
+
+/** Lane field ids, in the order they should appear in the "+ add field" list. */
+export const laneFieldOrder = Object.keys(laneFields);

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -18,7 +18,9 @@ import { utilRebind, utilUniqueDomId } from '../util';
  *
  * Accepts a single condition object or an array of conditions matched with OR
  * semantics (the field shows if any condition is satisfied). A condition uses
- * `key` with `value` / `values` / `valueNot` / `valuesNot`, or `keyNot`.
+ * `key` with `value` / `values` / `valueNot` / `valuesNot` / `valueGreaterThan`
+ * (numeric), or `keyNot`, or `allOf` (an array of conditions that must all be
+ * satisfied — AND semantics).
  *
  * @param {Object|Object[]} prerequisiteTag - a condition or an array of conditions
  * @param {Object} tags - the entity tags to test against
@@ -27,12 +29,19 @@ import { utilRebind, utilUniqueDomId } from '../util';
 export function prerequisiteTagSatisfied(prerequisiteTag, tags) {
     const conditions = Array.isArray(prerequisiteTag) ? prerequisiteTag : [prerequisiteTag];
     return conditions.some(function(condition) {
+        if (condition.allOf) {
+            return condition.allOf.every(c => prerequisiteTagSatisfied(c, tags));
+        }
         if (condition.key) {
             const value = tags[condition.key] || '';
             if (condition.valuesNot) return !condition.valuesNot.includes(value);
             if (condition.valueNot) return condition.valueNot !== value;
             if (condition.values) return condition.values.includes(value);
             if (condition.value) return condition.value === value;
+            // numeric comparison: satisfied when the tag parses above the bound
+            if (condition.valueGreaterThan !== undefined) {
+                return parseFloat(value) > condition.valueGreaterThan;
+            }
             return !!value;   // bare `key`: satisfied if any value is present
         }
         if (condition.keyNot) return !tags[condition.keyNot];

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -5,6 +5,8 @@ export * from './access';
 export * from './address';
 export * from './directional_combo';
 export * from './lanes';
+export * from './lane_list';
+export * from './lane_patterns';
 export * from './localized';
 export * from './roadheight';
 export * from './roadspeed';
@@ -50,6 +52,7 @@ import { uiFieldAccess } from './access';
 import { uiFieldAddress } from './address';
 import { uiFieldDirectionalCombo } from './directional_combo';
 import { uiFieldLanes } from './lanes';
+import { uiFieldLaneList } from './lane_list';
 import { uiFieldLocalized } from './localized';
 import { uiFieldRoadheight } from './roadheight';
 import { uiFieldRoadspeed } from './roadspeed';
@@ -72,6 +75,7 @@ export var uiFields = {
     email: uiFieldEmail,
     identifier: uiFieldIdentifier,
     lanes: uiFieldLanes,
+    laneList: uiFieldLaneList,
     localized: uiFieldLocalized,
     roadheight: uiFieldRoadheight,
     roadspeed: uiFieldRoadspeed,

--- a/modules/ui/fields/lane_list.ts
+++ b/modules/ui/fields/lane_list.ts
@@ -1,0 +1,207 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { uiCombobox } from '../combobox';
+import { t } from '../../core/localizer';
+import { utilNoAuto, utilRebind } from '../../util';
+import {
+    laneCountKey, laneKind, splitLaneValues, serializeLaneValues,
+    commonPatterns, matchPattern, cellOptions, cellDisplay, cellValue,
+    changeBoundaries, boundariesToValue, laneCountMismatch
+} from './lane_patterns';
+
+// Width pictographs are always drawn from `↑` and show their reverse (`↓`) too,
+// so a single base arrow covers both forward and backward fields at any angle
+// (matching v5, whose forward/backward width labels are identical).
+const WIDTH_ARROW = '↑';
+
+// =============================================================================
+// LANE LIST - hybrid editor for the per-lane tags (`width:lanes*`,
+// `change:lanes*`, `turn:lanes*`). A dropdown offers the common cases for the
+// current lane count; choosing "Custom…" (or loading a non-standard value)
+// reveals a per-lane grid with one combobox per lane. The kind is derived from
+// the field key; the lane count comes from the matching `lanes*` tag.
+// =============================================================================
+
+const CUSTOM_LABEL = 'Custom…';
+
+/**
+ * Per-lane preset field renderer (registered as the `laneList` field type).
+ *
+ * @param field - the preset field definition (decorated by `presetField`)
+ * @param context - the iD application context
+ * @returns the field component (callable on a d3 selection)
+ */
+export function uiFieldLaneList(
+    field: { type: string; key: string; safeid: string },
+    context: iD.Context
+) {
+    const dispatch = d3_dispatch('change');
+    const kind = laneKind(field.key);
+    const countKey = laneCountKey(field.key);
+    const arrow = WIDTH_ARROW;
+    const widthEnd = /:end$/.test(field.key);   // transition end mirrors width diagonals
+    const dropdownCombo = uiCombobox(context, 'lane-' + field.safeid);
+
+    // d3 selections are loosely typed here, like the sibling field components
+    let wrap: any = d3_select(null);
+    let _tags: Record<string, string> = {};
+    let _customMode = false;
+
+    function laneList(selection: any) {
+        wrap = selection.selectAll('.form-field-input-wrap')
+            .data([0]);
+
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type + ' lane-list')
+            .merge(wrap);
+
+        laneList.tags(_tags);
+    }
+
+    function laneCount() {
+        return parseInt(_tags[countKey], 10);
+    }
+
+    function render() {
+        const count = laneCount();
+        const value = _tags[field.key] || '';
+        const patterns = commonPatterns(kind, count, arrow, widthEnd);
+        const matched = matchPattern(kind, patterns, value);
+        // hybrid: dropdown always; grid as soon as a value is set (or Custom…)
+        const showGrid = patterns.length === 0 || _customMode || value !== '';
+
+        renderDropdown(patterns, matched, value);
+        renderGrid(showGrid, count, value);
+        renderWarning(value, count);
+    }
+
+    // Inline notice when the value's pipe count disagrees with the lanes tag.
+    // Reuses the shared `.field-warning` style (hidden automatically when empty).
+    function renderWarning(value: string, count: number) {
+        let warn = wrap.selectAll('.field-warning').data([0]);
+        warn = warn.enter()
+            .append('div')
+            .attr('class', 'field-warning')
+            .merge(warn);
+        const actual = laneCountMismatch(value, count);
+        warn.text(actual === undefined ? ''
+            : t('lanes.count_mismatch', { tag: field.key, actual, count }));
+    }
+
+    function renderDropdown(patterns: { value: string; title: string }[], matched: any, value: string) {
+        let row = wrap.selectAll('.lane-dropdown').data(patterns.length ? [0] : []);
+        row.exit().remove();
+        const enter = row.enter()
+            .append('div')
+            .attr('class', 'lane-dropdown');
+        enter.append('input')
+            .attr('type', 'text')
+            .attr('class', 'lane-dropdown-input')
+            .call(utilNoAuto)
+            .call(dropdownCombo)
+            .on('change', onDropdownChange)
+            .on('blur', onDropdownChange);
+        row = enter.merge(row);
+
+        if (!patterns.length) return;
+
+        dropdownCombo.data(patterns
+            .map(p => ({ value: p.title, title: p.title }))
+            .concat([{ value: CUSTOM_LABEL, title: CUSTOM_LABEL }]));
+
+        const shown = _customMode ? CUSTOM_LABEL
+            : matched ? matched.title
+            : value === '' ? '' : CUSTOM_LABEL;
+        row.select('.lane-dropdown-input').property('value', shown);
+    }
+
+    function renderGrid(show: boolean, count: number, value: string) {
+        let grid = wrap.selectAll('.lane-grid').data(show ? [0] : []);
+        grid.exit().remove();
+        grid = grid.enter()
+            .append('div')
+            .attr('class', 'lane-grid')
+            .merge(grid);
+
+        const data = show ? gridCells(value, count) : [];
+
+        let cells = grid.selectAll('.lane-cell').data(data, (d: { key: number }) => d.key);
+        cells.exit().remove();
+        const enter = cells.enter()
+            .append('label')
+            .attr('class', 'lane-cell');
+        enter.append('span')
+            .attr('class', 'lane-cell-label');
+        enter.append('input')
+            .attr('type', 'text')
+            .attr('class', 'lane-cell-input')
+            .call(utilNoAuto)
+            // a fresh combobox per cell, so their suggestion state stays independent
+            .each(function(this: HTMLElement) {
+                const combo = uiCombobox(context, 'lanecell-' + field.safeid);
+                combo.data(cellOptions(kind));
+                d3_select(this).call(combo);
+            })
+            .on('change', onGridChange)
+            .on('blur', onGridChange);
+        cells = enter.merge(cells);
+
+        cells.select('.lane-cell-label').text((d: { label: string }) => d.label);
+        cells.select('.lane-cell-input')
+            .property('value', (d: { value: string }) => cellDisplay(kind, d.value));
+    }
+
+    // Custom-grid cells: per lane for width/turn, per *boundary* for change
+    // (one control between each pair of lanes, e.g. label "1│2").
+    function gridCells(value: string, count: number) {
+        if (kind === 'change') {
+            return changeBoundaries(splitLaneValues(value, count).join('|'))
+                .map((glyph, i) => ({ key: i, label: `${i + 1}\u2502${i + 2}`, value: glyph }));
+        }
+        return splitLaneValues(value, count)
+            .map((v, lane) => ({ key: lane, label: String(lane + 1), value: v }));
+    }
+
+    function onDropdownChange(this: HTMLInputElement) {
+        if (this.value === CUSTOM_LABEL) {
+            _customMode = true;
+            render();
+            return;
+        }
+        const found = commonPatterns(kind, laneCount(), arrow, widthEnd).find(p => p.title === this.value);
+        if (!found) return;   // ignore free text that isn't a known case
+        _customMode = false;
+        emit(this, found.value || undefined);
+    }
+
+    function onGridChange(this: HTMLElement) {
+        _customMode = true;
+        const shown = wrap.selectAll('.lane-cell-input').nodes()
+            .map((node: HTMLInputElement) => cellValue(kind, node.value.trim()));
+        // change cells are boundary glyphs -> rebuild the per-lane value
+        const value = kind === 'change'
+            ? boundariesToValue(shown)
+            : serializeLaneValues(kind, shown);
+        emit(this, value);
+    }
+
+    function emit(node: HTMLElement, value: string | undefined) {
+        const tag: Record<string, string | undefined> = {};
+        tag[field.key] = value || undefined;
+        dispatch.call('change', node, tag);
+    }
+
+    laneList.tags = function(tags: Record<string, string>) {
+        _tags = tags || {};
+        render();
+    };
+
+    laneList.focus = function() {
+        const node = wrap.selectAll('input').node();
+        if (node) node.focus();
+    };
+
+    return utilRebind(laneList, dispatch, 'on');
+}

--- a/modules/ui/fields/lane_patterns.ts
+++ b/modules/ui/fields/lane_patterns.ts
@@ -96,8 +96,12 @@ export function turnLabel(value: string): string {
 
 // `change:lanes` is drawn per *boundary* between two lanes (v5 convention), not
 // per lane: the line is dotted on each side from which a change is allowed.
-const canChangeRight = (lane: string) => lane === 'yes' || lane === 'not_left';
-const canChangeLeft = (lane: string) => lane === 'yes' || lane === 'not_right';
+// `only_left` / `only_right` are accepted as synonyms of `not_right` / `not_left`
+// ("change only to the left" == "not to the right"), since both are seen in OSM.
+const canChangeRight = (lane: string) =>
+    lane === 'yes' || lane === 'not_left' || lane === 'only_right';
+const canChangeLeft = (lane: string) =>
+    lane === 'yes' || lane === 'not_right' || lane === 'only_left';
 
 /** Boundary glyph between two adjacent lanes (dotted on each open side). */
 function boundaryGlyph(left: string, right: string): string {

--- a/modules/ui/fields/lane_patterns.ts
+++ b/modules/ui/fields/lane_patterns.ts
@@ -1,0 +1,304 @@
+// =============================================================================
+// Pure helpers + data for the per-lane fields (`width:lanes*`, `change:lanes*`,
+// `turn:lanes*`). Kept separate from the d3 renderer (lane_list.ts) so the
+// value parsing and the dropdown/grid option generation stay easy to unit-test.
+// =============================================================================
+
+export type LaneKind = 'width' | 'change' | 'turn';
+
+/** One selectable option: the OSM value it sets and a pictographic label. */
+export interface LaneOption { value: string; title: string; terms?: string[]; }
+
+/** The `lanes*` tag whose value gives the lane count for a value key. */
+export function laneCountKey(valueKey: string): string {
+    const match = valueKey.match(/:(forward|backward)(?::(?:start|end))?$/);
+    return match ? `lanes:${match[1]}` : 'lanes';
+}
+
+/** Whether a value key holds lane widths, change permissions or turns. */
+export function laneKind(valueKey: string): LaneKind {
+    if (valueKey.indexOf('width:lanes') === 0) return 'width';
+    if (valueKey.indexOf('turn:lanes') === 0) return 'turn';
+    return 'change';
+}
+
+/** Split a `a|b|c` value into exactly `count` cells (pad/truncate). */
+export function splitLaneValues(value: string, count: number): string[] {
+    const parts = value ? value.split('|') : [];
+    const length = count > 0 ? count : parts.length;
+    return Array.from({ length }, (_, i) => parts[i] || '');
+}
+
+/** Join cell values into a `a|b|c` value, or undefined when all are empty. */
+export function joinLaneValues(values: string[]): string | undefined {
+    return values.some(v => v !== '') ? values.join('|') : undefined;
+}
+
+/**
+ * Detect when the pipe count of `value` disagrees with the `lanes*` tag, e.g.
+ * `turn:lanes=left|right` on a `lanes=3` road. Returns the actual lane count of
+ * the value when it mismatches, or undefined when consistent / not applicable
+ * (the caller turns this into a localized message). Kept message-free so this
+ * stays a pure helper.
+ *
+ * @param value - the per-lane tag value (`a|b|c`)
+ * @param count - the lane count from the matching `lanes*` tag
+ * @returns the value's lane count when it mismatches, otherwise undefined
+ */
+export function laneCountMismatch(value: string, count: number): number | undefined {
+    if (value === '' || !(count >= 1)) return undefined;   // nothing set / no count
+    const actual = value.split('|').length;
+    return actual === count ? undefined : actual;
+}
+
+/**
+ * Canonical `turn:lanes` value: empty cells become explicit `none`, so values
+ * stored with bare gaps (e.g. `left||right`) compare equal to the `none` form.
+ */
+export function canonicalTurn(value: string): string {
+    return value.split('|').map(cell => cell === '' ? 'none' : cell).join('|');
+}
+
+/**
+ * Serialize grid cells to a tag value (or undefined to clear). For `turn`,
+ * empty cells are written as explicit `none` (per OSM readability convention);
+ * other kinds keep gaps as-is.
+ */
+export function serializeLaneValues(kind: LaneKind, values: string[]): string | undefined {
+    if (!values.some(v => v !== '')) return undefined;   // all blank -> clear the tag
+    return kind === 'turn' ? canonicalTurn(values.join('|')) : values.join('|');
+}
+
+/** Find the common-case pattern matching `value` (turn matches the `none` form). */
+export function matchPattern(kind: LaneKind, patterns: LaneOption[], value: string): LaneOption | undefined {
+    const needle = (kind === 'turn' && value !== '') ? canonicalTurn(value) : value;
+    return patterns.find(p => p.value === needle);
+}
+
+// Arrow glyph per single turn value; combined turns (`a;b`) concatenate glyphs.
+// Glyphs are kept distinct (merge = double arrow vs slight = single) so a
+// pictograph maps back to exactly one value (see TURN_LABEL_TO_VALUE).
+const TURN_ARROW: Record<string, string> = {
+    none: '', through: '↑', left: '↰', right: '↱',
+    slight_left: '↖', slight_right: '↗', sharp_left: '↲', sharp_right: '↳',
+    reverse: '↩', merge_to_left: '⇖', merge_to_right: '⇗'
+};
+
+/** Pictograph for one lane cell, e.g. `left;through` -> `↰↑`. */
+export function turnCellLabel(cell: string): string {
+    return cell.split(';').map(turn => TURN_ARROW[turn] ?? turn).join('');
+}
+
+/** Pictograph for a whole `turn:lanes` value, e.g. `left|through|right`. */
+export function turnLabel(value: string): string {
+    return value.split('|').map(turnCellLabel).join(' | ');
+}
+
+// `change:lanes` is drawn per *boundary* between two lanes (v5 convention), not
+// per lane: the line is dotted on each side from which a change is allowed.
+const canChangeRight = (lane: string) => lane === 'yes' || lane === 'not_left';
+const canChangeLeft = (lane: string) => lane === 'yes' || lane === 'not_right';
+
+/** Boundary glyph between two adjacent lanes (dotted on each open side). */
+function boundaryGlyph(left: string, right: string): string {
+    const l = canChangeRight(left);    // left lane reaches across to the right
+    const r = canChangeLeft(right);    // right lane reaches across to the left
+    return l && r ? '⋮' : l ? '⋮|' : r ? '|⋮' : '|';
+}
+
+/** The `count-1` internal boundary glyphs of a `change:lanes` value. */
+export function changeBoundaries(value: string): string[] {
+    const lanes = value.split('|');
+    return lanes.slice(0, -1).map((lane, i) => boundaryGlyph(lane, lanes[i + 1]));
+}
+
+/**
+ * Pictograph for a whole `change:lanes` value: its boundary glyphs joined by a
+ * space, so `yes|yes` shares a single `⋮`. Outer road edges are not drawn.
+ */
+export function changeLabel(value: string): string {
+    return changeBoundaries(value).join(' ');
+}
+
+// Boundary glyphs offered in the custom editor (one control between each pair).
+export const CHANGE_BOUNDARY_OPTIONS: LaneOption[] = [
+    { value: '⋮', title: 'change allowed both ways', terms: ['yes'] },
+    { value: '|', title: 'no change across this line', terms: ['no'] },
+    { value: '⋮|', title: 'change from the left lane only', terms: ['not_left'] },
+    { value: '|⋮', title: 'change from the right lane only', terms: ['not_right'] }
+];
+
+/**
+ * Reconstruct the canonical `change:lanes` value from its boundary glyphs
+ * (inverse of changeBoundaries). Each lane combines the openness of its two
+ * boundaries: edge lanes are simply `yes`/`no`; interior lanes become yes / no
+ * / not_left / not_right. Round-trips through changeBoundaries / changeLabel.
+ */
+export function boundariesToValue(boundaries: string[]): string {
+    const count = boundaries.length + 1;
+    const rightOpen = (i: number) => boundaries[i] === '⋮' || boundaries[i] === '⋮|';
+    const leftOpen = (i: number) => boundaries[i - 1] === '⋮' || boundaries[i - 1] === '|⋮';
+    return Array.from({ length: count }, (_, i) => {
+        if (i === 0) return rightOpen(0) ? 'yes' : 'no';
+        if (i === count - 1) return leftOpen(i) ? 'yes' : 'no';
+        const l = leftOpen(i), r = rightOpen(i);
+        return l && r ? 'yes' : l ? 'not_right' : r ? 'not_left' : 'no';
+    }).join('|');
+}
+
+// Per-lane grid options. Width keeps raw metres; turn shows arrow icons (value
+// = pictograph), parsed back through TURN_LABEL_TO_VALUE.
+const WIDTH_CELL_OPTIONS: LaneOption[] = [
+    { value: '', title: '(default / full)' },
+    { value: '0', title: '0 (lane ends)' },
+    ...['1', '1.5', '2', '2.5', '3', '3.5'].map(v => ({ value: v, title: v }))
+];
+// Turn values selectable per lane; `none` is left out (clear a cell for none).
+const TURN_CELL_VALUES = ['through', 'left', 'right', 'slight_left', 'slight_right',
+    'sharp_left', 'sharp_right', 'reverse', 'merge_to_left', 'merge_to_right',
+    'left;through', 'through;right', 'left;right', 'left;through;right', 'reverse;through'];
+const TURN_LABEL_TO_VALUE: Record<string, string> =
+    Object.fromEntries(TURN_CELL_VALUES.map(v => [turnCellLabel(v), v]));
+
+/** Pictograph shown in a grid cell for a value (turn -> arrow icon; else raw). */
+export function cellDisplay(kind: LaneKind, value: string): string {
+    return kind === 'turn' ? turnCellLabel(value) : value;
+}
+
+/** Value for what a grid cell displays (turn arrow -> OSM value; else raw). */
+export function cellValue(kind: LaneKind, display: string): string {
+    return kind === 'turn' ? (TURN_LABEL_TO_VALUE[display] ?? display) : display;
+}
+
+/** Grid options for `kind` (change = boundary glyphs, turn = arrow icons). */
+export function cellOptions(kind: LaneKind): LaneOption[] {
+    if (kind === 'width') return WIDTH_CELL_OPTIONS;
+    if (kind === 'change') return CHANGE_BOUNDARY_OPTIONS;
+    return TURN_CELL_VALUES.map(v => ({ value: turnCellLabel(v), title: v, terms: [v] }));
+}
+
+/** `count` empty cells. */
+const empties = (count: number): string[] => Array(Math.max(count, 0)).fill('');
+
+/**
+ * Build a width pictograph label that shows the same configuration drawn for
+ * both way directions ("forward  or  reverse"), so the user can match whichever
+ * way the selected segment is angled. The reverse is the 180° rotation: the
+ * glyph tokens are reversed and the arrows flipped (`↑`↔`↓`); diagonals (`/`,
+ * `\`) are unchanged by a 180° turn, and multi-char tokens like `1.5` stay
+ * intact (we reverse tokens, not characters).
+ *
+ * @param tokens - left-to-right glyph tokens (arrows, `/`, `\`, `|`, widths)
+ * @returns a `forward  or  reverse` label
+ */
+function widthLabel(tokens: string[]): string {
+    const flip = (t: string) => t === '↑' ? '↓' : t === '↓' ? '↑' : t;
+    const reverse = tokens.slice().reverse().map(flip).join('');
+    return `${tokens.join('')}  or  ${reverse}`;
+}
+
+/**
+ * Common `width:lanes` transition cases for `count` lanes: a partial lane
+ * (1/1.5/2/2.5 m) or a lane that ends (`0`, drawn as a diagonal merge) at the
+ * left/right end, plus a both-ends merge (3+ lanes). `arrow` is the full-lane
+ * glyph; each label also shows its reverse-direction equivalent (see widthLabel).
+ *
+ * `end` flips the merge diagonals: a lane opens at a transition `:start` and
+ * closes at its `:end`, so the same `0` value is drawn mirrored (`↑/` at start
+ * vs `↑\` at end), matching the v5 convention.
+ *
+ * @param count - the lane count
+ * @param arrow - the full-lane glyph (`↑` forward, `↓` backward)
+ * @param end - whether this is the transition end (mirror the diagonals)
+ */
+export function widthPatterns(count: number, arrow: string, end = false): LaneOption[] {
+    if (!(count >= 2)) return [];   // also rejects NaN (missing/invalid lanes tag)
+    const fulls = Array(count - 1).fill(arrow);   // count-1 full-lane arrow tokens
+    const rightDiag = end ? '\\' : '/';           // glyph for a 0 at the right edge
+    const leftDiag = end ? '/' : '\\';            // glyph for a 0 at the left edge
+    const patterns: LaneOption[] = [
+        { value: '', title: `${widthLabel(Array(count).fill(arrow))} (all full)` }
+    ];
+    // merges (a lane ends, drawn as a diagonal) first, then partial widths
+    patterns.push({ value: [...empties(count - 1), '0'].join('|'), title: widthLabel([...fulls, rightDiag]) });
+    patterns.push({ value: ['0', ...empties(count - 1)].join('|'), title: widthLabel([leftDiag, ...fulls]) });
+    // both-ends merge needs a kept middle lane, so only for 3+ lanes (no `\/`)
+    if (count >= 3) {
+        patterns.push({ value: ['0', ...empties(count - 2), '0'].join('|'),
+            title: widthLabel([leftDiag, ...Array(count - 2).fill(arrow), rightDiag]) });
+    }
+    for (const w of ['1', '1.5', '2', '2.5']) {
+        patterns.push({ value: [...empties(count - 1), w].join('|'), title: widthLabel([...fulls, '|', w]) });
+        patterns.push({ value: [w, ...empties(count - 1)].join('|'), title: widthLabel([w, '|', ...fulls]) });
+    }
+    return patterns;
+}
+
+// Curated common `turn:lanes` values per lane count (ported from the v5 fork,
+// identical for oneway / forward / backward). Labels are generated by turnLabel.
+const TURN_VALUES: Record<number, string[]> = {
+    2: ['left|', '|right', 'left|right', 'left|through', 'through|right', 'through|through',
+        'left|through;right', 'left;through|right', 'left;through|through;right', 'through|through;right',
+        'left;through|through', 'left|left', 'right|right', '|merge_to_left', 'merge_to_right|',
+        'through|merge_to_left', 'merge_to_right|through', '|slight_right', 'slight_left|',
+        'through|slight_right', 'slight_left|through'],
+    3: ['left||', '||right', 'left|through|right', 'left|through|through;right', 'left;through|through|right',
+        'left;through|through|through;right', 'left|through|through', 'through|through|right', 'left||right',
+        '||merge_to_left', 'merge_to_right||', '||slight_right', 'slight_left||', 'through|through|through',
+        'left|left|through', 'through|right|right', 'left|left|right', 'left|right|right', 'left|left|left',
+        'right|right|right', 'left|left;right|right', 'slight_left|through|slight_right',
+        'slight_left|through|through', 'through|through|slight_right'],
+    4: ['left|through|through|right', 'left|through|through|through;right', 'left;through|through|through|right',
+        'left;through|through|through|through;right', 'left|through|through|through', 'through|through|through|right',
+        'through|through|through|through', 'left|||right', 'left|||', '|||right', '|||merge_to_left',
+        'merge_to_right|||', 'slight_left|||', '|||slight_right', 'through|through|through|slight_right',
+        'slight_left|through|through|through', 'through|through|slight_right|slight_right',
+        'slight_left|slight_left|through|through', 'slight_left|slight_left|slight_right|slight_right',
+        'slight_left|slight_right|slight_right|slight_right', 'slight_left|slight_left|slight_left|slight_right'],
+    5: ['left|through|through|through|right', 'left|through|through|through|through;right',
+        'left;through|through|through|through|right', 'left;through|through|through|through|through;right',
+        'left|through|through|through|through', 'through|through|through|through|right',
+        'through|through|through|through|through', 'left||||right', 'left||||', '||||right', '||||merge_to_left',
+        'merge_to_right||||', 'slight_left||||', '||||slight_right', 'left|left|through|through|right',
+        'left|left|through|through|through', 'left|left|through|right|right', 'left|through|through|right|right',
+        'through|through|through|right|right']
+};
+
+/**
+ * Common `change:lanes` cases for `count` lanes: all boundaries open / closed,
+ * plus (3+ lanes) one option per internal boundary closed on its own. Patterns
+ * differing only on outer lanes are omitted — they look identical once drawn
+ * per boundary (outer edges are not shown).
+ */
+export function changePatterns(count: number): LaneOption[] {
+    if (!(count >= 2)) return [];   // <2 lanes (or NaN) has no boundary to show
+    const open = Array(count - 1).fill('⋮');
+    const states = [open, Array(count - 1).fill('|')];   // all open, all closed
+    if (count >= 3) {
+        for (let k = 0; k < count - 1; k++) {            // close boundary k only
+            const s = open.slice(); s[k] = '|'; states.push(s);
+        }
+    }
+    return states.map(boundaries => {
+        const value = boundariesToValue(boundaries);
+        return { value, title: changeLabel(value) };
+    });
+}
+
+/** Common `turn:lanes` cases for `count` lanes (empty when none are curated). */
+export function turnPatterns(count: number): LaneOption[] {
+    return (TURN_VALUES[count] || []).map(raw => {
+        const value = canonicalTurn(raw);   // store/emit with explicit `none`
+        return { value, title: turnLabel(value) };
+    });
+}
+
+/**
+ * Common-case dropdown options, by kind and lane count.
+ * @param end - for width, whether this is a transition `:end` (mirror diagonals)
+ */
+export function commonPatterns(kind: LaneKind, count: number, arrow: string, end = false): LaneOption[] {
+    if (kind === 'width') return widthPatterns(count, arrow, end);
+    if (kind === 'turn') return turnPatterns(count);
+    return changePatterns(count);
+}

--- a/test/spec/ui/field.js
+++ b/test/spec/ui/field.js
@@ -18,7 +18,18 @@ describe('iD.prerequisiteTagSatisfied', () => {
         // array of conditions => OR semantics
         ['OR: first matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { a: 'lane' }, true],
         ['OR: second matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { b: 'lane' }, true],
-        ['OR: none matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { c: 'lane' }, false]
+        ['OR: none matches', [{ key: 'a', value: 'lane' }, { key: 'b', value: 'lane' }], { c: 'lane' }, false],
+        // allOf => AND semantics
+        ['AND: all match', { allOf: [{ key: 'a', value: 'lane' }, { key: 'b' }] }, { a: 'lane', b: 'x' }, true],
+        ['AND: one fails', { allOf: [{ key: 'a', value: 'lane' }, { key: 'b' }] }, { a: 'lane' }, false],
+        // allOf inside an OR array: either the AND group or the lone condition
+        ['OR of AND: group matches', [{ allOf: [{ key: 'a' }, { key: 'b' }] }, { key: 'c' }], { a: '1', b: '1' }, true],
+        ['OR of AND: fallback matches', [{ allOf: [{ key: 'a' }, { key: 'b' }] }, { key: 'c' }], { c: '1' }, true],
+        // valueGreaterThan => numeric comparison
+        ['gt: above', { key: 'lanes', valueGreaterThan: 2 }, { lanes: '3' }, true],
+        ['gt: equal', { key: 'lanes', valueGreaterThan: 2 }, { lanes: '2' }, false],
+        ['gt: below', { key: 'lanes', valueGreaterThan: 2 }, { lanes: '1' }, false],
+        ['gt: absent', { key: 'lanes', valueGreaterThan: 2 }, {}, false]
     ])('%s', (_desc, prerequisiteTag, tags, expected) => {
         it(`returns ${expected}`, () => {
             expect(iD.prerequisiteTagSatisfied(prerequisiteTag, tags)).toBe(expected);

--- a/test/spec/ui/fields/lane_list.js
+++ b/test/spec/ui/fields/lane_list.js
@@ -1,0 +1,271 @@
+describe('iD.uiFieldLaneList helpers', () => {
+
+    describe('laneCountKey', () => {
+        describe.each([
+            ['width:lanes', 'lanes'],
+            ['width:lanes:start', 'lanes'],
+            ['width:lanes:forward:start', 'lanes:forward'],
+            ['width:lanes:backward:end', 'lanes:backward'],
+            ['change:lanes', 'lanes'],
+            ['change:lanes:forward', 'lanes:forward'],
+            ['change:lanes:backward', 'lanes:backward'],
+            ['turn:lanes', 'lanes'],
+            ['turn:lanes:forward', 'lanes:forward'],
+            ['turn:lanes:backward', 'lanes:backward']
+        ])('%s', (key, expected) => {
+            it(`reads count from ${expected}`, () => {
+                expect(iD.laneCountKey(key)).toBe(expected);
+            });
+        });
+    });
+
+    describe('laneKind', () => {
+        describe.each([
+            ['width:lanes', 'width'],
+            ['width:lanes:forward:start', 'width'],
+            ['change:lanes', 'change'],
+            ['change:lanes:backward', 'change'],
+            ['turn:lanes', 'turn'],
+            ['turn:lanes:forward', 'turn']
+        ])('%s', (key, expected) => {
+            it(`is ${expected}`, () => {
+                expect(iD.laneKind(key)).toBe(expected);
+            });
+        });
+    });
+
+    describe('splitLaneValues', () => {
+        describe.each([
+            // [value, count, expected]
+            ['3|3|2.5', 3, ['3', '3', '2.5']],
+            ['3|3', 3, ['3', '3', '']],            // pad to count
+            ['3|3|2|2', 2, ['3', '3']],            // truncate to count
+            ['', 3, ['', '', '']],                 // empty value, known count
+            ['yes|no', 0, ['yes', 'no']],          // unknown count -> use the value's lanes
+            ['', 0, []]                            // unknown count, empty value
+        ])('(%s, %i)', (value, count, expected) => {
+            it(`-> ${JSON.stringify(expected)}`, () => {
+                expect(iD.splitLaneValues(value, count)).toEqual(expected);
+            });
+        });
+    });
+
+    describe('joinLaneValues', () => {
+        describe.each([
+            [['3', '3', '2.5'], '3|3|2.5'],
+            [['3', '', ''], '3||'],                // keep interior/trailing gaps
+            [['', '', ''], undefined],             // all empty -> clear the tag
+            [[], undefined]
+        ])('%j', (values, expected) => {
+            it(`-> ${expected}`, () => {
+                expect(iD.joinLaneValues(values)).toBe(expected);
+            });
+        });
+    });
+
+    describe('canonicalTurn', () => {
+        describe.each([
+            ['left||right', 'left|none|right'],         // bare gaps -> explicit none
+            ['|||', 'none|none|none|none'],
+            ['left|none|right', 'left|none|right'],      // already canonical
+            ['left;through|right', 'left;through|right'] // multi-turn cell untouched
+        ])('%s', (value, expected) => {
+            it(`-> ${expected}`, () => {
+                expect(iD.canonicalTurn(value)).toBe(expected);
+            });
+        });
+    });
+
+    describe('serializeLaneValues', () => {
+        describe.each([
+            // [kind, values, expected]
+            ['turn', ['left', '', 'right'], 'left|none|right'],   // turn fills gaps with none
+            ['turn', ['', '', ''], undefined],                    // all blank -> clear
+            ['width', ['3', '', '2'], '3||2'],                    // width keeps gaps
+            ['width', ['', ''], undefined],
+            ['change', ['yes', 'no'], 'yes|no']
+        ])('(%s, %j)', (kind, values, expected) => {
+            it(`-> ${expected}`, () => {
+                expect(iD.serializeLaneValues(kind, values)).toBe(expected);
+            });
+        });
+    });
+
+    describe('widthPatterns', () => {
+        it('returns nothing below 2 lanes', () => {
+            expect(iD.widthPatterns(1, '↑')).toEqual([]);
+        });
+        it('offers the merge and partial-lane cases for 3 lanes', () => {
+            const values = iD.widthPatterns(3, '↑').map(p => p.value);
+            expect(values).toContain('');         // all full
+            expect(values).toContain('||0');      // merge right
+            expect(values).toContain('0||');      // merge left
+            expect(values).toContain('0||0');     // merge both ends
+            expect(values).toContain('||1.5');    // partial 1.5 m right
+            expect(values).toContain('1.5||');    // partial 1.5 m left
+        });
+        it('omits the nonsensical both-ends merge (0|0) for 2 lanes', () => {
+            const values = iD.widthPatterns(2, '↑').map(p => p.value);
+            expect(values).toContain('|0');       // merge right kept
+            expect(values).toContain('0|');       // merge left kept
+            expect(values).not.toContain('0|0');  // both ends -> no middle lane
+        });
+        it.each([
+            ['|0', '↑/  or  /↓'],          // merge right + its 180° reverse
+            ['0|', '\\↑  or  ↓\\'],         // merge left
+            ['|1.5', '↑|1.5  or  1.5|↓'],  // multi-char width stays intact (not 5.1)
+            ['1.5|', '1.5|↑  or  ↓|1.5']
+        ])('labels %s with both directions (start)', (value, label) => {
+            const opt = iD.widthPatterns(2, '↑').find(p => p.value === value);
+            expect(opt.title).toBe(label);
+        });
+        // :end mirrors the merge diagonals vs :start (a lane closes, not opens)
+        it.each([
+            ['|0', '↑\\  or  \\↓'],   // start was ↑/ ; end flips the diagonal
+            ['0|', '/↑  or  ↓/']      // start was \↑
+        ])('mirrors %s diagonals for the transition end', (value, label) => {
+            const opt = iD.widthPatterns(2, '↑', true).find(p => p.value === value);
+            expect(opt.title).toBe(label);
+        });
+    });
+
+    describe('turnPatterns', () => {
+        it('emits curated cases with explicit none for 3 lanes', () => {
+            const values = iD.turnPatterns(3).map(p => p.value);
+            expect(values).toContain('left|none|none');
+            expect(values).toContain('left|through|right');
+        });
+        it('returns nothing for an uncurated lane count', () => {
+            expect(iD.turnPatterns(99)).toEqual([]);
+        });
+    });
+
+    // A missing/invalid `lanes` tag yields NaN; pattern generators must not throw.
+    describe('commonPatterns with NaN count', () => {
+        it.each(['width', 'change', 'turn'])('returns [] for %s', (kind) => {
+            expect(iD.commonPatterns(kind, NaN, '↑')).toEqual([]);
+        });
+    });
+
+    describe('changePatterns', () => {
+        it('offers all-open/all-closed and one closed boundary each for 3 lanes', () => {
+            const values = iD.changePatterns(3).map(p => p.value);
+            expect(values).toContain('yes|yes|yes');     // all open
+            expect(values).toContain('no|no|no');        // all closed
+            expect(values).toContain('no|not_left|yes'); // close boundary 1
+            expect(values).toContain('yes|not_right|no'); // close boundary 2
+        });
+        it('only offers all-open/all-closed for 2 lanes (single boundary)', () => {
+            expect(iD.changePatterns(2).map(p => p.value)).toEqual(['yes|yes', 'no|no']);
+        });
+        it('returns nothing for fewer than 2 lanes', () => {
+            expect(iD.changePatterns(1)).toEqual([]);
+            expect(iD.changePatterns(NaN)).toEqual([]);
+        });
+    });
+
+    describe('laneCountMismatch', () => {
+        it.each([
+            ['', 3],                  // no value set
+            ['left|through|right', 3], // matches
+            ['yes|yes', 2],
+            ['1|1.5', NaN]            // no lane count to compare against
+        ])('is silent for %s with count %s', (value, count) => {
+            expect(iD.laneCountMismatch(value, count)).toBeUndefined();
+        });
+
+        it.each([
+            ['left|right', 3, 2],
+            ['yes|yes|yes|yes', 2, 4],
+            ['1', 2, 1]
+        ])('flags %s (count %s) as having %s lanes', (value, count, actual) => {
+            expect(iD.laneCountMismatch(value, count)).toBe(actual);
+        });
+    });
+
+    describe('matchPattern', () => {
+        it('matches a bare-gap turn value to its none form', () => {
+            const match = iD.matchPattern('turn', iD.turnPatterns(3), 'left||');
+            expect(match && match.value).toBe('left|none|none');
+        });
+        it('matches the empty width value to the all-full case', () => {
+            const match = iD.matchPattern('width', iD.widthPatterns(3, '↑'), '');
+            expect(match && match.value).toBe('');
+        });
+    });
+
+    describe('change pictographs (v5 symbols, per boundary)', () => {
+        it.each([
+            ['yes|yes', '⋮'],            // shared boundary, both sides -> one dotted
+            ['no|no', '|'],              // closed
+            ['yes|no', '⋮|'],            // open from the left only
+            ['no|yes', '|⋮'],            // open from the right only
+            ['yes|yes|yes', '⋮ ⋮'],
+            ['no|yes|no', '|⋮ ⋮|'],      // matches v5
+            ['yes|not_right|no', '⋮ |']  // matches v5
+        ])('changeLabel(%s) -> %s', (value, label) => {
+            expect(iD.changeLabel(value)).toBe(label);
+        });
+        it('labels common change patterns with symbols', () => {
+            const titles = iD.changePatterns(2).map(p => p.title);
+            expect(titles).toEqual(['⋮', '|']);   // all open, all closed
+        });
+    });
+
+    describe('change boundaries (custom editor)', () => {
+        it.each([
+            ['yes|yes', ['⋮']],
+            ['no|no', ['|']],
+            ['yes|no|yes', ['⋮|', '|⋮']]
+        ])('changeBoundaries(%s) -> glyphs', (value, glyphs) => {
+            expect(iD.changeBoundaries(value)).toEqual(glyphs);
+        });
+
+        it.each([
+            [['⋮'], 'yes|yes'],
+            [['|'], 'no|no'],
+            [['⋮', '|'], 'yes|not_right|no'],   // close right boundary only
+            [['⋮|', '|⋮'], 'yes|no|yes']
+        ])('boundariesToValue(%s) -> %s', (glyphs, value) => {
+            expect(iD.boundariesToValue(glyphs)).toBe(value);
+        });
+
+        // editing must be stable: glyphs -> value -> glyphs is the identity.
+        // Rows are wrapped once so it.each passes the glyph array as one arg.
+        it.each([[['⋮']], [['|']], [['⋮|']], [['|⋮']], [['⋮', '|', '⋮|', '|⋮']]])(
+            'round-trips %j through boundariesToValue', (glyphs) => {
+                expect(iD.changeBoundaries(iD.boundariesToValue(glyphs))).toEqual(glyphs);
+            });
+    });
+
+    describe('cell options (grid)', () => {
+        it.each([
+            ['width', '1.5', '1.5'],
+            ['turn', 'left', '↰'],
+            ['turn', 'left;through', '↰↑'],
+            ['turn', 'none', ''],
+            ['turn', '', '']
+        ])('cellDisplay(%s, %s) -> %s', (kind, value, label) => {
+            expect(iD.cellDisplay(kind, value)).toBe(label);
+        });
+
+        it.each([
+            ['width', '1.5', '1.5'],
+            ['change', '⋮', '⋮'],             // change cells are boundary glyphs (identity)
+            ['turn', '↰', 'left'],
+            ['turn', '↰↑', 'left;through'],
+            ['turn', '⇖', 'merge_to_left'],   // distinct from slight_left ↖
+            ['turn', '↖', 'slight_left'],
+            ['turn', '', '']                  // cleared cell -> none on serialize
+        ])('cellValue(%s, %s) -> %s', (kind, label, value) => {
+            expect(iD.cellValue(kind, label)).toBe(value);
+        });
+
+        it('round-trips every turn cell option through display/value', () => {
+            iD.cellOptions('turn').forEach(opt => {
+                expect(iD.cellValue('turn', opt.value)).toBe(opt.title);
+                expect(iD.cellDisplay('turn', opt.title)).toBe(opt.value);
+            });
+        });
+    });
+});

--- a/test/spec/ui/fields/lane_list.js
+++ b/test/spec/ui/fields/lane_list.js
@@ -202,7 +202,11 @@ describe('iD.uiFieldLaneList helpers', () => {
             ['no|yes', '|⋮'],            // open from the right only
             ['yes|yes|yes', '⋮ ⋮'],
             ['no|yes|no', '|⋮ ⋮|'],      // matches v5
-            ['yes|not_right|no', '⋮ |']  // matches v5
+            ['yes|not_right|no', '⋮ |'], // matches v5
+            // only_left / only_right are synonyms of not_right / not_left
+            ['yes|only_left|no', '⋮ |'],
+            ['yes|not_right|no', '⋮ |'],
+            ['no|only_right|yes', '| ⋮']
         ])('changeLabel(%s) -> %s', (value, label) => {
             expect(iD.changeLabel(value)).toBe(label);
         });


### PR DESCRIPTION
## Summary
- Adds a single hybrid `laneList` field widget for `width:lanes`, `change:lanes` and `turn:lanes` (per-direction variants too): a dropdown of common pictographic cases that adapts to the lane count, plus a "Custom…" per-lane grid. Replaces v5's combinatorial per-lane-count JSON presets with one runtime renderer + pure, unit-tested helpers (`lane_patterns.ts`).
- Adds the `lanes:forward` / `lanes:backward` count fields, shown only when the split is ambiguous (`oneway!=yes` and `lanes>2`).
- Field display order on roads: lanes → forward/backward → turn → change → width → placement → cycleway. Each stays hidden until its lane-count/direction tags hold.
- Extends `prerequisiteTag` with `allOf` (AND) and numeric `valueGreaterThan`.
- `clone_transition` now also clones the `width:lanes:*` transition tags.

## Notes
- Pictographs follow the v5 convention: turn arrows, `change` boundary glyphs (`⋮`/`|`, drawn per boundary between lanes), and `width` merge diagonals shown with their reverse-direction equivalent (`↑/  or  /↓`) so they match the way at any angle. `:end` mirrors `:start`.
- Empty `turn:lanes` cells are normalized to `none`, while bare-gap values are still read as `none`.
- An inline warning flags a value whose pipe count disagrees with the `lanes*` tag (localized, tag-qualified).
- All new strings live in `data/locales/custom/{en,fr}.json`.

## Test plan
- [ ] `width:lanes:*` (forward/backward, start/end) on a `placement=transition` segment — diagonals match the drawn direction
- [ ] `turn:lanes` / `change:lanes` dropdown + custom grid on 2/3/4/5-lane roads
- [ ] `lanes:forward`/`lanes:backward` appear only when `lanes>2` and not oneway
- [ ] count-mismatch warning shows the offending tag
- [ ] `npm test` (tsc + eslint + vitest) green