### PR TITLE
Presets: add customers and private foot path, informal path, and sidewalk variants

### DIFF
--- a/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
@@ -1,0 +1,121 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+import { FOOTWAY_LINK_FIELDS, FOOTWAY_LINK_MORE_FIELDS } from './access_aisle_fields';
+
+const SIDEWALK_REFERENCE = { key: 'footway', value: 'sidewalk' } as const;
+
+type AccessLevel = 'customers' | 'private';
+
+const RESTRICTED_FOOTWAY_FIELDS = [...FOOTWAY_LINK_FIELDS, 'access_restricted'] as const;
+
+const RESTRICTED_REMOVE_WILDCARDS = { bicycle: ANY, footway: ANY, highway: ANY } as const;
+
+interface FootPathVariant {
+    id: string;
+    access: AccessLevel;
+    surface?: 'asphalt' | 'concrete';
+}
+
+const FOOT_PATH_VARIANTS: FootPathVariant[] = [
+    { id: 'highway/footway/customers_asphalt', access: 'customers', surface: 'asphalt' },
+    { id: 'highway/footway/customers_concrete', access: 'customers', surface: 'concrete' },
+    { id: 'highway/footway/customers_other', access: 'customers' },
+    { id: 'highway/footway/private_asphalt', access: 'private', surface: 'asphalt' },
+    { id: 'highway/footway/private_concrete', access: 'private', surface: 'concrete' },
+    { id: 'highway/footway/private_other', access: 'private' }
+];
+
+interface InformalPathVariant {
+    id: string;
+    access: AccessLevel;
+}
+
+const INFORMAL_PATH_VARIANTS: InformalPathVariant[] = [
+    { id: 'highway/footway/customers_informal', access: 'customers' },
+    { id: 'highway/footway/private_informal', access: 'private' }
+];
+
+interface RestrictedSidewalkVariant {
+    id: string;
+    access: AccessLevel;
+}
+
+const RESTRICTED_SIDEWALK_VARIANTS: RestrictedSidewalkVariant[] = [
+    { id: 'highway/footway/customers_sidewalk', access: 'customers' },
+    { id: 'highway/footway/private_sidewalk', access: 'private' }
+];
+
+function footPathPreset(variant: FootPathVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'footway',
+        access: variant.access
+    };
+    if (variant.surface) {
+        tags.surface = variant.surface;
+    }
+
+    return {
+        icon: 'temaki-pedestrian',
+        geometry: ['line'],
+        fields: [...RESTRICTED_FOOTWAY_FIELDS],
+        moreFields: [...FOOTWAY_LINK_MORE_FIELDS],
+        tags,
+        addTags: tags,
+        removeTags: buildRemoveTags(tags, { bicycle: ANY, footway: ANY }),
+        matchScore: 2,
+        reference: { key: 'footway', value: 'footway' },
+        name: presetNameEn(variant.id)
+    };
+}
+
+function informalPathPreset(variant: InformalPathVariant): CustomPreset {
+    const tags = {
+        highway: 'path',
+        informal: 'yes',
+        access: variant.access
+    };
+
+    return {
+        icon: 'iD-other-line',
+        geometry: ['line'],
+        fields: [...RESTRICTED_FOOTWAY_FIELDS],
+        moreFields: [...FOOTWAY_LINK_MORE_FIELDS],
+        tags,
+        addTags: tags,
+        removeTags: buildRemoveTags(tags, RESTRICTED_REMOVE_WILDCARDS),
+        matchScore: 2,
+        name: presetNameEn(variant.id)
+    };
+}
+
+function restrictedSidewalkPreset(variant: RestrictedSidewalkVariant): CustomPreset {
+    const tags = {
+        highway: 'footway',
+        footway: 'sidewalk',
+        access: variant.access
+    };
+    const addTags = {
+        ...tags,
+        surface: 'concrete'
+    };
+
+    return {
+        icon: 'temaki-pedestrian',
+        geometry: ['line'],
+        fields: [...RESTRICTED_FOOTWAY_FIELDS],
+        moreFields: [...FOOTWAY_LINK_MORE_FIELDS],
+        tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, { bicycle: ANY }),
+        matchScore: 2,
+        reference: SIDEWALK_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+export const restrictedFootwayVariantPresets: Record<string, CustomPreset> = {
+    ...Object.fromEntries(FOOT_PATH_VARIANTS.map((v) => [v.id, footPathPreset(v)] as const)),
+    ...Object.fromEntries(INFORMAL_PATH_VARIANTS.map((v) => [v.id, informalPathPreset(v)] as const)),
+    ...Object.fromEntries(RESTRICTED_SIDEWALK_VARIANTS.map((v) => [v.id, restrictedSidewalkPreset(v)] as const))
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -7,6 +7,7 @@ import { accessAisleVariantPresets } from './presets/highway/footway/access_aisl
 import { footwayLinkVariantPresets } from './presets/highway/footway/footway_link_variants';
 import { footwayCrossingVariantPresets } from './presets/highway/footway/footway_crossing_variants';
 import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_variants';
+import { restrictedFootwayVariantPresets } from './presets/highway/footway/restricted_footway_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -32,6 +33,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...bicycleDismountVariantPresets,
     ...accessAisleVariantPresets,
     ...footwayLinkVariantPresets,
+    ...restrictedFootwayVariantPresets,
     ...sidewalkVariantPresets,
     ...footwayCrossingVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -384,6 +384,31 @@
         "terms": "aaby, access aisle, parking aisle, striped zone, wheelchair aisle, bicycle yes, cycling",
         "aliases": "aaby"
     },
+    "highway/footway/customers_informal": {
+        "name": "Customers informal path",
+        "terms": "cfi, footway, informal path, desire path, trail, customers, hiking, walk",
+        "aliases": "cfi"
+    },
+    "highway/footway/customers_asphalt": {
+        "name": "Customers foot path (asphalt)",
+        "terms": "cfas, footway, foot path, pedestrian path, customers, asphalt, hike, trail, walk",
+        "aliases": "cfas"
+    },
+    "highway/footway/customers_concrete": {
+        "name": "Customers foot path (concrete)",
+        "terms": "cfac, footway, foot path, pedestrian path, customers, concrete, hike, trail, walk",
+        "aliases": "cfac"
+    },
+    "highway/footway/customers_other": {
+        "name": "Customers foot path",
+        "terms": "cfo, footway, foot path, pedestrian path, customers, hike, trail, walk, promenade",
+        "aliases": "cfo"
+    },
+    "highway/footway/customers_sidewalk": {
+        "name": "Customers sidewalk",
+        "terms": "csw, sidewalk, pavement, sidepath, footway, customers",
+        "aliases": "csw"
+    },
     "highway/footway/customers_access_aisle": {
         "name": "Customers access aisle",
         "terms": "caa, access aisle, parking aisle, striped zone, wheelchair aisle, customers",
@@ -403,6 +428,31 @@
         "name": "Footway link bicycle yes",
         "aliases": "flby",
         "terms": "flby, fl, footway link, bicycle yes, link, cycling, connector, connection, footway connector"
+    },
+    "highway/footway/private_informal": {
+        "name": "Private informal path",
+        "terms": "pfi, footway, informal path, desire path, trail, private, hiking, walk",
+        "aliases": "pfi"
+    },
+    "highway/footway/private_asphalt": {
+        "name": "Private foot path (asphalt)",
+        "terms": "pfas, footway, foot path, pedestrian path, private, asphalt, hike, trail, walk",
+        "aliases": "pfas"
+    },
+    "highway/footway/private_concrete": {
+        "name": "Private foot path (concrete)",
+        "terms": "pfac, footway, foot path, pedestrian path, private, concrete, hike, trail, walk",
+        "aliases": "pfac"
+    },
+    "highway/footway/private_other": {
+        "name": "Private foot path",
+        "terms": "pfo, footway, foot path, pedestrian path, private, hike, trail, walk, promenade",
+        "aliases": "pfo"
+    },
+    "highway/footway/private_sidewalk": {
+        "name": "Private sidewalk",
+        "terms": "psw, sidewalk, pavement, sidepath, footway, private",
+        "aliases": "psw"
     },
     "highway/footway/private_access_aisle": {
         "name": "Private access aisle",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -384,6 +384,31 @@
         "terms": "aaby, vcva, voie de circulation, allée, zone hachurée, stationnement, vélo autorisé, cyclisme",
         "aliases": "aaby"
     },
+    "highway/footway/customers_informal": {
+        "name": "Sentier informel — clients",
+        "terms": "cfi, footway, sentier informel, sentier, chemin de traverse, clients, randonnée",
+        "aliases": "cfi"
+    },
+    "highway/footway/customers_asphalt": {
+        "name": "Chemin piéton — clients (asphalte)",
+        "terms": "cfas, footway, chemin piéton, sentier, clients, asphalte, randonnée, marche",
+        "aliases": "cfas"
+    },
+    "highway/footway/customers_concrete": {
+        "name": "Chemin piéton — clients (béton)",
+        "terms": "cfac, footway, chemin piéton, sentier, clients, béton, randonnée, marche",
+        "aliases": "cfac"
+    },
+    "highway/footway/customers_other": {
+        "name": "Chemin piéton — clients",
+        "terms": "cfo, footway, chemin piéton, sentier, clients, randonnée, marche, promenade",
+        "aliases": "cfo"
+    },
+    "highway/footway/customers_sidewalk": {
+        "name": "Trottoir — clients",
+        "terms": "csw, trottoir, bordure, footway, clients",
+        "aliases": "csw"
+    },
     "highway/footway/customers_access_aisle": {
         "name": "Voie de circulation — clients",
         "terms": "caa, vcc, voie de circulation, allée, zone hachurée, stationnement, clients",
@@ -403,6 +428,31 @@
         "name": "Lien piétonnier vélo autorisé",
         "aliases": "flby",
         "terms": "flby, lpvo, lp, lien, liaison, liaison piéton, lien piéton, vélo autorisé, cyclable"
+    },
+    "highway/footway/private_informal": {
+        "name": "Sentier informel — privé",
+        "terms": "pfi, footway, sentier informel, sentier, chemin de traverse, privé, randonnée",
+        "aliases": "pfi"
+    },
+    "highway/footway/private_asphalt": {
+        "name": "Chemin piéton — privé (asphalte)",
+        "terms": "pfas, footway, chemin piéton, sentier, privé, asphalte, randonnée, marche",
+        "aliases": "pfas"
+    },
+    "highway/footway/private_concrete": {
+        "name": "Chemin piéton — privé (béton)",
+        "terms": "pfac, footway, chemin piéton, sentier, privé, béton, randonnée, marche",
+        "aliases": "pfac"
+    },
+    "highway/footway/private_other": {
+        "name": "Chemin piéton — privé",
+        "terms": "pfo, footway, chemin piéton, sentier, privé, randonnée, marche, promenade",
+        "aliases": "pfo"
+    },
+    "highway/footway/private_sidewalk": {
+        "name": "Trottoir — privé",
+        "terms": "psw, trottoir, bordure, footway, privé",
+        "aliases": "psw"
     },
     "highway/footway/private_access_aisle": {
         "name": "Voie de circulation — privé",

--- a/test/spec/presets/custom/footway.js
+++ b/test/spec/presets/custom/footway.js
@@ -29,6 +29,43 @@ describe('custom presets — footway', function() {
 
         const byPflIds = pool.search('pfl', 'line').collection.map((p) => p.id);
         expect(byPflIds).to.include('highway/footway/private_footway_link');
+
+        const byCfas = pool.search('cfas', 'line').collection.map((p) => p.id);
+        expect(byCfas).to.include('highway/footway/customers_asphalt');
+
+        const byCsw = pool.search('csw', 'line').collection.map((p) => p.id);
+        expect(byCsw).to.include('highway/footway/customers_sidewalk');
+    });
+
+    it('defines customers and private foot path presets', function() {
+        const customersAsphalt = iD.presetManager.item('highway/footway/customers_asphalt');
+        const customersOther = iD.presetManager.item('highway/footway/customers_other');
+        const privateConcrete = iD.presetManager.item('highway/footway/private_concrete');
+        expect(customersAsphalt.tags).to.include({
+            highway: 'footway',
+            access: 'customers',
+            surface: 'asphalt'
+        });
+        expect(customersOther.tags).to.include({ highway: 'footway', access: 'customers' });
+        expect(customersOther.tags).to.not.have.property('surface');
+        expect(privateConcrete.tags).to.include({ access: 'private', surface: 'concrete' });
+    });
+
+    it('defines restricted informal path and sidewalk presets', function() {
+        const customersInformal = iD.presetManager.item('highway/footway/customers_informal');
+        const privateSidewalk = iD.presetManager.item('highway/footway/private_sidewalk');
+        expect(customersInformal.tags).to.include({
+            highway: 'path',
+            informal: 'yes',
+            access: 'customers'
+        });
+        expect(privateSidewalk.tags).to.include({
+            highway: 'footway',
+            footway: 'sidewalk',
+            access: 'private'
+        });
+        expect(privateSidewalk.tags).to.not.have.property('bicycle');
+        expect(privateSidewalk.addTags.surface).to.equal('concrete');
     });
 
     it('defines access aisle bicycle yes preset tags', function() {


### PR DESCRIPTION
## Summary

Ports the restricted-access footway presets from the v5 Québec set into the v6 TypeScript-based custom preset pipeline (`data/custom-tagging/src`). All presets are generated from a single source module, `restricted_footway_variants.ts`, and registered in `registry.ts`.

New presets (line geometry, `matchScore: 2`):

- **Foot path** (`highway=footway` + `access=customers|private`), in `asphalt` / `concrete` / unspecified surface variants
- **Informal path** (`highway=path`, `informal=yes` + `access`)
- **Sidewalk** (`highway=footway`, `footway=sidewalk` + `access`, default `surface=concrete`)

Notes on tagging choices (confirmed with the author during review):
- No `motor_vehicle=no` is added (handled by the access field defaults for footways).
- Sidewalk variants do not force `bicycle=no`; `removeTags` still clears a stale `bicycle` when switching presets.

Shared `FOOTWAY_LINK` field lists plus the `access_restricted` field are reused rather than duplicated. EN/FR locale names, aliases (`cfas`, `cfac`, `cfo`, `cfi`, `csw` and the `p*` equivalents) and search terms are added.

## Test plan

- [x] `npm run generate:presets:custom && npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/` (37 passing)
- [ ] Spot-check the new presets appear in the editor search by alias/name