### PR TITLE
Map: v5 highway styling (access, links, placement=transition)

### DIFF
--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -1,0 +1,27 @@
+/**
+ * Chaire Mobilité iD fork — extra tag classes for map styling (css/30_highways.css custom section).
+ *
+ * Listed here so fork-specific OSM rules stay out of modules/svg/tag_classes.js.
+ */
+
+/**
+ * Exact tag matches → one class each (without `tag-` prefix).
+ * @type {{ key: string, value: string, class: string }[]}
+ */
+export const customExactTagClasses = [
+    { key: 'placement', value: 'transition', class: 'placement-transition' }
+];
+
+/**
+ * Append fork-specific tag classes for custom map styling.
+ *
+ * @param {string[]} classes
+ * @param {Record<string, string>} t entity tags
+ */
+export function appendCustomTagClasses(classes, t) {
+    for (const { key, value, class: className } of customExactTagClasses) {
+        if (t[key] === value) {
+            classes.push('tag-' + className);
+        }
+    }
+}

--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -1,8 +1,13 @@
 /**
  * Chaire Mobilité iD fork — extra tag classes for map styling (css/30_highways.css custom section).
  *
- * Listed here so fork-specific OSM rules stay out of modules/svg/tag_classes.js.
+ * Listed here so fork-specific OSM keys and access rules stay out of modules/svg/tag_classes.js.
  */
+
+/** Extra secondary OSM keys → `tag-{key}` and `tag-{key}-{value}` (do not duplicate upstream secondaries). */
+export const customSecondaryTagKeys = [
+    'cycleway'
+];
 
 /**
  * Exact tag matches → one class each (without `tag-` prefix).
@@ -13,15 +18,68 @@ export const customExactTagClasses = [
 ];
 
 /**
+ * OSM keys mapped to a CSS class prefix → `tag-{prefix}-{value}`.
+ * @type {{ keys: string[], prefix: string }[]}
+ */
+export const customAccessClassPrefixes = [
+    { keys: ['access'], prefix: 'access' },
+    { keys: ['foot', 'routing:foot'], prefix: 'foot' },
+    { keys: ['motor_vehicle', 'routing:motor_vehicle'], prefix: 'motor_vehicle' },
+    { keys: ['bus'], prefix: 'routing:bus' },
+    { keys: ['psv'], prefix: 'routing:psv' },
+    { keys: ['bicycle'], prefix: 'routing:bicycle' }
+];
+
+/** Access values that trigger wider motor-road casing (`tag-custom-access-emphasis`). */
+export const customAccessEmphasisValues = ['private', 'customers', 'permissive'];
+
+/** `highway=*` values excluded from motor-road access emphasis (footways, paths, etc.). */
+export const customAccessEmphasisExcludeHighways = [
+    'footway', 'path', 'cycleway', 'steps'
+];
+
+/** Class name added on motor roads when access emphasis applies (without `tag-` prefix). */
+export const customAccessEmphasisClass = 'custom-access-emphasis';
+
+/**
  * Append fork-specific tag classes for custom map styling.
  *
  * @param {string[]} classes
  * @param {Record<string, string>} t entity tags
  */
 export function appendCustomTagClasses(classes, t) {
+    const emphasisValues = new Set(customAccessEmphasisValues);
+    const excludeHighways = new Set(customAccessEmphasisExcludeHighways);
+
     for (const { key, value, class: className } of customExactTagClasses) {
         if (t[key] === value) {
             classes.push('tag-' + className);
         }
+    }
+
+    for (const { keys, prefix } of customAccessClassPrefixes) {
+        for (const key of keys) {
+            const value = t[key];
+            if (value && value !== 'no') {
+                classes.push('tag-' + prefix + '-' + value);
+            }
+        }
+    }
+
+    const highway = t.highway;
+    if (!highway || excludeHighways.has(highway)) return;
+
+    const access = t.access;
+    const motorVehicle = t.motor_vehicle || t['routing:motor_vehicle'];
+    const routingMotorVehicle = t['routing:motor_vehicle'];
+    const serviceAccess = highway === 'service' && emphasisValues.has(t.service);
+    const emphasized =
+        emphasisValues.has(access) ||
+        emphasisValues.has(motorVehicle) ||
+        emphasisValues.has(routingMotorVehicle) ||
+        serviceAccess;
+
+    if (emphasized) {
+        classes.push('tag-' + customAccessEmphasisClass);
     }
 }

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -745,3 +745,17 @@ g.midpoint.tag-highway-bridleway .fill {
     stroke-opacity: .8;
     opacity: .8;
 }
