### PR TITLE
GitHub Pages: v6 par défaut, v5 sous /v5/, bannière de migration

### DIFF
--- a/.github/workflows/deploy-transition-pages.yml
+++ b/.github/workflows/deploy-transition-pages.yml
@@ -1,0 +1,77 @@
+# Deploy Transition editor to GitHub Pages: v6 at site root, v5 under /v5/.
+# Replaces the previous workflow that published only the v5 branch to the root.
+name: Deploy Transition GitHub Pages
+
+on:
+  push:
+    branches: [v6]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout v6
+        uses: actions/checkout@v4
+        with:
+          ref: v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Build v6 editor
+        run: |
+          npm ci
+          npm run build
+          npm run dist
+
+      - name: Checkout v5
+        uses: actions/checkout@v4
+        with:
+          ref: v5
+          path: v5-src
+
+      - name: Build v5 editor
+        working-directory: v5-src
+        run: |
+          npm ci
+          npm run build
+          npm run dist
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site/v5
+          cp index.html land.html _site/
+          cp -r dist _site/dist
+          cp -r v5-src/dist/* _site/v5/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config/id.js
+++ b/config/id.js
@@ -3,6 +3,9 @@
 /** Name in the OSM changeset `created_by` tag (upstream iD uses `iD`). */
 const changesetEditorName = 'Chaire Mobilité iD';
 
+/** GitHub Pages path to the legacy v5 editor (trailing slash). */
+const legacyV5EditorPath = 'v5/';
+
 // cdns for external data packages
 const presetsCdnUrl = ENV__ID_PRESETS_CDN_URL
   || 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
