### PR TITLE
Warn on lanes when one-way road has directional lane tags

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2021,6 +2021,14 @@ input.date-selector {
     border-left: 1px solid var(--border-color);
 }
 
+/* Lanes one-way / directional-tag warning spans the field, between label and rows */
+.form-field .lanes-oneway-warning {
+    flex: 1 1 100%;
+    width: 100%;
+    margin: 0;
+    border-radius: 0;
+}
+
 
 /* Field - Structure
 ------------------------------------------------------- */

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -119,7 +119,7 @@
         },
         "lanes": {
             "count_mismatch": "“{tag}” has {actual} lanes, but the road is tagged with {count}.",
-            "oneway_directional_tags": "This one-way road uses directional lane tags ({tags}). Use lanes, turn:lanes, placement, and change:lanes without :forward or :backward."
+            "oneway_directional_tags": "This one-way road uses directional lane tags ({tags}). Use the undirected tags (lanes, turn:lanes, bus:lanes, motor_vehicle:lanes, etc.) without :forward or :backward."
         },
         "issues": {
             "redundant_directional_tag": {

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -118,7 +118,8 @@
             }
         },
         "lanes": {
-            "count_mismatch": "“{tag}” has {actual} lanes, but the road is tagged with {count}."
+            "count_mismatch": "“{tag}” has {actual} lanes, but the road is tagged with {count}.",
+            "oneway_directional_tags": "This one-way road uses directional lane tags ({tags}). Use lanes, turn:lanes, placement, and change:lanes without :forward or :backward."
         },
         "issues": {
             "redundant_directional_tag": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -118,7 +118,8 @@
             }
         },
         "lanes": {
-            "count_mismatch": "« {tag} » a {actual} voies, mais la route est taggée avec {count}."
+            "count_mismatch": "« {tag} » a {actual} voies, mais la route est taggée avec {count}.",
+            "oneway_directional_tags": "Cette route à sens unique utilise des tags de voies directionnels ({tags}). Utilisez lanes, turn:lanes, placement et change:lanes sans :forward ni :backward."
         },
         "issues": {
             "redundant_directional_tag": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -119,7 +119,7 @@
         },
         "lanes": {
             "count_mismatch": "« {tag} » a {actual} voies, mais la route est taggée avec {count}.",
-            "oneway_directional_tags": "Cette route à sens unique utilise des tags de voies directionnels ({tags}). Utilisez lanes, turn:lanes, placement et change:lanes sans :forward ni :backward."
+            "oneway_directional_tags": "Cette route à sens unique utilise des tags de voies directionnels ({tags}). Utilisez les tags non directionnels (lanes, turn:lanes, bus:lanes, motor_vehicle:lanes, etc.) sans :forward ni :backward."
         },
         "issues": {
             "redundant_directional_tag": {

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -8,6 +8,7 @@ import { uiTooltip } from './tooltip';
 import { geoExtent } from '../geo/extent';
 import { uiFieldHelp } from './field_help';
 import { uiFields } from './fields';
+import { directionalLaneTagsOnOneway } from './fields/lane_warnings';
 import { LANGUAGE_SUFFIX_REGEX } from './fields/localized';
 import { uiTagReference } from './tag_reference';
 import { utilRebind, utilUniqueDomId } from '../util';
@@ -104,6 +105,23 @@ export function uiField(context, presetField, entityIDs, options) {
 
     function allKeys() {
         return field.allKeys();
+    }
+
+
+    // Full-width notice above the Lanes input (not inside the directional sub-rows).
+    function renderLanesOnewayWarning(selection, tags) {
+        const found = directionalLaneTagsOnOneway(tags);
+        let warn = selection.selectAll('.lanes-oneway-warning')
+            .data(found.length ? [0] : []);
+
+        warn.exit().remove();
+
+        const enter = warn.enter()
+            .insert('div', '.form-field-input-wrap')
+            .attr('class', 'field-warning lanes-oneway-warning');
+
+        warn = enter.merge(warn);
+        warn.text(t('lanes.oneway_directional_tags', { tags: found.join(', ') }));
     }
 
 
@@ -261,6 +279,12 @@ export function uiField(context, presetField, entityIDs, options) {
 
                 selection
                     .call(d.impl);
+
+                if (d.key === 'lanes' && d.type === 'directionalGroup') {
+                    renderLanesOnewayWarning(selection, _tags);
+                } else {
+                    selection.selectAll('.lanes-oneway-warning').remove();
+                }
 
                 // add field help components
                 if (help) {

--- a/modules/ui/fields/directional_group.ts
+++ b/modules/ui/fields/directional_group.ts
@@ -1,9 +1,11 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
+import { t } from '../../core/localizer';
 import { utilRebind, utilUniqueDomId } from '../../util';
 import { presetManager } from '../../presets';
 import { prerequisiteTagSatisfied } from '../field';
+import { directionalLaneTagsOnOneway } from './lane_warnings';
 import { uiFieldCombo } from './combo';
 import { uiFieldNumber } from './input';
 import { uiFieldLaneList } from './lane_list';
@@ -39,7 +41,7 @@ interface GroupMember { id: string; label: string; }
  * @returns the field component (callable on a d3 selection)
  */
 export function uiFieldDirectionalGroup(
-    field: { type: string; members: GroupMember[] },
+    field: { type: string; key: string; members: GroupMember[] },
     context: iD.Context
 ) {
     const dispatch = d3_dispatch('change');
@@ -100,7 +102,22 @@ export function uiFieldDirectionalGroup(
 
         // feed the full tag set to each visible member renderer
         rows.each((m: any) => m.impl.tags(_tags));
+
+        if (field.key === 'lanes') renderOnewayDirectionalWarning(_tags);
     };
+
+    // Inline notice when a one-way road still has :forward / :backward lane tags.
+    function renderOnewayDirectionalWarning(tags: Record<string, string>) {
+        const found = directionalLaneTagsOnOneway(tags);
+        let warn = wrap.selectAll('.field-warning').data([0]);
+        warn = warn.enter()
+            .append('div')
+            .attr('class', 'field-warning')
+            .merge(warn);
+        warn.text(found.length
+            ? t('lanes.oneway_directional_tags', { tags: found.join(', ') })
+            : '');
+    }
 
     directionalGroup.focus = function() {
         const node = wrap.selectAll('input').node();

--- a/modules/ui/fields/directional_group.ts
+++ b/modules/ui/fields/directional_group.ts
@@ -1,11 +1,9 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
-import { t } from '../../core/localizer';
 import { utilRebind, utilUniqueDomId } from '../../util';
 import { presetManager } from '../../presets';
 import { prerequisiteTagSatisfied } from '../field';
-import { directionalLaneTagsOnOneway } from './lane_warnings';
 import { uiFieldCombo } from './combo';
 import { uiFieldNumber } from './input';
 import { uiFieldLaneList } from './lane_list';
@@ -102,22 +100,7 @@ export function uiFieldDirectionalGroup(
 
         // feed the full tag set to each visible member renderer
         rows.each((m: any) => m.impl.tags(_tags));
-
-        if (field.key === 'lanes') renderOnewayDirectionalWarning(_tags);
     };
-
-    // Inline notice when a one-way road still has :forward / :backward lane tags.
-    function renderOnewayDirectionalWarning(tags: Record<string, string>) {
-        const found = directionalLaneTagsOnOneway(tags);
-        let warn = wrap.selectAll('.field-warning').data([0]);
-        warn = warn.enter()
-            .append('div')
-            .attr('class', 'field-warning')
-            .merge(warn);
-        warn.text(found.length
-            ? t('lanes.oneway_directional_tags', { tags: found.join(', ') })
-            : '');
-    }
 
     directionalGroup.focus = function() {
         const node = wrap.selectAll('input').node();

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -8,6 +8,7 @@ export * from './directional_combo';
 export * from './lanes';
 export * from './lane_list';
 export * from './lane_patterns';
+export * from './lane_warnings';
 export * from './localized';
 export * from './roadheight';
 export * from './roadspeed';

--- a/modules/ui/fields/lane_warnings.ts
+++ b/modules/ui/fields/lane_warnings.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// Lane tag warnings — helpers for inline inspector notices on lane fields.
+// =============================================================================
+
+/** Directional lane tags that should not be used when `oneway=yes`. */
+export const ONEWAY_DIRECTIONAL_LANE_TAGS = [
+    'lanes:forward',
+    'lanes:backward',
+    'turn:lanes:forward',
+    'turn:lanes:backward',
+    'placement:forward',
+    'placement:backward',
+    'change:lanes:forward',
+    'change:lanes:backward'
+] as const;
+
+/**
+ * Whether the way is tagged one-way in the forward direction (`oneway=yes`).
+ *
+ * @param tags - entity tags
+ */
+export function isOnewayYes(tags: Record<string, string>): boolean {
+    return tags.oneway === 'yes';
+}
+
+/**
+ * Directional lane-related tags that are set while the way is `oneway=yes`.
+ * On one-way roads, use the undirected tags (`lanes`, `turn:lanes`, etc.) instead.
+ *
+ * @param tags - entity tags
+ * @returns tag keys that should be cleared or merged into the undirected tag
+ */
+export function directionalLaneTagsOnOneway(tags: Record<string, string>): string[] {
+    if (!isOnewayYes(tags)) return [];
+    return ONEWAY_DIRECTIONAL_LANE_TAGS.filter(key => {
+        const value = tags[key];
+        return value !== undefined && value !== '';
+    });
+}

--- a/modules/ui/fields/lane_warnings.ts
+++ b/modules/ui/fields/lane_warnings.ts
@@ -11,7 +11,13 @@ export const ONEWAY_DIRECTIONAL_LANE_TAGS = [
     'placement:forward',
     'placement:backward',
     'change:lanes:forward',
-    'change:lanes:backward'
+    'change:lanes:backward',
+    'bus:lanes:forward',
+    'bus:lanes:backward',
+    'lanes:bus:forward',
+    'lanes:bus:backward',
+    'motor_vehicle:lanes:forward',
+    'motor_vehicle:lanes:backward'
 ] as const;
 
 /**

--- a/test/spec/ui/fields/lane_warnings.js
+++ b/test/spec/ui/fields/lane_warnings.js
@@ -1,0 +1,26 @@
+describe('iD.lane warning helpers', () => {
+
+    describe('directionalLaneTagsOnOneway', () => {
+        describe.each([
+            ['not one-way', { oneway: 'no', 'lanes:forward': '2' }, []],
+            ['one-way, no directional tags', { oneway: 'yes', lanes: '3' }, []],
+            ['lanes:forward', { oneway: 'yes', 'lanes:forward': '2' }, ['lanes:forward']],
+            ['lanes:backward', { oneway: 'yes', 'lanes:backward': '1' }, ['lanes:backward']],
+            ['turn:lanes:forward', { oneway: 'yes', 'turn:lanes:forward': 'left|through' }, ['turn:lanes:forward']],
+            ['placement:backward', { oneway: 'yes', 'placement:backward': 'left_of:1' }, ['placement:backward']],
+            ['change:lanes:forward', { oneway: 'yes', 'change:lanes:forward': 'no|yes' }, ['change:lanes:forward']],
+            ['several tags', {
+                oneway: 'yes',
+                'lanes:forward': '2',
+                'turn:lanes:backward': 'right',
+                'change:lanes:forward': 'yes'
+            }, ['lanes:forward', 'turn:lanes:backward', 'change:lanes:forward']],
+            ['empty value ignored', { oneway: 'yes', 'lanes:forward': '' }, []],
+            ['reverse oneway ignored', { oneway: '-1', 'lanes:forward': '2' }, []]
+        ])('%s', (_label, tags, expected) => {
+            it(`returns ${JSON.stringify(expected)}`, () => {
+                expect(iD.directionalLaneTagsOnOneway(tags)).to.eql(expected);
+            });
+        });
+    });
+});

--- a/test/spec/ui/fields/lane_warnings.js
+++ b/test/spec/ui/fields/lane_warnings.js
@@ -9,6 +9,9 @@ describe('iD.lane warning helpers', () => {
             ['turn:lanes:forward', { oneway: 'yes', 'turn:lanes:forward': 'left|through' }, ['turn:lanes:forward']],
             ['placement:backward', { oneway: 'yes', 'placement:backward': 'left_of:1' }, ['placement:backward']],
             ['change:lanes:forward', { oneway: 'yes', 'change:lanes:forward': 'no|yes' }, ['change:lanes:forward']],
+            ['bus:lanes:forward', { oneway: 'yes', 'bus:lanes:forward': 'yes|designated' }, ['bus:lanes:forward']],
+            ['lanes:bus:backward', { oneway: 'yes', 'lanes:bus:backward': 'designated|yes' }, ['lanes:bus:backward']],
+            ['motor_vehicle:lanes:forward', { oneway: 'yes', 'motor_vehicle:lanes:forward': 'yes|no' }, ['motor_vehicle:lanes:forward']],
             ['several tags', {
                 oneway: 'yes',
                 'lanes:forward': '2',


### PR DESCRIPTION
## Summary
- Inline warning on the **Lanes** field when `oneway=yes` and directional lane tags are still set (`:forward` / `:backward` on lanes, turn, placement, change, bus, and motor_vehicle families)
- Warning spans the full field width (between label and directional sub-rows), not squeezed beside ↕/↑/↓ markers
- Helper `directionalLaneTagsOnOneway` + parametric tests; en/fr locales

New Transition convention (not ported from v5).

## Test plan
- [ ] One-way road with `lanes:bus:forward` (or similar) — full-width warning under the Lanes label, lists offending tags
- [ ] Clear directional tags or set `oneway=no` — warning disappears
- [ ] One-way with only `lanes=3` and `turn:lanes=…` — no warning
- [ ] `oneway=-1` with `lanes:forward` — no warning (only `oneway=yes` triggers)