### PR TITLE
OAuth et Pages: v5 servi sous /v5/ uniquement

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,11 +2,8 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["v5"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # v6 branch deploys v6 at site root and v5 under /v5/ (see deploy-transition-pages.yml).
+  # Manual only — avoids overwriting GitHub Pages on v5 pushes.
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -12,7 +12,7 @@ import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from '../geo';
 import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from '../osm';
 import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilRebind, utilTiler, utilQsString } from '../util';
 
-var redirectPath = 'https://projets.chaire.transition.city/';//window.location.origin + window.location.pathname;
+var redirectPath = 'https://projets.chaire.transition.city/v5/';
 var tiler = utilTiler();
 var dispatch = d3_dispatch('apiStatusChange', 'authLoading', 'authDone', 'change', 'loading', 'loaded', 'loadedNotes');
 var urlroot = 'https://www.openstreetmap.org';


### PR DESCRIPTION
## Summary

- `redirectPath` → `https://projets.chaire.transition.city/v5/` pour la connexion OSM depuis l’éditeur hébergé sous `/v5/`.
- Le workflow Jekyll ne se déclenche plus au push sur `v5` (évite d’écraser le site publié par le workflow `v6`).

## Test plan

- [ ] Ajouter l’URI de redirection OAuth sur l’application OSM Transition : `https://projets.chaire.transition.city/v5/`
- [ ] Merger en même temps (ou avant) la PR de déploiement sur `v6`