+
+/* -----------------------------------------------------------------------------
+ * Chaire Mobilité iD fork — placement=transition (wider road, v5 parity)
+ * Depends on config/tag_classes_custom.js and appendCustomTagClasses().
+ * ----------------------------------------------------------------------------- */
+path.line.shadow.tag-highway.tag-placement-transition {
+    stroke-width: 24;
+}
+path.line.casing.tag-highway.tag-placement-transition {
+    stroke-width: 14 !important;
+}
+path.line.stroke.tag-highway.tag-placement-transition {
+    stroke-width: 12;
+}

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -747,9 +747,161 @@ g.midpoint.tag-highway-bridleway .fill {
 }
 
 /* -----------------------------------------------------------------------------
- * Chaire Mobilité iD fork — placement=transition (wider road, v5 parity)
- * Depends on config/tag_classes_custom.js and appendCustomTagClasses().
+ * Chaire Mobilité iD fork — highway map styling (v5 parity)
+ *
+ * Not in upstream iD. Depends on config/tag_classes_custom.js and
+ * appendCustomTagClasses() in modules/svg/tag_classes.js.
  * ----------------------------------------------------------------------------- */
+
+/* Motor roads: colored casing; exclude footways and paths */
+path.line.casing.tag-access-customers:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-customers:not(.tag-highway-footway):not(.tag-highway-path) {
+    stroke: rgb(255, 136, 0) !important;
+}
+path.line.casing.tag-access-private:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-private:not(.tag-highway-footway):not(.tag-highway-path) {
+    stroke: rgb(205, 20, 20) !important;
+}
+path.line.casing.tag-access-permissive:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-permissive:not(.tag-highway-footway):not(.tag-highway-path) {
+    stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-service.tag-service-private,
+path.line.casing.tag-service-private {
+    stroke: rgb(205, 20, 20);
+}
+path.line.casing.tag-highway-service.tag-service-customers,
+path.line.casing.tag-service-customers {
+    stroke: rgb(255, 136, 0);
+}
+path.line.casing.tag-highway-service.tag-service-permissive,
+path.line.casing.tag-service-permissive {
+    stroke: rgb(255, 55, 0);
+}
+path.line.casing.tag-custom-access-emphasis {
+    stroke-width: 11 !important;
+}
+path.line.casing.tag-highway-service.tag-custom-access-emphasis {
+    stroke-width: 8 !important;
+}
+.low-zoom path.line.casing.tag-custom-access-emphasis {
+    stroke-width: 8 !important;
+}
+
+/* Footways / paths: colored dash only; white casing and selection halo (v5) */
+path.line.stroke.tag-highway-footway.tag-access-private,
+path.line.stroke.tag-highway-footway.tag-foot-private,
+path.line.stroke.tag-highway-path.tag-access-private,
+path.line.stroke.tag-highway-path.tag-foot-private {
+    stroke: rgb(205, 20, 20) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-customers,
+path.line.stroke.tag-highway-footway.tag-foot-customers,
+path.line.stroke.tag-highway-path.tag-access-customers,
+path.line.stroke.tag-highway-path.tag-foot-customers {
+    stroke: rgb(255, 136, 0) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-permissive,
+path.line.stroke.tag-highway-footway.tag-foot-permissive,
+path.line.stroke.tag-highway-path.tag-access-permissive,
+path.line.stroke.tag-highway-path.tag-foot-permissive {
+    stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-footway.tag-access-private,
+path.line.casing.tag-highway-footway.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-foot-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-permissive,
+path.line.casing.tag-highway-path.tag-access-private,
+path.line.casing.tag-highway-path.tag-foot-private,
+path.line.casing.tag-highway-path.tag-access-customers,
+path.line.casing.tag-highway-path.tag-foot-customers,
+path.line.casing.tag-highway-path.tag-access-permissive,
+path.line.casing.tag-highway-path.tag-foot-permissive {
+    stroke: #fff !important;
+}
+path.line.shadow.tag-highway-footway.tag-access-private,
+path.line.shadow.tag-highway-footway.tag-foot-private,
+path.line.shadow.tag-highway-footway.tag-access-customers,
+path.line.shadow.tag-highway-footway.tag-foot-customers,
+path.line.shadow.tag-highway-footway.tag-access-permissive,
+path.line.shadow.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.tag-highway-path.tag-access-private,
+path.line.shadow.tag-highway-path.tag-foot-private,
+path.line.shadow.tag-highway-path.tag-access-customers,
+path.line.shadow.tag-highway-path.tag-foot-customers,
+path.line.shadow.tag-highway-path.tag-access-permissive,
+path.line.shadow.tag-highway-path.tag-foot-permissive {
+    stroke: #fff !important;
+}
+path.line.shadow.selected.tag-highway-footway.tag-access-private,
+path.line.shadow.selected.tag-highway-footway.tag-foot-private,
+path.line.shadow.selected.tag-highway-footway.tag-access-customers,
+path.line.shadow.selected.tag-highway-footway.tag-foot-customers,
+path.line.shadow.selected.tag-highway-footway.tag-access-permissive,
+path.line.shadow.selected.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.hover.tag-highway-footway.tag-access-private,
+path.line.shadow.hover.tag-highway-footway.tag-foot-private,
+path.line.shadow.hover.tag-highway-footway.tag-access-customers,
+path.line.shadow.hover.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-private,
+path.line.shadow.related.tag-highway-footway.tag-foot-private,
+path.line.shadow.related.tag-highway-footway.tag-access-customers,
+path.line.shadow.related.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-permissive,
+path.line.shadow.related.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.selected.tag-highway-path.tag-access-private,
+path.line.shadow.selected.tag-highway-path.tag-foot-private,
+path.line.shadow.selected.tag-highway-path.tag-access-customers,
+path.line.shadow.selected.tag-highway-path.tag-foot-customers,
+path.line.shadow.hover.tag-highway-path.tag-access-private,
+path.line.shadow.hover.tag-highway-path.tag-foot-private,
+path.line.shadow.hover.tag-highway-path.tag-access-customers,
+path.line.shadow.hover.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-private,
+path.line.shadow.related.tag-highway-path.tag-foot-private,
+path.line.shadow.related.tag-highway-path.tag-access-customers,
+path.line.shadow.related.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-permissive,
+path.line.shadow.related.tag-highway-path.tag-foot-permissive {
+    stroke: #fff !important;
+    stroke-opacity: 0.45 !important;
+}
+
+/* footway=link / cycleway=link — continuous lines (v5) */
+path.line.stroke.tag-highway-footway.tag-footway-link,
+path.line.stroke.tag-highway-footway.tag-footway-link.tag-unpaved {
+    stroke: rgb(255, 241, 202);
+    opacity: 0.5 !important;
+    stroke-linecap: butt;
+    stroke-dasharray: none !important;
+}
+path.line.casing.tag-highway-footway.tag-footway-link,
+path.line.casing.tag-highway-footway.tag-footway-link.tag-unpaved {
+    opacity: 0.5 !important;
+}
+path.line.stroke.tag-cycleway-link,
+path.line.stroke.tag-highway-cycleway.tag-cycleway-link,
+path.line.stroke.tag-highway-path.tag-cycleway-link {
+    opacity: 0.5 !important;
+    stroke: rgb(4, 0, 255) !important;
+    stroke-linecap: butt;
+    stroke-dasharray: none !important;
+}
+path.line.casing.tag-cycleway-link,
+path.line.casing.tag-highway-cycleway.tag-cycleway-link,
+path.line.casing.tag-highway-path.tag-cycleway-link {
+    opacity: 0.5 !important;
+}
+
+/* placement=transition — wider road (+4px on shadow, casing, stroke) */
 path.line.shadow.tag-highway.tag-placement-transition {
     stroke-width: 24;
 }

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -1,5 +1,8 @@
 import { select as d3_select } from 'd3-selection';
-import { appendCustomTagClasses } from '../../config/tag_classes_custom.js';
+import {
+    appendCustomTagClasses,
+    customSecondaryTagKeys
+} from '../../config/tag_classes_custom.js';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
 
 
@@ -15,7 +18,8 @@ export function svgTagClasses() {
         'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
-        'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot'
+        'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot',
+        ...customSecondaryTagKeys
     ];
     var _tags = function(entity) { return entity.tags; };
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -1,4 +1,5 @@
 import { select as d3_select } from 'd3-selection';
+import { appendCustomTagClasses } from '../../config/tag_classes_custom.js';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
 
 
@@ -148,6 +149,8 @@ export function svgTagClasses() {
         if (qid) {
             classes.push('tag-wikidata');
         }
+
+        appendCustomTagClasses(classes, t);
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -82,6 +82,13 @@ describe('iD.svgTagClasses', function () {
         expect(selection.classed('tag-placement-transition')).to.be.true;
     });
 
+    it('adds cycleway=link secondary classes (custom fork)', function() {
+        selection
+            .datum(new iD.osmWay({tags: {highway: 'cycleway', cycleway: 'link'}}))
+            .call(iD.svgTagClasses());
+        expect(selection.classed('tag-cycleway-link')).to.be.true;
+    });
+
     it('adds no bridge=no tags', function() {
         selection
             .datum(new iD.osmWay({tags: {bridge: 'no'}}))

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -75,6 +75,13 @@ describe('iD.svgTagClasses', function () {
         expect(selection.attr('class')).to.equal('tag-railway tag-railway-rail tag-bridge tag-bridge-yes');
     });
 
+    it('adds placement=transition class (custom fork)', function() {
+        selection
+            .datum(new iD.osmWay({tags: {highway: 'secondary', placement: 'transition'}}))
+            .call(iD.svgTagClasses());
+        expect(selection.classed('tag-placement-transition')).to.be.true;
+    });
+
     it('adds no bridge=no tags', function() {
         selection
             .datum(new iD.osmWay({tags: {bridge: 'no'}}))


### PR DESCRIPTION
## Summary

Restore Transition v5 map styling on v6 via `config/tag_classes_custom.js` and a small hook in `modules/svg/tag_classes.js`:

- **Access** — `tag-access-*`, `tag-foot-*`, `tag-motor_vehicle-*`, routing keys (bus, psv, bicycle); colored casing on motor roads (private red, customers orange, permissive); wider casing (`tag-custom-access-emphasis`) on motor roads; colored stroke + white casing/shadow on footways and paths
- **Links** — `footway=link` (cream continuous line), `cycleway=link` (blue continuous line) via secondary `cycleway`
- **placement=transition** — wider shadow/casing/stroke (+4 px vs v6 defaults: 24 / 14 / 12)

Fork CSS lives at the end of `css/30_highways.css` (section comment).

## Test plan

- [ ] `npx vitest run test/spec/svg/tag_classes.js -t custom`
- [ ] Residential `access=private` / `customers` — red/orange casing, slightly wider
- [ ] Footway/path with restricted access — colored centerline, white halo on select
- [ ] `footway=link` and `cycleway=link` — solid styled lines
- [ ] `placement=transition` on a highway — visibly wider than without