### PR TITLE
Identify fork in changeset created_by tag

### DIFF
--- a/config/id.js
+++ b/config/id.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-undef */
 
+/** Name in the OSM changeset `created_by` tag (upstream iD uses `iD`). */
+const changesetEditorName = 'Chaire Mobilité iD';
+
 // cdns for external data packages
 const presetsCdnUrl = ENV__ID_PRESETS_CDN_URL
   || 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
@@ -54,6 +57,7 @@ const nominatimApiUrl = ENV__ID_NOMINATIM_API_URL
 const showDonationMessage = ENV__ID_SHOW_DONATION_MESSAGE !== 'false';
 
 export {
+  changesetEditorName,
   presetsCdnUrl,
   ociCdnUrl,
   wmfSitematrixCdnUrl,

--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -15,6 +15,7 @@ import { uiSectionRawTagEditor } from './sections/raw_tag_editor';
 import { utilArrayGroupBy, utilRebind, utilUniqueDomId } from '../util';
 import { utilDetect } from '../util/detect';
 import { getIncompatibleSources } from '../validations/incompatible_source';
+import { changesetEditorName } from '../../config/id.js';
 
 
 var readOnlyTags = [
@@ -87,7 +88,7 @@ export function uiCommit(context) {
         var detected = utilDetect();
         var tags = {
             comment: prefs('comment') || '',
-            created_by: context.cleanTagValue('iD ' + context.version),
+            created_by: context.cleanTagValue(changesetEditorName + ' ' + context.version),
             host: context.cleanTagValue(detected.host),
             locale: context.cleanTagValue(localizer.localeCode())
         };


### PR DESCRIPTION
## Summary

- Set the OSM changeset `created_by` prefix to **Chaire Mobilité iD** (config constant in `config/id.js`) instead of upstream `iD`.
- Uploads are tagged like `Chaire Mobilité iD 2.41.0-dev` (version still comes from `package.json`).

## Test plan

- [ ] Log in on a dev instance, make a small edit, upload a changeset.
- [ ] On openstreetmap.org, confirm the changeset shows `created_by=Chaire Mobilité iD …` (not `iD …`).