### PR TITLE
Refactor: custom presets cleanup (crossing dedup, references, typing)

### DIFF
--- a/data/custom-tagging/src/presets/highway/crossing_shared.ts
+++ b/data/custom-tagging/src/presets/highway/crossing_shared.ts
@@ -1,0 +1,18 @@
+/** Shared crossing types and marking map for footway and cycleway crossing presets. */
+
+/** Crossing control type (OSM `crossing=*`). */
+export type CrossingType = 'traffic_signals' | 'uncontrolled' | 'unmarked';
+
+/** Crossing marking style; `other` leaves `crossing:markings` unset, `no` means unmarked. */
+export type MarkingSlug = 'dots' | 'lines' | 'zebra' | 'surface' | 'dashes' | 'other' | 'no';
+
+/** OSM `crossing:markings` value per slug; `other` omits the key (unspecified markings). */
+export const MARKING_TAG: Record<MarkingSlug, string | null> = {
+    dots: 'dots',
+    lines: 'lines',
+    zebra: 'zebra',
+    surface: 'surface',
+    dashes: 'dashes',
+    other: null,
+    no: 'no'
+};

--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
@@ -9,9 +9,8 @@ import {
     CYCLEWAY_CROSSING_UNCONTROLLED_FIELDS,
     CYCLEWAY_CROSSING_UNMARKED_FIELDS
 } from './cycleway_crossing_fields';
+import { type CrossingType, type MarkingSlug, MARKING_TAG } from '../crossing_shared';
 