@@ -58,6 +61,7 @@ const showDonationMessage = ENV__ID_SHOW_DONATION_MESSAGE !== 'false';
 
 export {
   changesetEditorName,
+  legacyV5EditorPath,
   presetsCdnUrl,
   ociCdnUrl,
   wmfSitematrixCdnUrl,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -6024,6 +6024,48 @@ button.conflicts-button {
 
 /* Notices (Zoom in to Edit)
 ------------------------------------------------------- */
+/* Legacy v5 link (Transition deployment) */
+.version-branch-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 6000;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+.version-branch-banner-text {
+    flex: 1 1 240px;
+    line-height: 1.4;
+}
+.version-branch-banner-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+.version-branch-banner-link.button {
+    text-decoration: none;
+}
+.version-branch-banner-dismiss .icon {
+    width: 14px;
+    height: 14px;
+    vertical-align: middle;
+}
+html.version-branch-banner-visible #id-container.ideditor {
+    padding-top: 52px;
+    box-sizing: border-box;
+}
+html.version-branch-banner-visible #id-container.ideditor .sidebar,
+html.version-branch-banner-visible #id-container.ideditor .main-content {
+    height: calc(100% - 52px);
+}
+
 .notice {
     position: absolute;
     top: 15px;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1217,6 +1217,13 @@ en:
   confirm:
     okay: "OK"
     cancel: "Cancel"
+  version_branch_banner:
+    message: >-
+      You are using the new v6 editor. The migration from v5 is still incomplete;
+      keyboard shortcuts will change. You can return to the previous version if needed.
+    open_v5: Open v5 editor
+    footer_link: v5 editor
+    dismiss: Dismiss
   splash:
     welcome: Welcome to the iD OpenStreetMap editor
     text: "iD is a friendly but powerful tool for contributing to the world's best free world map. This is version {version}. For more information see {website} and report bugs at {github}."

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -109,6 +109,12 @@
         }
     },
     "general": {
+        "version_branch_banner": {
+            "message": "You are using the new v6 editor. The migration from v5 is still incomplete; keyboard shortcuts will change. You can return to the previous version if needed.",
+            "open_v5": "Open v5 editor",
+            "footer_link": "v5 editor",
+            "dismiss": "Dismiss"
+        },
         "settings": {
             "custom_background": {
                 "private_url": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -109,6 +109,12 @@
         }
     },
     "general": {
+        "version_branch_banner": {
+            "message": "Vous utilisez le nouvel éditeur v6. Le transfert des fonctionnalités depuis la v5 est encore incomplet et les raccourcis clavier seront modifiés. Vous pouvez revenir à la version précédente si nécessaire.",
+            "open_v5": "Ouvrir l'éditeur v5",
+            "footer_link": "Éditeur v5",
+            "dismiss": "Masquer"
+        },
         "settings": {
             "custom_background": {
                 "private_url": {

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -40,6 +40,7 @@ import { uiStatus } from './status';
 import { uiTooltip } from './tooltip';
 import { uiTopToolbar } from './top_toolbar';
 import { uiVersion } from './version';
+import { uiLegacyV5FooterLink, uiVersionBranchBanner } from './version_branch_banner';
 import { uiZoom } from './zoom';
 import { uiZoomToSelection } from './zoom_to_selection';
 import { uiCmd } from './cmd';
@@ -120,6 +121,9 @@ export function uiInit(context) {
         container
             .attr('lang', localizer.localeCode())
             .attr('dir', localizer.textDirection());
+
+        container
+            .call(uiVersionBranchBanner());
 
         // setup fullscreen keybindings (no button shown at this time)
         container
@@ -347,6 +351,11 @@ export function uiInit(context) {
             .append('li')
             .attr('class', 'version')
             .call(uiVersion(context));
+
+        aboutList
+            .append('li')
+            .attr('class', 'legacy-v5-editor')
+            .call(uiLegacyV5FooterLink());
 
         if (!context.embed()) {
             aboutList

--- a/modules/ui/version_branch_banner.js
+++ b/modules/ui/version_branch_banner.js
@@ -1,0 +1,79 @@
+import { select as d3_select } from 'd3-selection';
+
+import { legacyV5EditorPath } from '../../config/id.js';
+import { prefs } from '../core/preferences';
+import { t } from '../core/localizer';
+import { svgIcon } from '../svg/icon';
+
+const DISMISS_PREF = 'transition-v5-banner-dismissed';
+
+/**
+ * @returns {boolean} true when the v6 editor is served from the site root (not /v5/).
+ */
+export function isV6EditorLocation() {
+    const path = window.location.pathname;
+    return !(/\/v5(?:\/|$)/.test(path));
+}
+
+/**
+ * Top-of-page notice on the v6 editor with a link to the legacy v5 deployment.
+ *
+ * @returns {function(import('d3-selection').Selection)} d3 component
+ */
+export function uiVersionBranchBanner() {
+    return function(selection) {
+        if (!isV6EditorLocation()) return;
+        if (prefs(DISMISS_PREF) === 'true') return;
+
+        const banner = selection
+            .append('div')
+            .attr('class', 'version-branch-banner fillD');
+
+        banner
+            .append('div')
+            .attr('class', 'version-branch-banner-text')
+            .call(t.append('version_branch_banner.message'));
+
+        const actions = banner
+            .append('div')
+            .attr('class', 'version-branch-banner-actions');
+
+        actions
+            .append('a')
+            .attr('class', 'version-branch-banner-link button')
+            .attr('href', legacyV5EditorPath)
+            .call(t.append('version_branch_banner.open_v5'));
+
+        actions
+            .append('button')
+            .attr('type', 'button')
+            .attr('class', 'version-branch-banner-dismiss button')
+            .on('click', function() {
+                prefs(DISMISS_PREF, 'true');
+                banner.remove();
+                d3_select(document.documentElement).classed('version-branch-banner-visible', false);
+            })
+            .call(t.append('version_branch_banner.dismiss'));
+
+        actions.select('.version-branch-banner-dismiss')
+            .call(svgIcon('#iD-icon-close'));
+
+        d3_select(document.documentElement).classed('version-branch-banner-visible', true);
+    };
+}
+
+/**
+ * Footer link to the legacy v5 editor (always shown on v6, including after the banner is dismissed).
+ *
+ * @returns {function(import('d3-selection').Selection)} d3 component
+ */
+export function uiLegacyV5FooterLink() {
+    return function(selection) {
+        if (!isV6EditorLocation()) return;
+
+        selection
+            .append('a')
+            .attr('href', legacyV5EditorPath)
+            .call(t.append('version_branch_banner.footer_link'));
+    };
+}


### PR DESCRIPTION
## Summary

- Déploie **v6** à la racine de https://projets.chaire.transition.city/ sur chaque push vers `v6` (workflow `deploy-transition-pages.yml`).
- Inclut **v5** sous `/v5/` en checkoutant la branche `v5` dans le job CI (`v5-src/`, dossier éphémère sur le runner).
- Bannière dismissible (prefs `localStorage`) + lien permanent « Éditeur v5 » dans le footer.
- Désactive le déploiement automatique Pages sur push `v5` (voir PR compagnon sur `v5`).

## Déploiement

Après merge dans `v6`, GitHub Actions publie automatiquement v6 + v5. Aucun dossier `v5-src` dans le dépôt.

## Test plan

- [ ] Merger aussi la PR sur `v5` (OAuth `/v5/`) et ajouter l’URI de redirection OSM `https://projets.chaire.transition.city/v5/`
- [ ] Vérifier Settings → Pages → source **GitHub Actions**
- [ ] Après merge : `/` → v6 + bannière ; dismiss + refresh → bannière absente, lien footer présent
- [ ] `/v5/` → éditeur v5, connexion OSM