### PR TITLE
Add dual_carriageway field for one-way divided roads

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -19,6 +19,13 @@
                 "turn_lanes_group": { "label": "Turn" },
                 "change_lanes_group": { "label": "Change" },
                 "buswaylanes": { "label": "Bus lanes" },
+                "dual_carriageway": {
+                    "label": "Dual carriageway",
+                    "options": {
+                        "yes": "Yes",
+                        "no": "No"
+                    }
+                },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -19,6 +19,13 @@
                 "turn_lanes_group": { "label": "Virage" },
                 "change_lanes_group": { "label": "Changement" },
                 "buswaylanes": { "label": "Voies réservées bus" },
+                "dual_carriageway": {
+                    "label": "Chaussée séparée",
+                    "options": {
+                        "yes": "Oui",
+                        "no": "Non"
+                    }
+                },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -288,6 +288,9 @@ export const osmRightSideIsInsideTags: TagDictionary<true | string> = {
     },
     'waterway': {
         'weir': true
+    },
+    'dual_carriageway': {
+        'yes': true
     }
 };
 

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -128,6 +128,15 @@ export const customFields = {
         geometry: ['line'],
         reference: { key: 'busway' },
         prerequisiteTag: { key: 'lanes', valueGreaterThan: 1 }
+    },
+    // Marks a one-way carriageway that is half of a divided road (`dual_carriageway=yes`).
+    // Shown only when `oneway=yes` (same as v5).
+    dual_carriageway: {
+        key: 'dual_carriageway',
+        type: 'radio',
+        options: ['yes', 'no'],
+        geometry: ['line'],
+        prerequisiteTag: { key: 'oneway', value: 'yes' }
     }
 };
 
@@ -261,15 +270,24 @@ export function applyCustomFields(presetManager) {
         removeField(moreFields, 'access');
         fields.splice(fields.indexOf('structure'), 0, 'access');
 
-        if (!NON_MOTORWAY_HIGHWAYS.has(highway)) return;
+        if (!NON_MOTORWAY_HIGHWAYS.has(highway)) {
+            // oneway:bicycle: shown right after the main `oneway` field as a default
+            // field (stays hidden until oneway=yes, see customizeOnewayBicycle).
+            removeField(fields, 'oneway/bicycle');
+            removeField(moreFields, 'oneway/bicycle');
+            const onewayIndex = fields.indexOf('oneway');
+            const insertAt = onewayIndex === -1 ? fields.indexOf('structure') : onewayIndex + 1;
+            fields.splice(insertAt, 0, 'oneway/bicycle');
+        }
 
-        // oneway:bicycle: shown right after the main `oneway` field as a default
-        // field (stays hidden until oneway=yes, see customizeOnewayBicycle).
-        removeField(fields, 'oneway/bicycle');
-        removeField(moreFields, 'oneway/bicycle');
-        const onewayIndex = fields.indexOf('oneway');
-        const insertAt = onewayIndex === -1 ? fields.indexOf('structure') : onewayIndex + 1;
-        fields.splice(insertAt, 0, 'oneway/bicycle');
+        // dual carriageway: default field after `oneway` (and `oneway/bicycle` when
+        // present); hidden until oneway=yes.
+        removeField(fields, 'dual_carriageway');
+        removeField(moreFields, 'dual_carriageway');
+        const afterOnewayExtras = fields.indexOf('oneway/bicycle');
+        const dualAnchor = afterOnewayExtras === -1 ? fields.indexOf('oneway') : afterOnewayExtras;
+        const dualAt = dualAnchor === -1 ? fields.indexOf('structure') : dualAnchor + 1;
+        fields.splice(dualAt < 0 ? fields.length : dualAt, 0, 'dual_carriageway');
     });
 }
 


### PR DESCRIPTION
## Summary
Restore the v5 **Dual carriageway** field on road presets:

- Radio **Yes / No** on `dual_carriageway`, visible only when `oneway=yes`.
- Inserted after `oneway` (and `oneway/bicycle` on non-motorway roads).
- Labels in custom locales (`Dual carriageway` / `Chaussée séparée`).
- Adds `dual_carriageway=yes` to `osmRightSideIsInsideTags` (left/right side semantics, as in v5).

## Test plan
- [ ] Select a one-way road (`oneway=yes`) → field appears with Yes/No.
- [ ] Select a two-way road → field hidden.
- [ ] Set Yes → `dual_carriageway=yes` written; clone dual_carriageway still works.
- [ ] Sidewalk « opposite (use_sidepath) » still sets `dual_carriageway=yes` as before.