### PR TITLE
Compact feature editor: dense mode, small fields, directional groups

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -927,6 +927,54 @@ summary.hide-toggle::-webkit-details-marker {
 .entity-editor {
     padding: 20px;
 }
+
+/* Compact ("dense") feature editor, toggled from the Editing preferences. The
+   `dense` class is set on `.sidebar` by uiDenseInspector; these overrides trim
+   padding, margins, row height and label size so more tags fit on screen. */
+/* shrink the "Edit feature" header bar and the gap below it */
+.sidebar.dense .header {
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+.sidebar.dense .header h3 {
+    font-size: 14px;
+}
+.sidebar.dense .entity-editor {
+    padding: 4px 10px;
+}
+.sidebar.dense .section:not(:last-child) {
+    margin-bottom: 8px;
+}
+/* tighten the disclosure headings ("Feature Type" / "Fields") */
+.sidebar.dense .entity-editor .hide-toggle {
+    margin-bottom: 4px;
+}
+/* shrink the selected-preset row (icon + label) */
+.sidebar.dense .preset-list-button-wrap {
+    min-height: 42px;
+}
+.sidebar.dense .preset-icon-container {
+    width: 42px;
+    height: 42px;
+}
+.sidebar.dense .form-field {
+    margin-bottom: 3px;
+}
+.sidebar.dense .field-label .label-text {
+    padding: 2px 0 2px 8px;
+    font-size: 11px;
+}
+.sidebar.dense input[type=text],
+.sidebar.dense input[type=number],
+.sidebar.dense input[type=tel],
+.sidebar.dense input[type=email],
+.sidebar.dense .tag-row input {
+    height: 2em;
+}
+.sidebar.dense .tag-text,
+.sidebar.dense .tag-list {
+    margin-top: 4px;
+}
 /* preserve extra space at bottom of inspector to allow for dropdown options - #5280 */
 .entity-editor > div:last-child {
     margin-bottom: 150px;
@@ -1727,6 +1775,29 @@ button.preset-reset .label.flash-bg {
     border-radius: 0;
 }
 
+/* Compact one-row fields (flagged `small`, e.g. One way / Lanes): the label
+   sits to the left of the value instead of stacked above it, saving a row. */
+.form-field-small {
+    flex-flow: row nowrap;
+    align-items: stretch;
+}
+.form-field-small .field-label {
+    flex: 0 0 42%;
+    align-items: center;
+    border-radius: 4px 0 0 4px;
+}
+.form-field-small .form-field-input-wrap {
+    width: auto;
+    flex: 1 1 auto;
+    border-radius: 0 4px 4px 0;
+}
+.ideditor[dir='rtl'] .form-field-small .field-label {
+    border-radius: 0 4px 4px 0;
+}
+.ideditor[dir='rtl'] .form-field-small .form-field-input-wrap {
+    border-radius: 4px 0 0 4px;
+}
+
 
 .form-field-input-wrap > input,
 .form-field-input-wrap > label,
@@ -1921,6 +1992,33 @@ input.date-selector {
 .form-field ul.rows.rows-table li.labeled-input > div:nth-child(2) {
     display: table-cell;
     width: auto;
+}
+
+/* Field - directional group (compact ↕ / ↑ / ↓ sub-rows under one header)
+------------------------------------------------------- */
+.form-field-input-directionalGroup {
+    flex: 1 1 auto;
+    width: 100%;
+}
+/* narrow direction-marker cell on the leading edge; the value fills the rest */
+.form-field ul.rows li.directional-group-row > div.directional-group-label {
+    flex: 0 0 2em;
+    width: 2em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.65;
+    font-weight: bold;
+}
+.form-field ul.rows li.directional-group-row > div.directional-group-input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.ideditor[dir='ltr'] .directional-group-label {
+    border-right: 1px solid var(--border-color);
+}
+.ideditor[dir='rtl'] .directional-group-label {
+    border-left: 1px solid var(--border-color);
 }
 
 
@@ -4259,25 +4357,51 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     margin: 5px;
 }
 
-/* Editing preferences - circularize segment length */
-.editing-options-container .display-control {
-    border-bottom: 1px solid var(--border-color);
-    padding-bottom: 10px;
+/* Editing preferences - each preference is a rounded card styled like the
+   Data Layers list: a filled control row with its description below. */
+.editing-options-container .editing-pref {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
     margin-bottom: 10px;
+    overflow: hidden;          /* clip the filled rows to the card radius */
 }
+.editing-options-container .editing-pref:last-child {
+    margin-bottom: 0;
+}
+
+/* the control row (toggle or slider), like a .layer-list row */
+.editing-options-container .display-control {
+    background-color: var(--bg-color);
+    color: var(--link-color);
+    padding: 8px 10px;
+    margin: 0;
+}
+@media (hover: hover) {
+    .editing-options-container .dense-inspector-control:hover,
+    .editing-options-container .delete-outside-view-control:hover {
+        background-color: var(--bg-color-3);
+    }
+}
+.editing-options-container .dense-inspector-control input,
+.editing-options-container .delete-outside-view-control input {
+    margin: 5px;
+}
+
 .editing-options-container .circularize-segment-length-max {
     font-weight: normal;
     opacity: 0.5;
     margin: 5px;
 }
-.editing-options-container .editing-option-description {
-    margin: 5px;
-    opacity: 0.5;
-    font-style: italic;
+.editing-options-container .delete-outside-view-warning {
+    margin: 8px 10px;
 }
-/* Editing preferences - allow deleting features outside the view */
-.editing-options-container .delete-outside-view-control input {
-    margin: 5px;
+/* description sits under the control row, separated within the same card */
+.editing-options-container .editing-option-description {
+    margin: 0;
+    padding: 8px 10px;
+    border-top: 1px solid var(--border-color);
+    opacity: 0.6;
+    font-style: italic;
 }
 
 .display-control .control-wrap {

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -5,23 +5,36 @@
                 "sidewalk": {
                     "label": "Sidewalk"
                 },
+                "access": {
+                    "types": {
+                        "routing:motor_vehicle": "Motor Veh. Routing",
+                        "routing:bicycle": "Bicycles Routing",
+                        "bus": "Bus",
+                        "routing:bus": "Bus Routing",
+                        "psv": "Public Service Veh."
+                    }
+                },
+                "lanes_group": { "label": "Lanes" },
+                "placement_group": { "label": "Placement" },
+                "turn_lanes_group": { "label": "Turn" },
+                "change_lanes_group": { "label": "Change" },
                 "placement": { "label": "Placement" },
-                "placement_forward": { "label": "Placement (forward)" },
-                "placement_backward": { "label": "Placement (backward)" },
-                "lanes_forward": { "label": "Lanes (forward)" },
-                "lanes_backward": { "label": "Lanes (backward)" },
-                "width_lanes_start": { "label": "Lane widths — transition start (m)" },
-                "width_lanes_end": { "label": "Lane widths — transition end (m)" },
-                "width_lanes_forward_start": { "label": "Lane widths, forward — transition start (m)" },
-                "width_lanes_forward_end": { "label": "Lane widths, forward — transition end (m)" },
-                "width_lanes_backward_start": { "label": "Lane widths, backward — transition start (m)" },
-                "width_lanes_backward_end": { "label": "Lane widths, backward — transition end (m)" },
-                "change_lanes": { "label": "Lane change permissions" },
-                "change_lanes_forward": { "label": "Lane change permissions (forward)" },
-                "change_lanes_backward": { "label": "Lane change permissions (backward)" },
-                "turn_lanes": { "label": "Turn indications per lane" },
-                "turn_lanes_forward": { "label": "Turn indications per lane (forward)" },
-                "turn_lanes_backward": { "label": "Turn indications per lane (backward)" },
+                "placement_forward": { "label": "Placement ↑" },
+                "placement_backward": { "label": "Placement ↓" },
+                "lanes_forward": { "label": "Lanes ↑" },
+                "lanes_backward": { "label": "Lanes ↓" },
+                "width_lanes_start": { "label": "Lane transition start" },
+                "width_lanes_end": { "label": "lane transition end" },
+                "width_lanes_forward_start": { "label": "Lane transition ↑ start" },
+                "width_lanes_forward_end": { "label": "Lane transition ↑ end" },
+                "width_lanes_backward_start": { "label": "Lane transition ↓ start" },
+                "width_lanes_backward_end": { "label": "Lane transition ↓ end" },
+                "change_lanes": { "label": "Change" },
+                "change_lanes_forward": { "label": "Change ↑" },
+                "change_lanes_backward": { "label": "Change ↓" },
+                "turn_lanes": { "label": "Turn" },
+                "turn_lanes_forward": { "label": "Turn ↑" },
+                "turn_lanes_backward": { "label": "Turn ↓" },
                 "cycleway": {
                     "types": {
                         "cycleway:both": "Both Sides"
@@ -79,6 +92,14 @@
         }
     },
     "general": {
+        "preferences": {
+            "editing": {
+                "dense": {
+                    "title": "Compact feature editor",
+                    "description": "Reduce padding and row height in the feature editor so more tags fit on screen."
+                }
+            }
+        },
         "lanes": {
             "count_mismatch": "“{tag}” has {actual} lanes, but the road is tagged with {count}."
         },

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -5,23 +5,36 @@
                 "sidewalk": {
                     "label": "Trottoir"
                 },
+                "access": {
+                    "types": {
+                        "routing:motor_vehicle": "Routage véh. motorisés",
+                        "routing:bicycle": "Routage vélos",
+                        "bus": "Autobus",
+                        "routing:bus": "Routage autobus",
+                        "psv": "Véh. de service public"
+                    }
+                },
+                "lanes_group": { "label": "Voies" },
+                "placement_group": { "label": "Placement" },
+                "turn_lanes_group": { "label": "Virage" },
+                "change_lanes_group": { "label": "Changement" },
                 "placement": { "label": "Placement" },
-                "placement_forward": { "label": "Placement (sens du tracé)" },
-                "placement_backward": { "label": "Placement (sens inverse)" },
-                "lanes_forward": { "label": "Voies (sens du tracé)" },
-                "lanes_backward": { "label": "Voies (sens inverse)" },
-                "width_lanes_start": { "label": "Largeurs de voies — début de transition (m)" },
-                "width_lanes_end": { "label": "Largeurs de voies — fin de transition (m)" },
-                "width_lanes_forward_start": { "label": "Largeurs de voies, sens du tracé — début de transition (m)" },
-                "width_lanes_forward_end": { "label": "Largeurs de voies, sens du tracé — fin de transition (m)" },
-                "width_lanes_backward_start": { "label": "Largeurs de voies, sens inverse — début de transition (m)" },
-                "width_lanes_backward_end": { "label": "Largeurs de voies, sens inverse — fin de transition (m)" },
-                "change_lanes": { "label": "Permissions de changement de voie" },
-                "change_lanes_forward": { "label": "Permissions de changement de voie (sens du tracé)" },
-                "change_lanes_backward": { "label": "Permissions de changement de voie (sens inverse)" },
-                "turn_lanes": { "label": "Indications de direction par voie" },
-                "turn_lanes_forward": { "label": "Indications de direction par voie (sens du tracé)" },
-                "turn_lanes_backward": { "label": "Indications de direction par voie (sens inverse)" },
+                "placement_forward": { "label": "Placement ↑" },
+                "placement_backward": { "label": "Placement ↓" },
+                "lanes_forward": { "label": "Voies ↑" },
+                "lanes_backward": { "label": "Voies ↓" },
+                "width_lanes_start": { "label": "Transition de largeurs début" },
+                "width_lanes_end": { "label": "Transition de largeurs fin" },
+                "width_lanes_forward_start": { "label": "Transition de largeurs ↑ début" },
+                "width_lanes_forward_end": { "label": "Transition de largeurs ↑ fin" },
+                "width_lanes_backward_start": { "label": "Transition de largeurs ↓ début" },
+                "width_lanes_backward_end": { "label": "Transition de largeurs ↓ fin" },
+                "change_lanes": { "label": "Changement" },
+                "change_lanes_forward": { "label": "Changement ↑" },
+                "change_lanes_backward": { "label": "Changement ↓" },
+                "turn_lanes": { "label": "Virage" },
+                "turn_lanes_forward": { "label": "Virage ↑" },
+                "turn_lanes_backward": { "label": "Virage ↓" },
                 "cycleway": {
                     "types": {
                         "cycleway:both": "Les deux côtés"
@@ -79,6 +92,14 @@
         }
     },
     "general": {
+        "preferences": {
+            "editing": {
+                "dense": {
+                    "title": "Éditeur d'objet compact",
+                    "description": "Réduit l'espacement et la hauteur des rangées dans l'éditeur d'objet pour afficher plus de tags à l'écran."
+                }
+            }
+        },
         "lanes": {
             "count_mismatch": "« {tag} » a {actual} voies, mais la route est taggée avec {count}."
         },

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -55,18 +55,100 @@ export const customFields = {
         minValue: 0,
         geometry: ['line'],
         prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
+    },
+    // Directional groups: one header with compact `↕` / `↑` / `↓` sub-rows for a
+    // bare key and its per-direction variants (see uiFieldDirectionalGroup). Each
+    // sub-row reuses its member field's renderer and prerequisite, so the
+    // forward/backward rows stay hidden until their lane-count tags hold. Groups
+    // without a `prerequisiteTag` always show (their bare member always applies);
+    // turn/change groups show only when one of their members applies.
+    lanes_group: {
+        key: 'lanes',
+        type: 'directionalGroup',
+        geometry: ['line'],
+        members: [
+            { id: 'lanes', label: '↕' },
+            { id: 'lanes_forward', label: '↑' },
+            { id: 'lanes_backward', label: '↓' }
+        ]
+    },
+    placement_group: {
+        key: 'placement',
+        type: 'directionalGroup',
+        geometry: ['line'],
+        members: [
+            { id: 'placement', label: '↕' },
+            { id: 'placement_forward', label: '↑' },
+            { id: 'placement_backward', label: '↓' }
+        ]
+    },
+    turn_lanes_group: {
+        key: 'turn:lanes',
+        type: 'directionalGroup',
+        geometry: ['line'],
+        prerequisiteTag: [
+            laneFields.turn_lanes.prerequisiteTag,
+            laneFields.turn_lanes_forward.prerequisiteTag,
+            laneFields.turn_lanes_backward.prerequisiteTag
+        ],
+        members: [
+            { id: 'turn_lanes', label: '↕' },
+            { id: 'turn_lanes_forward', label: '↑' },
+            { id: 'turn_lanes_backward', label: '↓' }
+        ]
+    },
+    change_lanes_group: {
+        key: 'change:lanes',
+        type: 'directionalGroup',
+        geometry: ['line'],
+        prerequisiteTag: [
+            laneFields.change_lanes.prerequisiteTag,
+            laneFields.change_lanes_forward.prerequisiteTag,
+            laneFields.change_lanes_backward.prerequisiteTag
+        ],
+        members: [
+            { id: 'change_lanes', label: '↕' },
+            { id: 'change_lanes_forward', label: '↑' },
+            { id: 'change_lanes_backward', label: '↓' }
+        ]
     }
 };
 
-// Road lane block, inserted just after the `lanes` field as default fields (see
-// applyCustomFields), in display order: per-direction lane counts, the per-lane
-// fields (turn / change / width), then placement. Prerequisites keep each one
-// hidden until the relevant lane-count / direction tags hold (e.g.
-// lanes_forward/backward show only when lanes>2 and the way is two-way).
+// Width fields stay standalone (they only apply to transition segments); the
+// lanes / turn / change / placement fields are folded into directional groups.
+const WIDTH_FIELDS = laneFieldOrder.filter(id => id.startsWith('width'));
+
+// Road lane block, inserted where the upstream `lanes` field sat, as default
+// fields (see applyCustomFields). Display order: the lanes group (with the
+// road-attributes block spliced in just after it), then turn / change groups,
+// the standalone width fields, then the placement group. Group headers stand in
+// for the bare key plus its `↑` / `↓` rows; the forward/backward rows and the
+// turn/change groups stay hidden (by prerequisite) until their lane-count tags
+// hold.
 const LANE_BLOCK = [
+    'lanes_group',
+    'turn_lanes_group', 'change_lanes_group',
+    ...WIDTH_FIELDS,
+    'placement_group'
+];
+
+// Every field id managed by the lane block (group headers, their member fields,
+// and the standalone width fields). Removed before insertion so we control the
+// order and never duplicate an entry.
+const MANAGED_LANE_FIELDS = [
+    'lanes', ...LANE_BLOCK,
     'lanes_forward', 'lanes_backward',
-    ...laneFieldOrder,
-    'placement', 'placement_forward', 'placement_backward'
+    'placement', 'placement_forward', 'placement_backward',
+    'turn_lanes', 'turn_lanes_forward', 'turn_lanes_backward',
+    'change_lanes', 'change_lanes_forward', 'change_lanes_backward'
+];
+
+// Fields whose value is short enough to sit beside its label on one row (see
+// the `small` field flag, read by uiField). Only standalone fields are listed;
+// the lane / placement fields fold into directional groups, which lay their
+// sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
+const SMALL_FIELDS = [
+    'oneway', 'maxspeed', 'surface', 'sidewalk', 'ref_road_number'
 ];
 
 // highway=* values that should offer the sidewalk field
@@ -102,6 +184,8 @@ export function applyCustomFields(presetManager) {
     presetManager.merge({ fields: laneFields });
     customizeCycleway(presetManager);
     customizeOnewayBicycle(presetManager);
+    customizeAccess(presetManager);
+    markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
     presetManager.collection.forEach(preset => {
@@ -117,41 +201,50 @@ export function applyCustomFields(presetManager) {
         // are skipped: they inherit the field from the parent we modify here.
         if (fields.indexOf('structure') === -1) return;
 
-        // drop any pre-existing entry (upstream lists `sidewalk` in some moreFields)
-        // so we control its position and avoid duplicates
-        removeField(fields, 'sidewalk');
-        removeField(moreFields, 'sidewalk');
+        // Lane block: default fields inserted where the upstream `lanes` field
+        // sat (the `lanes_group` header replaces it). The directional groups and
+        // per-lane width fields stay hidden (by prerequisite) until their
+        // lane-count and direction tags hold. Applies to every road, including
+        // motorways. Falls back to before Structure when a preset has no `lanes`
+        // field. Only `lanes` is present at this point, so removing it leaves the
+        // insert index pointing at its former position.
+        const lanesIndex = fields.indexOf('lanes');
+        MANAGED_LANE_FIELDS.forEach(id => { removeField(fields, id); removeField(moreFields, id); });
+        const laneInsertAt = lanesIndex === -1 ? fields.indexOf('structure') : lanesIndex;
+        fields.splice(laneInsertAt < 0 ? fields.length : laneInsertAt, 0, ...LANE_BLOCK);
 
-        if (SIDEWALK_MORE_ONLY.has(highway)) {
-            // motorways: available via "+ add field", not shown by default
-            moreFields.push('sidewalk');
-        } else {
-            // other roads: shown by default, just before the Structure field
-            fields.splice(fields.indexOf('structure'), 0, 'sidewalk');
+        // Road-attributes block, spliced in right after the lanes group and
+        // before the turn/change groups (so it reads lanes → sidewalk → surface →
+        // cycleway → turn → change → width → placement): sidewalk, surface, then
+        // cycleway and its lane sub-fields. We control their position, so first
+        // drop any pre-existing entries to avoid duplicates. Sidewalk on motorways
+        // stays in moreFields ("+ add field"); cycleway is non-motorway only.
+        ['sidewalk', 'surface', 'cycleway', ...cyclewaySubFieldOrder].forEach(id => {
+            removeField(fields, id);
+            removeField(moreFields, id);
+        });
+
+        const attrBlock = [];
+        if (SIDEWALK_MORE_ONLY.has(highway)) moreFields.push('sidewalk');
+        else attrBlock.push('sidewalk');
+        attrBlock.push('surface');
+        // cycleway + sub-fields only on non-motorway roads; sub-fields stay hidden
+        // (by prerequisite) until a cycleway side is a lane.
+        if (NON_MOTORWAY_HIGHWAYS.has(highway)) {
+            attrBlock.push('cycleway', ...cyclewaySubFieldOrder);
         }
 
-        // Lane block (per-direction counts, per-lane turn/change/width, then
-        // placement): default fields inserted right after the `lanes` field, so
-        // they read top-to-bottom as lanes → forward/backward → turn → change →
-        // width → placement. The directional / per-lane fields stay hidden (by
-        // prerequisite) until their lane-count and direction tags hold. Applies
-        // to every road, including motorways. Falls back to before Structure
-        // when a preset has no `lanes` field.
-        LANE_BLOCK.forEach(id => { removeField(fields, id); removeField(moreFields, id); });
-        const afterLanes = fields.indexOf('lanes');
-        const laneInsertAt = afterLanes === -1 ? fields.indexOf('structure') : afterLanes + 1;
-        fields.splice(laneInsertAt, 0, ...LANE_BLOCK);
+        // anchor right after the lanes group (just before the turn group)
+        const afterLanesGroup = fields.indexOf('lanes_group');
+        const attrAt = afterLanesGroup === -1 ? fields.indexOf('structure') : afterLanesGroup + 1;
+        fields.splice(attrAt < 0 ? fields.length : attrAt, 0, ...attrBlock);
+
+        // access shown as a default field, just before Structure
+        removeField(fields, 'access');
+        removeField(moreFields, 'access');
+        fields.splice(fields.indexOf('structure'), 0, 'access');
 
         if (!NON_MOTORWAY_HIGHWAYS.has(highway)) return;
-
-        // cycleway and its lane sub-fields: grouped right after the lane block as
-        // default fields. `cycleway` is moved out of upstream's moreFields; the
-        // sub-fields stay hidden (by prerequisite) until a cycleway side is a lane.
-        const cyclewayBlock = ['cycleway', ...cyclewaySubFieldOrder];
-        cyclewayBlock.forEach(id => { removeField(fields, id); removeField(moreFields, id); });
-        const afterBlock = fields.indexOf('placement_backward');
-        const cyclewayAt = afterBlock === -1 ? fields.indexOf('structure') : afterBlock + 1;
-        fields.splice(cyclewayAt, 0, ...cyclewayBlock);
 
         // oneway:bicycle: shown right after the main `oneway` field as a default
         // field (stays hidden until oneway=yes, see customizeOnewayBicycle).
@@ -167,6 +260,21 @@ export function applyCustomFields(presetManager) {
 function removeField(list, fieldID) {
     const index = list.indexOf(fieldID);
     if (index !== -1) list.splice(index, 1);
+}
+
+/**
+ * Flag the given fields as `small` so they render with the label and value on a
+ * single row (see uiField). Mutates each shared field in place; unknown ids are
+ * skipped so the set can list fields a preset may not have loaded.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ * @param {string[]} ids - field ids to flag
+ */
+function markSmallFields(presetManager, ids) {
+    ids.forEach(id => {
+        const field = presetManager.field(id);
+        if (field) field.small = true;
+    });
 }
 
 /**
@@ -210,3 +318,21 @@ function customizeOnewayBicycle(presetManager) {
     if (!field) return;
     field.prerequisiteTag = { key: 'oneway', value: 'yes' };
 }
+
+/**
+ * Restore the v5 `access` field rows: drop `horse` (not used in our context) and
+ * add the per-mode routing keys plus transit access (`bus`, `psv`). The row
+ * labels for the added keys live in the custom locale files (access.types).
+ * Mutates the shared upstream field in place.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizeAccess(presetManager) {
+    const field = presetManager.field('access');
+    if (!field || field.type !== 'access') return;
+    field.keys = [
+        'access', 'foot', 'motor_vehicle', 'routing:motor_vehicle',
+        'bicycle', 'routing:bicycle', 'bus', 'routing:bus', 'psv'
+    ];
+}
+

--- a/modules/ui/dense_inspector.js
+++ b/modules/ui/dense_inspector.js
@@ -1,0 +1,25 @@
+import { prefs } from '../core/preferences';
+
+// Preference key: when set to 'true', the feature editor (left sidebar) is shown
+// in a compact layout (reduced padding/row height) so more tags fit on screen.
+// Opt-in, toggled from the Editing preferences section.
+export const DENSE_INSPECTOR = 'preferences.editing.dense';
+
+/**
+ * Wire the compact ("dense") inspector preference to the sidebar. Toggles the
+ * `dense` class on the always-present `.sidebar` element (so it survives the
+ * inspector's frequent re-renders) whenever the preference changes, and applies
+ * the stored value once on startup. CSS scoped to `.sidebar.dense` does the
+ * actual compacting.
+ *
+ * @param {*} context - the iD application context
+ */
+export function uiDenseInspector(context) {
+    function update() {
+        context.container().selectAll('.sidebar')
+            .classed('dense', prefs(DENSE_INSPECTOR) === 'true');
+    }
+
+    update();
+    prefs.onChange(DENSE_INSPECTOR, update);
+}

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -217,6 +217,10 @@ export function uiField(context, presetField, entityIDs, options) {
         container = container
             .merge(enter);
 
+        // fields flagged `small` (short values like oneway / lanes) render with
+        // the label left and value right on one row, saving vertical space.
+        container.classed('form-field-small', !!field.small);
+
         container.select('.field-label > .remove-icon')  // propagate bound data
             .on('click', remove);
 

--- a/modules/ui/fields/directional_group.ts
+++ b/modules/ui/fields/directional_group.ts
@@ -1,0 +1,111 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { utilRebind, utilUniqueDomId } from '../../util';
+import { presetManager } from '../../presets';
+import { prerequisiteTagSatisfied } from '../field';
+import { uiFieldCombo } from './combo';
+import { uiFieldNumber } from './input';
+import { uiFieldLaneList } from './lane_list';
+
+// =============================================================================
+// DIRECTIONAL GROUP - one header with several compact sub-rows, each editing a
+// related tag (a bare key and its `:forward` / `:backward` variants), so e.g.
+// `lanes`, `lanes:forward` and `lanes:backward` read as a single "Lanes" block
+// instead of three separate fields. Mirrors the cycleway grouping, but works
+// across mixed sub-field types (combo / number / laneList) and forward/backward
+// directions. Each sub-row reuses the real renderer of its member field, so the
+// editing behaviour is identical to the standalone field.
+// =============================================================================
+
+// Sub-field renderers a group member may use, mapped by field type. Imported
+// directly (not via the `uiFields` registry) to avoid a circular import.
+const RENDERERS: Record<string, any> = {
+    combo: uiFieldCombo,
+    number: uiFieldNumber,
+    laneList: uiFieldLaneList
+};
+
+interface GroupMember { id: string; label: string; }
+
+/**
+ * Directional group field renderer (registered as the `directionalGroup` field
+ * type). `field.members` lists the member fields (by id) and the short marker
+ * shown at the start of each row (e.g. `↕` / `↑` / `↓`). A member row is shown
+ * only when the member field's own `prerequisiteTag` is satisfied.
+ *
+ * @param field - the preset field definition (decorated by `presetField`)
+ * @param context - the iD application context
+ * @returns the field component (callable on a d3 selection)
+ */
+export function uiFieldDirectionalGroup(
+    field: { type: string; members: GroupMember[] },
+    context: iD.Context
+) {
+    const dispatch = d3_dispatch('change');
+
+    // resolve each member once: its decorated preset field and its renderer.
+    // `domId` and `locked` are normally added by uiField; supply them here since
+    // the sub-renderers (number / combo) read them but we call them directly.
+    // Group rows aren't individually lockable, so `locked` is a no-op false.
+    const members = (field.members || []).map(member => {
+        const base = presetManager.field(member.id);
+        const make = base && RENDERERS[base.type];
+        if (!make) return null;
+        const sub = Object.assign({}, base);
+        sub.domId = utilUniqueDomId('form-field-' + base.safeid);
+        sub.locked = () => false;
+        const impl = make(sub, context);
+        impl.on('change', (t: any, onInput: any) => dispatch.call('change', impl, t, onInput));
+        return { sub, impl, label: member.label };
+    }).filter(Boolean) as { sub: any; impl: any; label: string }[];
+
+    // d3 selections are loosely typed here, like the sibling field components
+    let wrap: any = d3_select(null);
+    let _tags: Record<string, string> = {};
+
+    function directionalGroup(selection: any) {
+        wrap = selection.selectAll('.form-field-input-wrap').data([0]);
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type + ' directional-group')
+            .merge(wrap);
+
+        wrap.selectAll('ul').data([0]).enter()
+            .append('ul')
+            .attr('class', 'rows directional-group-rows');
+
+        directionalGroup.tags(_tags);
+    }
+
+    directionalGroup.tags = function(tags: Record<string, string>) {
+        _tags = tags || {};
+
+        // only show rows whose member prerequisite holds for the current tags
+        const visible = members.filter(m =>
+            !m.sub.prerequisiteTag || prerequisiteTagSatisfied(m.sub.prerequisiteTag, _tags));
+
+        let rows = wrap.select('ul').selectAll('li').data(visible, (m: any) => m.sub.id);
+        rows.exit().remove();
+        const enter = rows.enter()
+            .append('li')
+            .attr('class', (m: any) => 'labeled-input directional-group-row directional-group-' + m.sub.safeid);
+        enter.append('div')
+            .attr('class', 'label directional-group-label')
+            .text((m: any) => m.label);
+        enter.append('div')
+            .attr('class', 'directional-group-input form-field-input-wrap')
+            .each(function(this: HTMLElement, m: any) { d3_select(this).call(m.impl); });
+        rows = enter.merge(rows);
+
+        // feed the full tag set to each visible member renderer
+        rows.each((m: any) => m.impl.tags(_tags));
+    };
+
+    directionalGroup.focus = function() {
+        const node = wrap.selectAll('input').node();
+        if (node) node.focus();
+    };
+
+    return utilRebind(directionalGroup, dispatch, 'on');
+}

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -51,6 +51,7 @@ import {
 import { uiFieldAccess } from './access';
 import { uiFieldAddress } from './address';
 import { uiFieldDirectionalCombo } from './directional_combo';
+import { uiFieldDirectionalGroup } from './directional_group';
 import { uiFieldLanes } from './lanes';
 import { uiFieldLaneList } from './lane_list';
 import { uiFieldLocalized } from './localized';
@@ -72,13 +73,12 @@ export var uiFields = {
     date: uiFieldText,
     defaultCheck: uiFieldDefaultCheck,
     directionalCombo: uiFieldDirectionalCombo,
+    directionalGroup: uiFieldDirectionalGroup,
     email: uiFieldEmail,
     identifier: uiFieldIdentifier,
-    lanes: uiFieldLanes,
     laneList: uiFieldLaneList,
+    lanes: uiFieldLanes,
     localized: uiFieldLocalized,
-    roadheight: uiFieldRoadheight,
-    roadspeed: uiFieldRoadspeed,
     manyCombo: uiFieldManyCombo,
     multiCombo: uiFieldMultiCombo,
     networkCombo: uiFieldNetworkCombo,
@@ -86,6 +86,8 @@ export var uiFields = {
     onewayCheck: uiFieldOnewayCheck,
     radio: uiFieldRadio,
     restrictions: uiFieldRestrictions,
+    roadheight: uiFieldRoadheight,
+    roadspeed: uiFieldRoadspeed,
     schedule: uiFieldSchedule,
     semiCombo: uiFieldSemiCombo,
     sidewalk: uiFieldSidewalk,

--- a/modules/ui/fields/sidewalk.ts
+++ b/modules/ui/fields/sidewalk.ts
@@ -74,12 +74,12 @@ function readLeftRight(left: string, right: string, foot: string): string {
 
 /** Resolve the selector value from the full set of sidewalk-related tags. */
 function readValue(tags: Record<string, string>): string {
-    const sidewalk = tags['sidewalk'];
+    const sidewalk = tags.sidewalk;
     const both = tags['sidewalk:both'];
     const left = tags['sidewalk:left'];
     const right = tags['sidewalk:right'];
-    const foot = tags['foot'];
-    const dual = tags['dual_carriageway'];
+    const foot = tags.foot;
+    const dual = tags.dual_carriageway;
 
     // mixing single/both with left/right (or sidewalk with sidewalk:both) is invalid
     if ((left || right) && (both || sidewalk)) return '';
@@ -152,7 +152,7 @@ export function uiFieldSidewalk(field: { type: string }, context: iD.Context) {
 
         const tag: Record<string, string | undefined> = {};
         RESET_KEYS.forEach((key) => { tag[key] = mapping[key]; });
-        if (mapping['dual_carriageway']) tag['dual_carriageway'] = mapping['dual_carriageway'];
+        if (mapping.dual_carriageway) tag.dual_carriageway = mapping.dual_carriageway;
 
         dispatch.call('change', d3_event.currentTarget, tag);
     }

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -32,6 +32,7 @@ import { uiRestore } from './restore';
 import { uiScale } from './scale';
 import { uiShortcuts } from './shortcuts';
 import { uiSidebar } from './sidebar';
+import { uiDenseInspector } from './dense_inspector';
 import { uiSourceSwitch } from './source_switch';
 import { uiSpinner } from './spinner';
 import { uiSplash } from './splash';
@@ -143,6 +144,9 @@ export function uiInit(context) {
             .append('div')
             .attr('class', 'sidebar')
             .call(ui.sidebar);
+
+        // apply (and keep in sync) the compact-inspector preference
+        uiDenseInspector(context);
 
         var content = container
             .append('div')

--- a/modules/ui/sections/editing_preferences.js
+++ b/modules/ui/sections/editing_preferences.js
@@ -7,6 +7,7 @@ import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 import { SEGMENT_LENGTH, MAX_VERTICES } from '../../actions/circularize';
 import { DELETE_OUTSIDE_VIEW } from '../../operations/delete';
+import { DENSE_INSPECTOR } from '../dense_inspector';
 
 
 /**
@@ -41,15 +42,52 @@ export function uiSectionEditingPreferences(context) {
         return prefs(DELETE_OUTSIDE_VIEW) === 'true';
     }
 
+    /** Whether the feature editor is shown in the compact ("dense") layout. */
+    function denseInspector() {
+        return prefs(DENSE_INSPECTOR) === 'true';
+    }
+
     function renderDisclosureContent(selection) {
         let container = selection.selectAll('.editing-options-container')
             .data([0]);
 
+        // each preference sits in its own card (.editing-pref) so the controls
+        // are visually separated rather than sharing one outer border
         const containerEnter = container.enter()
             .append('div')
-            .attr('class', 'display-options-container editing-options-container controls-list');
+            .attr('class', 'display-options-container editing-options-container');
 
-        const controlEnter = containerEnter
+        // compact ("dense") inspector toggle: clicking the label flips the pref;
+        // the class is applied to the sidebar by uiDenseInspector.
+        const denseGroup = containerEnter
+            .append('div')
+            .attr('class', 'editing-pref');
+
+        const denseControlEnter = denseGroup
+            .append('label')
+            .attr('class', 'display-control dense-inspector-control');
+
+        denseControlEnter
+            .append('input')
+            .attr('type', 'checkbox')
+            .attr('class', 'dense-inspector-input')
+            .on('change', function() {
+                prefs(DENSE_INSPECTOR, d3_select(this).property('checked') ? 'true' : 'false');
+            });
+
+        denseControlEnter
+            .call(t.append('preferences.editing.dense.title'));
+
+        denseGroup
+            .append('div')
+            .attr('class', 'editing-option-description')
+            .call(t.append('preferences.editing.dense.description'));
+
+        const circularizeGroup = containerEnter
+            .append('div')
+            .attr('class', 'editing-pref');
+
+        const controlEnter = circularizeGroup
             .append('label')
             .attr('class', 'display-control circularize-segment-length-control');
 
@@ -98,7 +136,11 @@ export function uiSectionEditingPreferences(context) {
             .call(t.append('preferences.editing.circularize_segment_length.description'));
 
         // delete-outside-view toggle: clicking the label flips the preference
-        const deleteControlEnter = containerEnter
+        const deleteGroup = containerEnter
+            .append('div')
+            .attr('class', 'editing-pref');
+
+        const deleteControlEnter = deleteGroup
             .append('label')
             .attr('class', 'display-control delete-outside-view-control');
 
@@ -115,12 +157,12 @@ export function uiSectionEditingPreferences(context) {
 
         // description and an advanced-user warning sit outside the label so they
         // are not clickable toggles
-        containerEnter
+        deleteGroup
             .append('div')
             .attr('class', 'editing-option-description')
             .call(t.append('preferences.editing.delete_outside_view.description'));
 
-        const warnEnter = containerEnter
+        const warnEnter = deleteGroup
             .append('div')
             .attr('class', 'field-warning delete-outside-view-warning');
 
@@ -133,6 +175,9 @@ export function uiSectionEditingPreferences(context) {
 
         // update
         container = containerEnter.merge(container);
+
+        container.selectAll('.dense-inspector-input')
+            .property('checked', denseInspector());
 
         container.selectAll('.delete-outside-view-input')
             .property('checked', deleteOutsideView());
@@ -149,6 +194,7 @@ export function uiSectionEditingPreferences(context) {
 
     prefs.onChange(SEGMENT_LENGTH.pref, section.reRender);
     prefs.onChange(DELETE_OUTSIDE_VIEW, section.reRender);
+    prefs.onChange(DENSE_INSPECTOR, section.reRender);
 
     return section;
 }


### PR DESCRIPTION
## Summary
Make the road/feature editor fit more on screen and read more cleanly. Builds on top of `v6`.

- **Dense inspector preference** (Editing prefs): toggles a `dense` class on the sidebar that trims the "Edit feature" header height, padding, row height, label size and the selected-preset row. New `uiDenseInspector` module keeps it in sync via `prefs.onChange`.
- **`field.small` flag**: renders short-value fields (oneway, maxspeed, surface, sidewalk, ref) with the label on the left and value on the right, on one row.
- **`directionalGroup` field**: one header with compact `↕ / ↑ / ↓` sub-rows, each reusing its member field's real renderer and prerequisite. Groups **lanes, turn, change and placement** with their forward/backward variants (mixed combo / number / laneList). Avoids three separate fields per concern.
- **Editing preferences as separate cards** (Data-Layers style).
- **Field reordering on roads**: sidewalk / surface / cycleway after lanes, access before structure. Sidewalk options reordered (recommended first). Access options restored from v5 (drop `horse`, add `routing:*` / `bus` / `psv`).
- Directional labels use `↑ / ↓` arrows; all new strings live in the custom locale files.

## Notes for review
- The dense overrides are all scoped under `.sidebar.dense`; default (non-dense) spacing is unchanged.
- `directionalGroup` calls member renderers directly, so it supplies the `domId` / `locked` bits that `uiField` normally adds; `presetField` provides the rest.
- The group's "remove" (X) clears only the bare key (e.g. `lanes`), not the `:forward` / `:backward` variants — easy follow-up if wanted.
- No tsconfig in the repo, so TS is transpiled (not type-checked) by esbuild.

## Test plan
- [ ] Toggle "Compact feature editor" in Editing preferences; confirm header/preset/field spacing shrinks and default mode is unchanged.
- [ ] Select a two-way road with `lanes>2`; confirm Lanes/Turn/Change/Placement show grouped `↕/↑/↓` rows with the right prerequisites.
- [ ] Edit a value in each group row and confirm tags write correctly.
- [ ] `npm run lint`, `npm test`, and a dev build.