### PR TITLE
Add junction_oneway field for one-way junction types

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -26,6 +26,15 @@
                         "no": "No"
                     }
                 },
+                "junction_oneway": {
+                    "label": "Junction",
+                    "options": {
+                        "roundabout": "Roundabout",
+                        "circular": "Traffic circle",
+                        "jughandle": "Jughandle",
+                        "turning_loop": "Turning loop"
+                    }
+                },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -26,6 +26,15 @@
                         "no": "Non"
                     }
                 },
+                "junction_oneway": {
+                    "label": "Jonction",
+                    "options": {
+                        "roundabout": "Rond-point",
+                        "circular": "Cercle routier",
+                        "jughandle": "Bretelle en J",
+                        "turning_loop": "Boucle de retournement"
+                    }
+                },
                 "placement": { "label": "Placement" },
                 "placement_forward": { "label": "Placement ↑" },
                 "placement_backward": { "label": "Placement ↓" },

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -137,6 +137,18 @@ export const customFields = {
         options: ['yes', 'no'],
         geometry: ['line'],
         prerequisiteTag: { key: 'oneway', value: 'yes' }
+    },
+    // Junction type on one-way roads (`junction=*`). Replaces the upstream
+    // `junction_line` field on our road presets (adds `turning_loop`, shown only
+    // when `oneway=yes`, same as v5).
+    junction_oneway: {
+        key: 'junction',
+        type: 'combo',
+        options: ['roundabout', 'circular', 'jughandle', 'turning_loop'],
+        autoSuggestions: false,
+        customValues: false,
+        geometry: ['line'],
+        prerequisiteTag: { key: 'oneway', value: 'yes' }
     }
 };
 
@@ -288,6 +300,16 @@ export function applyCustomFields(presetManager) {
         const dualAnchor = afterOnewayExtras === -1 ? fields.indexOf('oneway') : afterOnewayExtras;
         const dualAt = dualAnchor === -1 ? fields.indexOf('structure') : dualAnchor + 1;
         fields.splice(dualAt < 0 ? fields.length : dualAt, 0, 'dual_carriageway');
+
+        // junction on one-way roads: drop upstream `junction_line` to avoid two
+        // editors for the same tag, then insert our field after dual_carriageway.
+        removeField(fields, 'junction_line');
+        removeField(moreFields, 'junction_line');
+        removeField(fields, 'junction_oneway');
+        removeField(moreFields, 'junction_oneway');
+        const afterDual = fields.indexOf('dual_carriageway');
+        const junctionAt = afterDual === -1 ? dualAt : afterDual + 1;
+        fields.splice(junctionAt < 0 ? fields.length : junctionAt, 0, 'junction_oneway');
     });
 }
 


### PR DESCRIPTION
## Summary
- Add `junction_oneway` custom combo on road presets (roundabout, circular, jughandle, turning_loop)
- Visible only when `oneway=yes` (prerequisite tag)
- Replaces upstream `junction_line` on our road presets to avoid duplicate editors for the same `junction` tag
- en/fr locale strings

## Test plan
- [ ] Select a one-way road (`oneway=yes`) — Junction field appears after Dual carriageway
- [ ] Select a two-way road — Junction field is hidden
- [ ] Set junction to roundabout / circular / jughandle / turning_loop — tag writes correctly
- [ ] Clear junction value — tag removed
- [ ] Verify no duplicate junction field from upstream preset