-type CrossingType = 'traffic_signals' | 'uncontrolled' | 'unmarked';
-type MarkingSlug = 'dots' | 'lines' | 'zebra' | 'surface' | 'dashes' | 'other' | 'no';
 type FootMode = 'no_foot' | 'not_segregated' | 'segregated';
 
 interface CyclewayCrossingVariant {
@@ -26,17 +25,6 @@ const FOOT_MODE_TAGS: Record<FootMode, Record<string, string>> = {
     no_foot: { foot: 'no' },
     not_segregated: { foot: 'designated', segregated: 'no' },
     segregated: { foot: 'designated', segregated: 'yes' }
-};
-
-/** OSM `crossing:markings` value; `other` omits the key (unspecified markings). */
-const MARKING_TAG: Record<MarkingSlug, string | null> = {
-    dots: 'dots',
-    lines: 'lines',
-    zebra: 'zebra',
-    surface: 'surface',
-    dashes: 'dashes',
-    other: null,
-    no: 'no'
 };
 
 function cyclewayCrossingIcon(crossing: CrossingType, markings: MarkingSlug): string {

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
@@ -10,9 +10,7 @@ import {
     FOOTWAY_CROSSING_UNMARKED_FIELDS,
     FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS
 } from './footway_crossing_fields';
-
-type CrossingType = 'traffic_signals' | 'uncontrolled' | 'unmarked';
-type MarkingSlug = 'dots' | 'lines' | 'zebra' | 'surface' | 'dashes' | 'other' | 'no';
+import { type CrossingType, type MarkingSlug, MARKING_TAG } from '../crossing_shared';
 
 interface FootwayCrossingVariant {
     id: string;
@@ -20,17 +18,6 @@ interface FootwayCrossingVariant {
     markings: MarkingSlug;
     icon: string;
 }
-
-/** OSM `crossing:markings` value; `other` omits the key (unspecified markings). */
-const MARKING_TAG: Record<MarkingSlug, string | null> = {
-    dots: 'dots',
-    lines: 'lines',
-    zebra: 'zebra',
-    surface: 'surface',
-    dashes: 'dashes',
-    other: null,
-    no: 'no'
-};
 
 function footwayCrossingIcon(marking: MarkingSlug): string {
     if (marking === 'zebra') {

--- a/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
@@ -64,7 +64,7 @@ function footPathPreset(variant: FootPathVariant): CustomPreset {
         addTags: tags,
         removeTags: buildRemoveTags(tags, { bicycle: ANY, footway: ANY }),
         matchScore: 2,
-        reference: { key: 'footway', value: 'footway' },
+        reference: { key: 'highway', value: 'footway' },
         name: presetNameEn(variant.id)
     };
 }

--- a/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/restricted_footway_variants.ts
@@ -61,7 +61,7 @@ function footPathPreset(variant: FootPathVariant): CustomPreset {
         fields: [...RESTRICTED_FOOTWAY_FIELDS],
         moreFields: [...FOOTWAY_LINK_MORE_FIELDS],
         tags,
-        addTags: tags,
+        addTags: { ...tags },
         removeTags: buildRemoveTags(tags, { bicycle: ANY, footway: ANY }),
         matchScore: 2,
         reference: { key: 'highway', value: 'footway' },
@@ -82,7 +82,7 @@ function informalPathPreset(variant: InformalPathVariant): CustomPreset {
         fields: [...RESTRICTED_FOOTWAY_FIELDS],
         moreFields: [...FOOTWAY_LINK_MORE_FIELDS],
         tags,
-        addTags: tags,
+        addTags: { ...tags },
         removeTags: buildRemoveTags(tags, RESTRICTED_REMOVE_WILDCARDS),
         matchScore: 2,
         name: presetNameEn(variant.id)

--- a/data/custom-tagging/src/types.ts
+++ b/data/custom-tagging/src/types.ts
@@ -1,10 +1,41 @@
 /** id-tagging-schema geometry values used by custom presets and fields. */
 export type PresetGeometry = 'point' | 'line' | 'area' | 'vertex' | 'relation';
 
+/** Field input types supported by schema-builder. */
+export type CustomFieldType =
+    | 'access'
+    | 'address'
+    | 'check'
+    | 'combo'
+    | 'date'
+    | 'directionalCombo'
+    | 'email'
+    | 'identifier'
+    | 'lanes'
+    | 'localized'
+    | 'manyCombo'
+    | 'multiCombo'
+    | 'networkCombo'
+    | 'number'
+    | 'radio'
+    | 'roadheight'
+    | 'roadspeed'
+    | 'semiCombo'
+    | 'tel'
+    | 'text'
+    | 'textarea'
+    | 'typeCombo'
+    | 'url'
+    | 'wikidata'
+    | 'wikipedia';
+
+/** Wiki tag reference (key/value) backing a preset documentation link. */
+export type PresetReference = { key: string; value: string };
+
 /** Custom field definition (id-tagging-schema shape). */
 export type CustomField = {
     key: string;
-    type?: string;
+    type?: CustomFieldType;
     label?: string;
     options?: string[];
     minValue?: number;
@@ -23,7 +54,7 @@ export type CustomPreset = {
     name?: string;
     icon?: string;
     matchScore?: number;
-    reference?: { key: string; value: string };
+    reference?: PresetReference;
     searchable?: boolean;
     locationSet?: { include?: string[]; exclude?: string[] };
 };


### PR DESCRIPTION
## Summary

Follow-up review cleanup of the `data/custom-tagging` custom preset code. Four
small, independent commits, no behaviour change except a corrected wiki
reference:

1. **Refactor** — extract the identical `CrossingType`, `MarkingSlug` and
   `MARKING_TAG` into `presets/highway/crossing_shared.ts`, imported by both the
   footway and cycleway crossing modules (removes ~30 duplicated lines).
2. **Fix** — point the customers/private foot path presets at the real
   `highway=footway` wiki tag instead of the synthetic `footway=footway`.
3. **Refactor** — use `addTags: { ...tags }` in the restricted footway builders
   to match the convention used elsewhere (no shared object reference).
4. **Refactor** — replace `CustomField.type?: string` with a `CustomFieldType`
   union of schema-builder field types, and add a named `PresetReference` type.

Only commit 2 changes generated output (one `reference` value); the rest are
source-only and produce identical preset JSON.

## Test plan

- [x] `npm run generate:presets:custom && npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/` (37 passing)
- [x] ESLint clean on touched files