### PR TITLE
Add bus lanes side selector with motor_vehicle:lanes derivation

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -18,6 +18,7 @@
                 "placement_group": { "label": "Placement" },
                 "turn_lanes_group": { "label": "Turn" },
                 "change_lanes_group": { "label": "Change" },
+                "buswaylanes": { "label": "Bus lanes" },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -18,6 +18,7 @@
                 "placement_group": { "label": "Placement" },
                 "turn_lanes_group": { "label": "Virage" },
                 "change_lanes_group": { "label": "Changement" },
+                "buswaylanes": { "label": "Voies réservées bus" },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -111,6 +111,23 @@ export const customFields = {
             { id: 'change_lanes_forward', label: '↑' },
             { id: 'change_lanes_backward', label: '↓' }
         ]
+    },
+    // Bus lanes: one side selector writing the whole bus-lane tag family
+    // (bus:lanes*, lanes:bus*, busway:left/right). `keys` lists every tag it
+    // owns so the field reads as present and clears them all on removal. Shown
+    // once the road has at least two lanes.
+    buswaylanes: {
+        key: 'bus:lanes',
+        keys: [
+            'bus:lanes', 'bus:lanes:forward', 'bus:lanes:backward',
+            'lanes:bus', 'lanes:bus:forward', 'lanes:bus:backward',
+            'busway:right', 'busway:left',
+            'motor_vehicle:lanes', 'motor_vehicle:lanes:forward', 'motor_vehicle:lanes:backward'
+        ],
+        type: 'buswaylanes',
+        geometry: ['line'],
+        reference: { key: 'busway' },
+        prerequisiteTag: { key: 'lanes', valueGreaterThan: 1 }
     }
 };
 
@@ -127,7 +144,7 @@ const WIDTH_FIELDS = laneFieldOrder.filter(id => id.startsWith('width'));
 // hold.
 const LANE_BLOCK = [
     'lanes_group',
-    'turn_lanes_group', 'change_lanes_group',
+    'turn_lanes_group', 'change_lanes_group', 'buswaylanes',
     ...WIDTH_FIELDS,
     'placement_group'
 ];

