### PR TITLE
Presets: add footway crossings and generic foot path bicycle access.

### DIFF
--- a/data/custom-tagging/src/presets/highway/footway/bicycle_dismount_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/bicycle_dismount_variants.ts
@@ -1,0 +1,65 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+
+const BICYCLE_DISMOUNT_REFERENCE = { key: 'footway', value: 'footway_bicycle_dismount' } as const;
+const BICYCLE_YES_REFERENCE = { key: 'footway', value: 'footway_bicycle_yes' } as const;
+
+interface BicycleDismountVariant {
+    id: string;
+    surface?: 'asphalt' | 'concrete';
+}
+
+const BICYCLE_DISMOUNT_VARIANTS: BicycleDismountVariant[] = [
+    { id: 'highway/footway/bicycle_dismount_asphalt', surface: 'asphalt' },
+    { id: 'highway/footway/bicycle_dismount_concrete', surface: 'concrete' },
+    { id: 'highway/footway/bicycle_dismount_other' }
+];
+
+function bicycleDismountPreset(variant: BicycleDismountVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'footway',
+        bicycle: 'dismount'
+    };
+    const addTags: Record<string, string> = { ...tags };
+    if (variant.surface) {
+        tags.surface = variant.surface;
+        addTags.surface = variant.surface;
+    }
+
+    return {
+        icon: 'temaki-pedestrian',
+        geometry: ['line'],
+        fields: ['{highway/footway}'],
+        moreFields: ['{highway/footway}'],
+        tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, { access: ANY, footway: ANY }),
+        matchScore: 2,
+        reference: BICYCLE_DISMOUNT_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+function bicycleYesPreset(): CustomPreset {
+    const tags = { highway: 'footway', bicycle: 'yes' as const };
+    const addTags = { ...tags, surface: 'asphalt' };
+
+    return {
+        icon: 'temaki-pedestrian',
+        geometry: ['line'],
+        fields: ['{highway/footway}'],
+        moreFields: ['{highway/footway}'],
+        tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, { access: ANY, footway: ANY }),
+        matchScore: 2,
+        reference: BICYCLE_YES_REFERENCE,
+        name: presetNameEn('highway/footway/bicycle_yes')
+    };
+}
+
+export const bicycleDismountVariantPresets: Record<string, CustomPreset> = {
+    ...Object.fromEntries(BICYCLE_DISMOUNT_VARIANTS.map((v) => [v.id, bicycleDismountPreset(v)] as const)),
+    'highway/footway/bicycle_yes': bicycleYesPreset()
+};

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
@@ -1,0 +1,38 @@
+/** Field lists aligned with upstream `highway/footway/crossing/*` presets. */
+export const FOOTWAY_CROSSING_TRAFFIC_SIGNALS_FIELDS = [
+    'crossing',
+    '{@templates/crossing/traffic_signal}',
+    '{@templates/crossing/markings}',
+    'surface'
+] as const;
+
+export const FOOTWAY_CROSSING_UNCONTROLLED_FIELDS = [
+    'crossing',
+    '{@templates/crossing/markings_yes}',
+    'surface'
+] as const;
+
+export const FOOTWAY_CROSSING_UNMARKED_FIELDS = [
+    'crossing',
+    'surface'
+] as const;
+
+/** Unmarked crossings with `access` (use `access_restricted` field). */
+export const FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS = [
+    'crossing',
+    'surface',
+    'access_restricted'
+] as const;
+
+export const FOOTWAY_CROSSING_MORE_FIELDS = [
+    '{@templates/crossing/defaults}',
+    '{@templates/crossing/geometry_way_more}',
+    'flashing_lights'
+] as const;
+
+export const FOOTWAY_CROSSING_TRAFFIC_SIGNALS_MORE_FIELDS = [
+    '{@templates/crossing/traffic_signal_more}',
+    ...FOOTWAY_CROSSING_MORE_FIELDS
+] as const;
+
+export const FOOTWAY_CROSSING_REFERENCE = { key: 'footway', value: 'crossing' } as const;

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
@@ -1,0 +1,186 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+import {
+    FOOTWAY_CROSSING_MORE_FIELDS,
+    FOOTWAY_CROSSING_REFERENCE,
+    FOOTWAY_CROSSING_TRAFFIC_SIGNALS_FIELDS,
+    FOOTWAY_CROSSING_TRAFFIC_SIGNALS_MORE_FIELDS,
+    FOOTWAY_CROSSING_UNCONTROLLED_FIELDS,
+    FOOTWAY_CROSSING_UNMARKED_FIELDS,
+    FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS
+} from './footway_crossing_fields';
+
+type CrossingType = 'traffic_signals' | 'uncontrolled' | 'unmarked';
+type MarkingSlug = 'dots' | 'lines' | 'zebra' | 'surface' | 'dashes' | 'other' | 'no';
+
+interface FootwayCrossingVariant {
+    id: string;
+    crossing: CrossingType;
+    markings: MarkingSlug;
+    icon: string;
+}
+
+/** OSM `crossing:markings` value; `other` omits the key (unspecified markings). */
+const MARKING_TAG: Record<MarkingSlug, string | null> = {
+    dots: 'dots',
+    lines: 'lines',
+    zebra: 'zebra',
+    surface: 'surface',
+    dashes: 'dashes',
+    other: null,
+    no: 'no'
+};
+
+function footwayCrossingIcon(marking: MarkingSlug): string {
+    if (marking === 'zebra') {
+        return 'temaki-pedestrian_crosswalk';
+    }
+    return 'temaki-pedestrian';
+}
+
+function buildVariantList(): FootwayCrossingVariant[] {
+    const trafficMarkings: MarkingSlug[] = ['dots', 'lines', 'zebra', 'surface', 'dashes', 'other'];
+    const uncontrolledMarkings: MarkingSlug[] = ['dots', 'lines', 'zebra', 'surface', 'dashes', 'other'];
+    const variants: FootwayCrossingVariant[] = [];
+
+    variants.push({
+        id: 'highway/footway/crossing/traffic_signals',
+        crossing: 'traffic_signals',
+        markings: 'no',
+        icon: footwayCrossingIcon('no')
+    });
+    for (const markings of trafficMarkings) {
+        variants.push({
+            id: `highway/footway/crossing/traffic_signals-${markings}`,
+            crossing: 'traffic_signals',
+            markings,
+            icon: footwayCrossingIcon(markings)
+        });
+    }
+    for (const markings of uncontrolledMarkings) {
+        variants.push({
+            id: `highway/footway/crossing/uncontrolled-${markings}`,
+            crossing: 'uncontrolled',
+            markings,
+            icon: footwayCrossingIcon(markings)
+        });
+    }
+    variants.push({
+        id: 'highway/footway/crossing/unmarked',
+        crossing: 'unmarked',
+        markings: 'no',
+        icon: footwayCrossingIcon('no')
+    });
+    return variants;
+}
+
+interface UnmarkedExtraVariant {
+    id: string;
+    extraTags: Record<string, string>;
+    fields: readonly string[];
+    removeWildcards?: Record<string, typeof ANY>;
+}
+
+/** v5 unmarked footway crossings (surface or access variants). */
+const UNMARKED_EXTRA_VARIANTS: UnmarkedExtraVariant[] = [
+    {
+        id: 'highway/footway/crossing/unmarked_asphalt',
+        extraTags: { surface: 'asphalt' },
+        fields: FOOTWAY_CROSSING_UNMARKED_FIELDS
+    },
+    {
+        id: 'highway/footway/crossing/unmarked_concrete',
+        extraTags: { surface: 'concrete' },
+        fields: FOOTWAY_CROSSING_UNMARKED_FIELDS
+    },
+    {
+        id: 'highway/footway/crossing/unmarked_customers',
+        extraTags: { access: 'customers' },
+        fields: FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    },
+    {
+        id: 'highway/footway/crossing/unmarked_private',
+        extraTags: { access: 'private' },
+        fields: FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    }
+];
+
+const FOOTWAY_CROSSING_REMOVE_WILDCARDS = { bicycle: ANY, foot: ANY, segregated: ANY } as const;
+
+function unmarkedExtraPreset(variant: UnmarkedExtraVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'footway',
+        footway: 'crossing',
+        crossing: 'unmarked',
+        'crossing:markings': 'no',
+        ...variant.extraTags
+    };
+
+    return {
+        icon: 'temaki-pedestrian',
+        geometry: ['line'],
+        fields: [...variant.fields],
+        moreFields: [...FOOTWAY_CROSSING_MORE_FIELDS],
+        tags,
+        addTags: { ...tags },
+        removeTags: buildRemoveTags({ ...tags }, variant.removeWildcards ?? FOOTWAY_CROSSING_REMOVE_WILDCARDS),
+        matchScore: 2,
+        reference: FOOTWAY_CROSSING_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+function footwayCrossingFields(crossing: CrossingType): readonly string[] {
+    if (crossing === 'traffic_signals') {
+        return FOOTWAY_CROSSING_TRAFFIC_SIGNALS_FIELDS;
+    }
+    if (crossing === 'uncontrolled') {
+        return FOOTWAY_CROSSING_UNCONTROLLED_FIELDS;
+    }
+    return FOOTWAY_CROSSING_UNMARKED_FIELDS;
+}
+
+function footwayCrossingMoreFields(crossing: CrossingType): readonly string[] {
+    if (crossing === 'traffic_signals') {
+        return FOOTWAY_CROSSING_TRAFFIC_SIGNALS_MORE_FIELDS;
+    }
+    return FOOTWAY_CROSSING_MORE_FIELDS;
+}
+
+function footwayCrossingPreset(variant: FootwayCrossingVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'footway',
+        footway: 'crossing',
+        crossing: variant.crossing
+    };
+    const markingTag = MARKING_TAG[variant.markings];
+    if (markingTag) {
+        tags['crossing:markings'] = markingTag;
+    }
+
+    const addTags: Record<string, string> = {
+        ...tags,
+        surface: 'asphalt'
+    };
+
+    return {
+        icon: variant.icon,
+        geometry: ['line'],
+        fields: [...footwayCrossingFields(variant.crossing)],
+        moreFields: [...footwayCrossingMoreFields(variant.crossing)],
+        tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, FOOTWAY_CROSSING_REMOVE_WILDCARDS),
+        matchScore: 2,
+        reference: FOOTWAY_CROSSING_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+export const footwayCrossingVariantPresets: Record<string, CustomPreset> = {
+    ...Object.fromEntries(buildVariantList().map((v) => [v.id, footwayCrossingPreset(v)] as const)),
+    ...Object.fromEntries(UNMARKED_EXTRA_VARIANTS.map((v) => [v.id, unmarkedExtraPreset(v)] as const))
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -2,8 +2,10 @@ import { accessRestricted } from './fields/access_restricted';
 import { capacityCharging } from './fields/capacity_charging';
 import { parkingCondition } from './fields/parking_condition';
 import { placement } from './fields/placement';
+import { bicycleDismountVariantPresets } from './presets/highway/footway/bicycle_dismount_variants';
 import { accessAisleVariantPresets } from './presets/highway/footway/access_aisle_variants';
 import { footwayLinkVariantPresets } from './presets/highway/footway/footway_link_variants';
+import { footwayCrossingVariantPresets } from './presets/highway/footway/footway_crossing_variants';
 import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
@@ -27,9 +29,11 @@ export const customTemplates: Record<string, CustomTemplatePreset> = {
 
 /** Preset path (e.g. `highway/footway/footway_link_bicycle_dismount`) → definition under `presets/`. */
 export const customPresets: Record<string, CustomPreset> = {
+    ...bicycleDismountVariantPresets,
     ...accessAisleVariantPresets,
     ...footwayLinkVariantPresets,
     ...sidewalkVariantPresets,
+    ...footwayCrossingVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -259,6 +259,116 @@
         "aliases": "cl",
         "terms": "cl, cycleway link, link, connector, connection, cycleway connector"
     },
+    "highway/footway/crossing/traffic_signals": {
+        "name": "Traffic Signals Footway Crossing (No Markings)",
+        "terms": "tsn, tr, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, no marking crossing",
+        "aliases": "tsn"
+    },
+    "highway/footway/crossing/traffic_signals-dashes": {
+        "name": "Traffic Signals Dashes Footway Crossing",
+        "terms": "tsdcns, tsd, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, dashes crossing, dashes",
+        "aliases": "tsdcns"
+    },
+    "highway/footway/crossing/traffic_signals-dots": {
+        "name": "Traffic Signals Dots Footway Crossing",
+        "terms": "tsdns, tsd, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, dots crossing, dots",
+        "aliases": "tsdns"
+    },
+    "highway/footway/crossing/traffic_signals-lines": {
+        "name": "Traffic Signals Lines Footway Crossing (Lines)",
+        "terms": "tslns, tsl, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, lines crossing, lines",
+        "aliases": "tslns"
+    },
+    "highway/footway/crossing/traffic_signals-other": {
+        "name": "Traffic Signals Footway Crossing (Other)",
+        "terms": "tsons, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, other marking",
+        "aliases": "tsons"
+    },
+    "highway/footway/crossing/traffic_signals-surface": {
+        "name": "Traffic Signals Surface Footway Crossing",
+        "terms": "tssns, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, surface change crossing, surface",
+        "aliases": "tssns"
+    },
+    "highway/footway/crossing/traffic_signals-zebra": {
+        "name": "Traffic Signals Zebra Footway Crossing",
+        "terms": "tszns, tsz, footway crossing, traffic signals footway crossing, traffic signals crosswalk, traffic signals pedestrian crossing, zebra crossing, zebra",
+        "aliases": "tszns"
+    },
+    "highway/footway/crossing/uncontrolled-dashes": {
+        "name": "Uncontrolled Dashes Footway Crossing",
+        "terms": "udns, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, dashes crossing, dashes",
+        "aliases": "udns"
+    },
+    "highway/footway/crossing/uncontrolled-dots": {
+        "name": "Uncontrolled Dots Footway Crossing (Dots)",
+        "terms": "udons, udns, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, dots crossing, dots",
+        "aliases": "udons"
+    },
+    "highway/footway/crossing/uncontrolled-lines": {
+        "name": "Uncontrolled Lines Footway Crossing (Lines)",
+        "terms": "ulns, ul, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, lines crossing, lines",
+        "aliases": "ulns"
+    },
+    "highway/footway/crossing/uncontrolled-other": {
+        "name": "Uncontrolled Footway Crossing (Other)",
+        "terms": "ucons, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, other marking",
+        "aliases": "ucons"
+    },
+    "highway/footway/crossing/uncontrolled-surface": {
+        "name": "Uncontrolled Surface Footway Crossing",
+        "terms": "usurf, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, surface change crossing, surface",
+        "aliases": "usurf"
+    },
+    "highway/footway/crossing/uncontrolled-zebra": {
+        "name": "Uncontrolled Zebra Footway Crossing",
+        "terms": "uzns, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra",
+        "aliases": "uzns"
+    },
+    "highway/footway/crossing/unmarked": {
+        "name": "Unmarked Footway Crossing",
+        "terms": "uns, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing",
+        "aliases": "uns"
+    },
+    "highway/footway/crossing/unmarked_asphalt": {
+        "name": "Unmarked Footway Crossing (Asphalt)",
+        "terms": "una, un, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, asphalt",
+        "aliases": "una"
+    },
+    "highway/footway/crossing/unmarked_concrete": {
+        "name": "Unmarked Footway Crossing (Concrete)",
+        "terms": "unc, un, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, concrete",
+        "aliases": "unc"
+    },
+    "highway/footway/crossing/unmarked_customers": {
+        "name": "Unmarked Footway Crossing (Customers)",
+        "terms": "ucn, uc, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, customers",
+        "aliases": "ucn"
+    },
+    "highway/footway/crossing/unmarked_private": {
+        "name": "Unmarked Footway Crossing (Private)",
+        "terms": "unp, up, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, private",
+        "aliases": "unp"
+    },
+    "highway/footway/bicycle_dismount_asphalt": {
+        "name": "Foot path (bicycle dismount asphalt)",
+        "terms": "bda, footway, foot path, pedestrian path, bicycle dismount, dismount, asphalt",
+        "aliases": "bda"
+    },
+    "highway/footway/bicycle_dismount_concrete": {
+        "name": "Foot path (bicycle dismount concrete)",
+        "terms": "bdc, footway, foot path, pedestrian path, bicycle dismount, dismount, concrete",
+        "aliases": "bdc"
+    },
+    "highway/footway/bicycle_dismount_other": {
+        "name": "Foot path (bicycle dismount)",
+        "terms": "bdo, footway, foot path, pedestrian path, bicycle dismount, dismount",
+        "aliases": "bdo"
+    },
+    "highway/footway/bicycle_yes": {
+        "name": "Foot path (bicycle yes)",
+        "terms": "fby, footway, foot path, pedestrian path, bicycle yes, cycling",
+        "aliases": "fby"
+    },
     "highway/footway/access_aisle": {
         "name": "Access aisle",
         "terms": "aa, access aisle, parking aisle, striped zone, wheelchair aisle",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -259,6 +259,116 @@
         "aliases": "cl",
         "terms": "cl, lc, lien, liaison, liaison cyclable, lien cyclable"
     },
+    "highway/footway/crossing/traffic_signals": {
+        "name": "Traversée piétonne — Feux, sans marquage",
+        "terms": "tsn, tr, traversée piétonne, passage piéton, traversée, feux, feux de circulation, signalisation, sans marquage",
+        "aliases": "tsn"
+    },
+    "highway/footway/crossing/traffic_signals-dashes": {
+        "name": "Traversée piétonne — Feux, tirets",
+        "terms": "tsdcns, tsdashns, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, tirets, marquage en tirets",
+        "aliases": "tsdcns"
+    },
+    "highway/footway/crossing/traffic_signals-dots": {
+        "name": "Traversée piétonne — Feux, pointillés",
+        "terms": "tsdns, tsdns, dtns, dts, td, tdns, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, pointillés, marquage pointillé",
+        "aliases": "tsdns"
+    },
+    "highway/footway/crossing/traffic_signals-lines": {
+        "name": "Traversée piétonne — Feux, lignes",
+        "terms": "tslns, tslns, tsl, ltns, tl, tlns, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, lignes, marquage en lignes",
+        "aliases": "tslns"
+    },
+    "highway/footway/crossing/traffic_signals-other": {
+        "name": "Traversée piétonne — Feux, autre",
+        "terms": "tsons, tsnso, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, autre marquage, marquage autre",
+        "aliases": "tsons"
+    },
+    "highway/footway/crossing/traffic_signals-surface": {
+        "name": "Traversée piétonne — Feux, changement de surface",
+        "terms": "tssns, tssurfns, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, changement de surface",
+        "aliases": "tssns"
+    },
+    "highway/footway/crossing/traffic_signals-zebra": {
+        "name": "Traversée piétonne — Feux, zébrée",
+        "terms": "tszns, tszns, tsz, ztns, zts, tz, tzns, traversée piétonne, passage piéton, passage piéton, traversée, feux, feux de circulation, signalisation, zébrée, passage zébré, bandes zébrées",
+        "aliases": "tszns"
+    },
+    "highway/footway/crossing/uncontrolled-dashes": {
+        "name": "Traversée piétonne — Non contrôlé, tirets",
+        "terms": "udns, ucdashns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, tirets, marquage en tirets",
+        "aliases": "udns"
+    },
+    "highway/footway/crossing/uncontrolled-dots": {
+        "name": "Traversée piétonne — Non contrôlé, pointillés",
+        "terms": "udons, udns, ud, ucdns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, pointillés, marquage pointillé",
+        "aliases": "udons"
+    },
+    "highway/footway/crossing/uncontrolled-lines": {
+        "name": "Traversée piétonne — Non contrôlé, lignes",
+        "terms": "ulns, ulns, ul, uclns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, lignes, marquage en lignes",
+        "aliases": "ulns"
+    },
+    "highway/footway/crossing/uncontrolled-other": {
+        "name": "Traversée piétonne — Non contrôlé, autre",
+        "terms": "ucons, ucons, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, autre marquage, marquage autre",
+        "aliases": "ucons"
+    },
+    "highway/footway/crossing/uncontrolled-surface": {
+        "name": "Traversée piétonne — Non contrôlé, changement de surface",
+        "terms": "usurf, traversée piétonne, passage piéton, traversée, non contrôlé, sans signalisation, changement de surface, surface",
+        "aliases": "usurf"
+    },
+    "highway/footway/crossing/uncontrolled-zebra": {
+        "name": "Traversée piétonne — Non contrôlé, zébrée",
+        "terms": "uzns, uzns, uz, zns, zuns, uczns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, zébrée, passage zébré, bandes zébrées",
+        "aliases": "uzns"
+    },
+    "highway/footway/crossing/unmarked": {
+        "name": "Traversée piétonne — Non marqué",
+        "terms": "uns, uns, un, traversée piétonne, passage piéton, passage piéton, traversée, non marqué, sans marquage",
+        "aliases": "uns"
+    },
+    "highway/footway/crossing/unmarked_asphalt": {
+        "name": "Traversée piétonne — Non marqué (asphalte)",
+        "terms": "una, un, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, asphalte",
+        "aliases": "una"
+    },
+    "highway/footway/crossing/unmarked_concrete": {
+        "name": "Traversée piétonne — Non marqué (béton)",
+        "terms": "unc, un, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, béton",
+        "aliases": "unc"
+    },
+    "highway/footway/crossing/unmarked_customers": {
+        "name": "Traversée piétonne — Non marqué (clients)",
+        "terms": "ucn, uc, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, clients",
+        "aliases": "ucn"
+    },
+    "highway/footway/crossing/unmarked_private": {
+        "name": "Traversée piétonne — Non marqué (privé)",
+        "terms": "unp, up, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, privé",
+        "aliases": "unp"
+    },
+    "highway/footway/bicycle_dismount_asphalt": {
+        "name": "Chemin piéton (vélo à pied, asphalte)",
+        "terms": "bda, footway, chemin piéton, sentier, vélo à pied, asphalte",
+        "aliases": "bda"
+    },
+    "highway/footway/bicycle_dismount_concrete": {
+        "name": "Chemin piéton (vélo à pied, béton)",
+        "terms": "bdc, footway, chemin piéton, sentier, vélo à pied, béton",
+        "aliases": "bdc"
+    },
+    "highway/footway/bicycle_dismount_other": {
+        "name": "Chemin piéton (vélo à pied)",
+        "terms": "bdo, footway, chemin piéton, sentier, vélo à pied",
+        "aliases": "bdo"
+    },
+    "highway/footway/bicycle_yes": {
+        "name": "Chemin piéton (vélo autorisé)",
+        "terms": "fby, footway, chemin piéton, sentier, vélo autorisé, cyclisme",
+        "aliases": "fby"
+    },
     "highway/footway/access_aisle": {
         "name": "Voie de circulation (allée)",
         "terms": "aa, vca, voie de circulation, allée, zone hachurée, stationnement",

--- a/test/spec/presets/custom/footway.js
+++ b/test/spec/presets/custom/footway.js
@@ -88,6 +88,25 @@ describe('custom presets — footway', function() {
         expect(tags).to.not.have.property('bicycle');
     });
 
+    it('defines footway bicycle yes preset tags', function() {
+        const yes = iD.presetManager.item('highway/footway/bicycle_yes');
+        expect(yes, 'footway bicycle yes').to.exist;
+        expect(yes.tags).to.include({ highway: 'footway', bicycle: 'yes' });
+        expect(yes.tags).to.not.have.property('footway');
+        expect(yes.addTags.surface).to.equal('asphalt');
+    });
+
+    it('defines bicycle dismount footway presets by surface', function() {
+        const asphalt = iD.presetManager.item('highway/footway/bicycle_dismount_asphalt');
+        const concrete = iD.presetManager.item('highway/footway/bicycle_dismount_concrete');
+        const other = iD.presetManager.item('highway/footway/bicycle_dismount_other');
+        expect(asphalt.tags).to.include({ highway: 'footway', bicycle: 'dismount', surface: 'asphalt' });
+        expect(concrete.tags).to.include({ surface: 'concrete' });
+        expect(other.tags).to.include({ bicycle: 'dismount' });
+        expect(other.tags).to.not.have.property('surface');
+        expect(other.tags).to.not.have.property('footway');
+    });
+
     it('defines sidewalk bicycle dismount and yes preset tags', function() {
         const dismount = iD.presetManager.item('highway/footway/sidewalk_bicycle_dismount');
         const yes = iD.presetManager.item('highway/footway/sidewalk_bicycle_yes');

--- a/test/spec/presets/custom/footway_crossing.js
+++ b/test/spec/presets/custom/footway_crossing.js
@@ -1,0 +1,65 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — footway crossing', function() {
+    loadCustomPresets();
+
+    it('defines traffic signals footway crossing without markings', function() {
+        const preset = iD.presetManager.item('highway/footway/crossing/traffic_signals');
+        expect(preset, 'traffic signals no markings').to.exist;
+        expect(preset.tags).to.include({
+            crossing: 'traffic_signals',
+            'crossing:markings': 'no'
+        });
+    });
+
+    it('defines traffic signals dots footway crossing preset tags', function() {
+        const preset = iD.presetManager.item('highway/footway/crossing/traffic_signals-dots');
+        expect(preset, 'traffic signals dots').to.exist;
+        expect(preset.name()).to.equal('Traffic Signals Dots Footway Crossing');
+        expect(preset.tags).to.include({
+            highway: 'footway',
+            footway: 'crossing',
+            crossing: 'traffic_signals',
+            'crossing:markings': 'dots'
+        });
+        expect(preset.tags).to.not.have.property('foot');
+        expect(preset.tags).to.not.have.property('segregated');
+        expect(preset.tags).to.not.have.property('bicycle');
+        expect(preset.addable()).to.be.true;
+    });
+
+    it('does not register segregated or no_foot footway crossing presets', function() {
+        expect(iD.presetManager.item('highway/footway/crossing/traffic_signals-dots_not_segregated')).to.be.undefined;
+        expect(iD.presetManager.item('highway/footway/crossing/traffic_signals-dots_no_foot')).to.be.undefined;
+        expect(iD.presetManager.item('highway/footway/crossing/unmarked_segregated')).to.be.undefined;
+    });
+
+    it('finds footway crossing presets via alias search', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        const byAlias = pool.search('tsdns', 'line').collection.map((p) => p.id);
+        expect(byAlias).to.include('highway/footway/crossing/traffic_signals-dots');
+    });
+
+    it('defines uncontrolled surface and omits markings for other variants', function() {
+        const surface = iD.presetManager.item('highway/footway/crossing/uncontrolled-surface');
+        expect(surface.tags).to.include({
+            crossing: 'uncontrolled',
+            'crossing:markings': 'surface'
+        });
+        const other = iD.presetManager.item('highway/footway/crossing/uncontrolled-other');
+        expect(other.tags).to.not.have.property('crossing:markings');
+    });
+
+    it('defines unmarked and surface or access variants', function() {
+        const unmarked = iD.presetManager.item('highway/footway/crossing/unmarked');
+        expect(unmarked.tags).to.include({
+            crossing: 'unmarked',
+            'crossing:markings': 'no'
+        });
+        const asphalt = iD.presetManager.item('highway/footway/crossing/unmarked_asphalt');
+        expect(asphalt.tags).to.include({ surface: 'asphalt' });
+        expect(iD.presetManager.item('highway/footway/crossing/unmarked_customers').tags).to.include({
+            access: 'customers'
+        });
+    });
+});


### PR DESCRIPTION
Add footway/crossing presets (traffic signals, uncontrolled, unmarked) with one variant per marking type plus v5 unmarked asphalt, concrete, customers, and private. Include traffic_signals with crossing:markings=no. Omit no_foot and segregated tags (cycleway-only). Add generic foot path presets for bicycle=dismount (asphalt, concrete, other) and bicycle=yes, with v5-style display names and footway in search terms. Localize EN/FR with footway-specific aliases; add footway_crossing tests and extend footway preset tests.