### PR TITLE
Chore: merge upstream develop into v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Add high-resolution toggle for Mapilio photo viewer ([#12353], thanks [@sezerbozbiyik])
 #### :white_check_mark: Validation
 * Fix bug causing first click not focussing the respective features when clicking on a validation message in the upload dialog ([#8848])
+* Check the flow direction of `waterway=pressurised` ([#12386], thanks [@paulklie])
 #### :bug: Bugfixes
 * Restore dedicated rendering of ski pistes and building parts ([#12297], thanks [@matkoniecz])
 * Pressing backspace while in the feature type selecting mode should not delete the object
@@ -71,6 +72,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12337]: https://github.com/openstreetmap/iD/issues/12337
 [#12353]: https://github.com/openstreetmap/iD/pull/12353
 [#12374]: https://github.com/openstreetmap/iD/pull/12374
+[#12386]: https://github.com/openstreetmap/iD/pull/12386
 
 
 # 2.40.0

--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -317,7 +317,7 @@ export const osmRailwayTrackTagValues: Record<TagValue, true> = {
 
 // "waterway" tag values for line features representing water flow
 export const osmFlowingWaterwayTagValues: Record<string, true> = {
-    canal: true, ditch: true, drain: true, fish_pass: true, flowline: true, river: true, stream: true, tidal_channel: true
+    canal: true, ditch: true, drain: true, fish_pass: true, flowline: true, river: true, stream: true, tidal_channel: true, pressurised: true
 };
 
 // Tag values that represent actual land use (areas)

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -140,6 +140,7 @@ export function uiPresetList(context) {
             .attr('class', 'preset-list')
             .call(drawList, presetManager.defaults(entityGeometries()[0], 36, !context.inIntro(), _currLoc, entityPresets));
 
+        listWrap.node().scrollTo({ top: 0 });
         context.features().on('change.preset-list', updateForFeatureHiddenState);
     }
 


### PR DESCRIPTION
## Summary

Merge the two new upstream (`openstreetmap/iD` develop) commits into `v6`. No
conflicts; neither touches the custom preset code.

- **Validate waterway=pressurised flow direction** (#12386) — adds `pressurised`
  to `osmFlowingWaterwayTagValues` so pressurised conduits get flow-direction
  validation.
- **Reset preset list scroll when opening it** (#12393) — `preset_list.js`
  scrolls back to top on open.

## Test plan

- [x] `git merge up/develop` clean (no conflicts)
- [ ] CI green