--- a/modules/ui/fields/bus_lanes.ts
+++ b/modules/ui/fields/bus_lanes.ts
@@ -1,0 +1,234 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { uiCombobox } from '../combobox';
+import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
+
+// =============================================================================
+// BUS LANES - a single side selector (None / Right / Left / Both / Left-opposite)
+// that reads and writes the bus-lane tag family in one shot:
+//   bus:lanes(:forward|:backward), lanes:bus(:forward|:backward),
+//   busway:left, busway:right.
+// The per-lane `bus:lanes*` sequence is derived from the lane count (a bus lane
+// on one edge, plain lanes elsewhere), so the mapper only asks for the side.
+// Ported from the v5 `buswaylanes` field, rewritten so read and write share one
+// definition: a tag set "matches" a side iff writing that side reproduces it.
+// =============================================================================
+
+// Identifying bus-lane keys: these define the side and are matched on read.
+const BUS_KEYS = [
+    'bus:lanes', 'bus:lanes:forward', 'bus:lanes:backward',
+    'lanes:bus', 'lanes:bus:forward', 'lanes:bus:backward',
+    'busway:right', 'busway:left'
+] as const;
+
+// Companion `motor_vehicle:lanes` keys, derived from `bus:lanes*` on write (the
+// bus lane is closed to motor vehicles). Cleared/written but not matched on read
+// so existing bus:lanes data without them is still recognised.
+const MOTOR_KEYS = [
+    'motor_vehicle:lanes', 'motor_vehicle:lanes:forward', 'motor_vehicle:lanes:backward'
+] as const;
+
+// per-direction suffixes shared by the bus and motor_vehicle lane keys
+const SUFFIXES = ['', ':forward', ':backward'] as const;
+
+// Human-readable labels for the combobox, in menu order. `none` clears the tags.
+const TITLES: Record<string, string> = {
+    none: 'None',
+    right: 'Right side',
+    left: 'Left side',
+    both: 'Both sides',
+    opposite_left: 'Left side (opposite direction)'
+};
+
+type Tags = Record<string, string>;
+type TagDiff = Record<string, string | undefined>;
+
+/**
+ * Build a per-lane `bus:lanes` value for a single bus lane on one edge: every
+ * lane is `yes` except the bus lane which is `designated`. The bus lane is the
+ * last cell for `right` / `opposite_left`, the first cell for `left`.
+ *
+ * @param count - number of lanes in the direction
+ * @param side - which edge carries the bus lane
+ * @returns the pipe-joined value, or undefined when `count` < 1
+ */
+export function busLaneSequence(count: number, side: 'right' | 'left' | 'opposite_left'): string | undefined {
+    if (!(count >= 1)) return undefined;
+    const cells = new Array(count).fill('yes');
+    cells[side === 'left' ? 0 : count - 1] = 'designated';
+    return cells.join('|');
+}
+
+/**
+ * Derive the `motor_vehicle:lanes` value matching a `bus:lanes` value: the bus
+ * (`designated`) lane is closed (`no`), every other lane stays open (`yes`).
+ *
+ * @param busValue - a pipe-joined `bus:lanes` value
+ * @returns the matching `motor_vehicle:lanes` value
+ */
+export function motorVehicleFromBus(busValue: string): string {
+    return busValue.split('|').map(cell => (cell === 'designated' ? 'no' : 'yes')).join('|');
+}
+
+/** Sides offered for the road's direction (two-way roads add both / opposite). */
+function candidateSides(tags: Tags): string[] {
+    return tags.oneway === 'yes'
+        ? ['none', 'right', 'left']
+        : ['none', 'right', 'left', 'both', 'opposite_left'];
+}
+
+/** A diff with every managed key cleared; side handlers set what they need. */
+function clearedDiff(): TagDiff {
+    const diff: TagDiff = {};
+    BUS_KEYS.forEach(key => { diff[key] = undefined; });
+    MOTOR_KEYS.forEach(key => { diff[key] = undefined; });
+    return diff;
+}
+
+/**
+ * Compute the bus-lane tag diff for the chosen side, deriving the per-lane
+ * sequences from the lane counts. Returns null when the side cannot be applied
+ * (fewer than 2 lanes, or a two-way road with >2 lanes that lacks the
+ * lanes:forward / lanes:backward split needed to place the bus lane).
+ *
+ * @param side - the selected side (`none` / `right` / `left` / `both` / `opposite_left`)
+ * @param tags - the way's tags (reads `lanes`, `oneway`, `lanes:forward|backward`)
+ * @returns the tag diff to apply, or null when invalid
+ */
+export function writeBusLanes(side: string, tags: Tags): TagDiff | null {
+    const diff = clearedDiff();
+    if (side === 'none') return diff;   // clearing is always allowed
+
+    const total = Number(tags.lanes);
+    if (!(total >= 2)) return null;
+    const twoWay = tags.oneway !== 'yes';
+
+    // per-direction lane counts
+    let forward: number, backward: number;
+    if (!twoWay) {
+        forward = total; backward = 0;
+    } else if (tags['lanes:forward'] && tags['lanes:backward']) {
+        forward = Number(tags['lanes:forward']); backward = Number(tags['lanes:backward']);
+    } else if (total === 2) {
+        forward = 1; backward = 1;
+    } else {
+        return null;   // ambiguous: two-way, >2 lanes, no forward/backward split
+    }
+
+    if (!twoWay) {
+        // one-way: a single `bus:lanes` sequence + busway side
+        if (side !== 'right' && side !== 'left') return null;
+        diff['bus:lanes'] = busLaneSequence(total, side);
+        diff['lanes:bus'] = '1';
+        diff[side === 'right' ? 'busway:right' : 'busway:left'] = 'lane';
+    } else if (side === 'right') {
+        diff['bus:lanes:forward'] = busLaneSequence(forward, 'right');
+        diff['lanes:bus:forward'] = '1';
+        diff['busway:right'] = 'lane';
+    } else if (side === 'left') {
+        diff['bus:lanes:backward'] = busLaneSequence(backward, 'left');
+        diff['lanes:bus:backward'] = '1';
+        diff['busway:left'] = 'lane';
+    } else if (side === 'both') {
+        diff['bus:lanes:forward'] = busLaneSequence(forward, 'right');
+        diff['bus:lanes:backward'] = busLaneSequence(backward, 'right');
+        diff['lanes:bus:forward'] = '1';
+        diff['lanes:bus:backward'] = '1';
+        diff['busway:right'] = 'lane';
+        diff['busway:left'] = 'lane';
+    } else if (side === 'opposite_left') {
+        diff['bus:lanes:backward'] = busLaneSequence(backward, 'opposite_left');
+        diff['lanes:bus:backward'] = '1';
+        diff['busway:left'] = 'lane';
+    } else {
+        return null;
+    }
+
+    // mirror each written bus:lanes* into motor_vehicle:lanes* (bus lane closed)
+    SUFFIXES.forEach(suffix => {
+        const bus = diff['bus:lanes' + suffix];
+        diff['motor_vehicle:lanes' + suffix] = bus ? motorVehicleFromBus(bus) : undefined;
+    });
+    return diff;
+}
+
+/** Whether applying `diff` would leave the bus-lane keys exactly as in `tags`. */
+function diffMatches(diff: TagDiff, tags: Tags): boolean {
+    return BUS_KEYS.every(key => (diff[key] || '') === (tags[key] || ''));
+}
+
+/**
+ * Resolve the selected side from the current tags: the side whose written tags
+ * reproduce them. Returns '' for an unsupported (custom) combination.
+ *
+ * @param tags - the way's tags
+ * @returns the matching side key, or '' when none matches
+ */
+export function readBusLanes(tags: Tags): string {
+    for (const side of candidateSides(tags)) {
+        const diff = writeBusLanes(side, tags);
+        if (diff && diffMatches(diff, tags)) return side;
+    }
+    return '';
+}
+
+/**
+ * Bus-lanes preset field: a single side selector mapping to the bus-lane tag
+ * family (registered as the `buswaylanes` field type).
+ *
+ * @param field - the preset field definition (decorated by `presetField`)
+ * @param context - the iD application context
+ * @returns the field component (callable on a d3 selection)
+ */
+export function uiFieldBusLanes(field: { type: string }, context: iD.Context) {
+    const dispatch = d3_dispatch('change');
+    const combo = uiCombobox(context, 'buswaylanes');
+    // d3 selections are loosely typed here, like the sibling field components
+    let input: any = d3_select(null);
+    let wrap: any = d3_select(null);
+    let _tags: Tags = {};
+
+    function busLanes(selection: any) {
+        wrap = selection.selectAll('.form-field-input-wrap').data([0]);
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
+            .merge(wrap);
+
+        input = wrap.selectAll('input').data([0]);
+        input = input.enter()
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'preset-input-buswaylanes')
+            .call(utilNoAuto)
+            .call(combo)
+            .merge(input);
+
+        input.on('change', change).on('blur', change);
+
+        busLanes.tags(_tags);
+    }
+
+    function change(d3_event: any) {
+        const value = utilGetSetValue(d3_select(d3_event.currentTarget));
+        const side = candidateSides(_tags).find(s => TITLES[s] === value);
+        if (!side) return;   // ignore free text that isn't a known side
+        const diff = writeBusLanes(side, _tags);
+        if (diff) dispatch.call('change', d3_event.currentTarget, diff);
+    }
+
+    busLanes.tags = function(tags: Tags) {
+        _tags = tags || {};
+        combo.data(candidateSides(_tags).map(s => ({ value: TITLES[s], title: TITLES[s] })));
+        const side = readBusLanes(_tags);
+        utilGetSetValue(input, side ? TITLES[side] : '');
+    };
+
+    busLanes.focus = function() {
+        const node = wrap.selectAll('input').node();
+        if (node) node.focus();
+    };
+
+    return utilRebind(busLanes, dispatch, 'on');
+}

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -3,6 +3,7 @@ export * from './combo';
 export * from './input';
 export * from './access';
 export * from './address';
+export * from './bus_lanes';
 export * from './directional_combo';
 export * from './lanes';
 export * from './lane_list';
@@ -50,6 +51,7 @@ import {
 
 import { uiFieldAccess } from './access';
 import { uiFieldAddress } from './address';
+import { uiFieldBusLanes } from './bus_lanes';
 import { uiFieldDirectionalCombo } from './directional_combo';
 import { uiFieldDirectionalGroup } from './directional_group';
 import { uiFieldLanes } from './lanes';
@@ -66,6 +68,7 @@ import { uiFieldWikipedia } from './wikipedia';
 export var uiFields = {
     access: uiFieldAccess,
     address: uiFieldAddress,
+    buswaylanes: uiFieldBusLanes,
     check: uiFieldCheck,
     colour: uiFieldColour,
     combo: uiFieldCombo,

--- a/test/spec/ui/fields/bus_lanes.js
+++ b/test/spec/ui/fields/bus_lanes.js
@@ -1,0 +1,104 @@
+describe('iD.uiFieldBusLanes helpers', () => {
+
+    describe('busLaneSequence', () => {
+        describe.each([
+            [2, 'right', 'yes|designated'],
+            [3, 'right', 'yes|yes|designated'],
+            [2, 'left', 'designated|yes'],
+            [3, 'left', 'designated|yes|yes'],
+            [3, 'opposite_left', 'yes|yes|designated'],
+            [1, 'right', 'designated'],
+            [0, 'right', undefined]
+        ])('(%i, %s)', (count, side, expected) => {
+            it(`is ${expected}`, () => {
+                expect(iD.busLaneSequence(count, side)).toBe(expected);
+            });
+        });
+    });
+
+    describe('motorVehicleFromBus', () => {
+        describe.each([
+            ['yes|yes|designated', 'yes|yes|no'],
+            ['designated|yes', 'no|yes'],
+            ['designated', 'no']
+        ])('%s', (bus, expected) => {
+            it(`is ${expected}`, () => {
+                expect(iD.motorVehicleFromBus(bus)).toBe(expected);
+            });
+        });
+    });
+
+    describe('writeBusLanes', () => {
+        it('mirrors bus:lanes into motor_vehicle:lanes (bus lane closed)', () => {
+            const diff = iD.writeBusLanes('right', { lanes: '3', oneway: 'yes' });
+            expect(diff['bus:lanes']).toBe('yes|yes|designated');
+            expect(diff['motor_vehicle:lanes']).toBe('yes|yes|no');
+        });
+
+        it('clears motor_vehicle:lanes for "none"', () => {
+            const diff = iD.writeBusLanes('none', { lanes: '3' });
+            expect(diff['motor_vehicle:lanes']).toBeUndefined();
+        });
+
+        it('clears every bus-lane key for "none"', () => {
+            const diff = iD.writeBusLanes('none', { lanes: '3', oneway: 'yes', 'bus:lanes': 'yes|yes|designated' });
+            expect(diff['bus:lanes']).toBeUndefined();
+            expect(diff['busway:right']).toBeUndefined();
+        });
+
+        it('writes a one-way right bus lane', () => {
+            const diff = iD.writeBusLanes('right', { lanes: '3', oneway: 'yes' });
+            expect(diff['bus:lanes']).toBe('yes|yes|designated');
+            expect(diff['lanes:bus']).toBe('1');
+            expect(diff['busway:right']).toBe('lane');
+            expect(diff['busway:left']).toBeUndefined();
+        });
+
+        it('writes a two-way left bus lane on the backward direction', () => {
+            const diff = iD.writeBusLanes('left', { lanes: '4', oneway: 'no', 'lanes:forward': '2', 'lanes:backward': '2' });
+            expect(diff['bus:lanes:backward']).toBe('designated|yes');
+            expect(diff['lanes:bus:backward']).toBe('1');
+            expect(diff['busway:left']).toBe('lane');
+        });
+
+        describe.each([
+            ['fewer than 2 lanes', { lanes: '1', oneway: 'yes' }, 'right'],
+            ['two-way >2 lanes without split', { lanes: '4', oneway: 'no' }, 'right'],
+            ['both on a one-way road', { lanes: '3', oneway: 'yes' }, 'both']
+        ])('returns null for %s', (_label, tags, side) => {
+            it('null', () => {
+                expect(iD.writeBusLanes(side, tags)).toBeNull();
+            });
+        });
+    });
+
+    describe('readBusLanes round-trips writeBusLanes', () => {
+        // apply a write diff on top of the base road tags, dropping cleared keys
+        function apply(base, diff) {
+            const tags = Object.assign({}, base);
+            Object.keys(diff).forEach(key => {
+                if (diff[key] === undefined) delete tags[key];
+                else tags[key] = diff[key];
+            });
+            return tags;
+        }
+
+        describe.each([
+            ['one-way right', { lanes: '3', oneway: 'yes' }, 'right'],
+            ['one-way left', { lanes: '2', oneway: 'yes' }, 'left'],
+            ['two-way right', { lanes: '4', oneway: 'no', 'lanes:forward': '2', 'lanes:backward': '2' }, 'right'],
+            ['two-way both', { lanes: '4', oneway: 'no', 'lanes:forward': '2', 'lanes:backward': '2' }, 'both'],
+            ['two-way opposite_left', { lanes: '4', oneway: 'no', 'lanes:forward': '2', 'lanes:backward': '2' }, 'opposite_left'],
+            ['empty is none', { lanes: '3', oneway: 'yes' }, 'none']
+        ])('%s', (_label, base, side) => {
+            it(`reads back "${side}"`, () => {
+                const tags = apply(base, iD.writeBusLanes(side, base));
+                expect(iD.readBusLanes(tags)).toBe(side);
+            });
+        });
+
+        it('returns "" for an unsupported combination', () => {
+            expect(iD.readBusLanes({ lanes: '3', oneway: 'yes', 'bus:lanes': 'yes|designated|yes' })).toBe('');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Add the v5 **Bus lanes** field to v6, rewritten for maintainability:

- Single side selector (**None / Right / Left / Both / Left-opposite**) writing the whole bus-lane tag family in one shot: `bus:lanes*`, `lanes:bus*`, `busway:left/right`.
- Per-lane `bus:lanes` sequences are derived from the lane count (bus lane = `designated`, others = `yes`).
- **`motor_vehicle:lanes*`** is written alongside (`designated` → `no`, others → `yes`), e.g. `bus:lanes=yes|yes|designated` → `motor_vehicle:lanes=yes|yes|no`.
- Read and write share one definition (round-trip detection); unsupported/custom combinations show as empty.
- Pure helpers (`busLaneSequence`, `motorVehicleFromBus`, `writeBusLanes`, `readBusLanes`) with parametric tests (25 cases).
- Field appears on roads once `lanes ≥ 2`, after the Change group in the lane block.

## Notes for review
- Detection matches on bus-lane keys only (not `motor_vehicle:lanes`), so existing data without motor_vehicle tags is still recognised; re-selecting the side adds/corrects them.
- Option labels are in TS (like `sidewalk`); field label is in custom locales (`Bus lanes` / `Voies réservées bus`).

## Test plan
- [ ] Select a road with `lanes=3`, choose Right / Left / Both and confirm tags write correctly including `motor_vehicle:lanes*`.
- [ ] Choose None and confirm all bus + motor_vehicle lane keys are cleared.
- [ ] Load existing `bus:lanes` data and confirm the side is detected.
- [ ] `npx vitest run test/spec/ui/fields/bus_lanes.js`