### PR TITLE
Presets: add road sidewalk / use_sidepath variants (6 highway classes)

### DIFF
--- a/data/custom-tagging/src/presets/highway/street_sidewalk_variants.ts
+++ b/data/custom-tagging/src/presets/highway/street_sidewalk_variants.ts
@@ -1,0 +1,65 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+/** Road classes that get the Québec `foot=use_sidepath` sidewalk variants. */
+const STREETS = ['primary', 'residential', 'secondary', 'tertiary', 'trunk', 'unclassified'] as const;
+
+type SidewalkVariant = 'both' | 'left' | 'right' | 'opposite' | 'no';
+
+const VARIANTS: SidewalkVariant[] = ['both', 'left', 'right', 'opposite', 'no'];
+
+/** Sidewalk tags per variant (added to `highway`, plus `foot=use_sidepath` where it applies). */
+const VARIANT_TAGS: Record<SidewalkVariant, Record<string, string>> = {
+    both: { 'sidewalk:both': 'separate' },
+    left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no' },
+    right: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate' },
+    // Divided road whose sidewalk is mapped along the opposite carriageway.
+    opposite: { sidewalk: 'no', dual_carriageway: 'yes' },
+    // Road with no sidewalk at all (no separate sidepath to use).
+    no: { sidewalk: 'no' }
+};
+
+/** Variants where a separate sidepath exists, so the road carries `foot=use_sidepath`. */
+const USE_SIDEPATH: Record<SidewalkVariant, boolean> = {
+    both: true,
+    left: true,
+    right: true,
+    opposite: true,
+    no: false
+};
+
+/** Preset id: `opposite` keeps the v5 `-opposite-use_sidepath` suffix. */
+function streetId(highway: string, variant: SidewalkVariant): string {
+    return variant === 'opposite'
+        ? `highway/${highway}-opposite-use_sidepath`
+        : `highway/${highway}_sidewalk_${variant}`;
+}
+
+function streetPreset(highway: string, variant: SidewalkVariant): CustomPreset {
+    const useSidepath = USE_SIDEPATH[variant];
+    const tags: Record<string, string> = {
+        highway,
+        ...(useSidepath ? { foot: 'use_sidepath' } : {}),
+        ...VARIANT_TAGS[variant]
+    };
+
+    return {
+        icon: `iD-highway-${highway}`,
+        geometry: ['line'],
+        fields: [`{highway/${highway}}`],
+        moreFields: [`{highway/${highway}}`],
+        tags,
+        addTags: { ...tags, surface: 'asphalt' },
+        // Only force-remove foot=use_sidepath on preset change; sidewalk tags are
+        // managed by the shared sidewalk field, which iD preserves (preserveKeys).
+        removeTags: useSidepath ? { foot: 'use_sidepath' } : {},
+        reference: { key: 'highway', value: highway },
+        name: presetNameEn(streetId(highway, variant))
+    };
+}
+
+export const streetSidewalkVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    STREETS.flatMap((highway) =>
+        VARIANTS.map((variant) => [streetId(highway, variant), streetPreset(highway, variant)] as const)
+    )
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -8,6 +8,7 @@ import { footwayLinkVariantPresets } from './presets/highway/footway/footway_lin
 import { footwayCrossingVariantPresets } from './presets/highway/footway/footway_crossing_variants';
 import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_variants';
 import { restrictedFootwayVariantPresets } from './presets/highway/footway/restricted_footway_variants';
+import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -36,6 +37,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...restrictedFootwayVariantPresets,
     ...sidewalkVariantPresets,
     ...footwayCrossingVariantPresets,
+    ...streetSidewalkVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -473,5 +473,155 @@
         "name": "Sidewalk bicycle yes",
         "aliases": "sby",
         "terms": "sby, sidewalk, pavement, sidepath, footway, bicycle yes, cycling"
+    },
+    "highway/primary_sidewalk_both": {
+        "name": "Primary road (separate sidewalk, both sides)",
+        "terms": "psb, primary, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "psb"
+    },
+    "highway/primary_sidewalk_left": {
+        "name": "Primary road (separate sidewalk, left)",
+        "terms": "pls, primary, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "psl"
+    },
+    "highway/primary_sidewalk_right": {
+        "name": "Primary road (separate sidewalk, right)",
+        "terms": "psr, primary, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "psr"
+    },
+    "highway/primary-opposite-use_sidepath": {
+        "name": "Primary road (divided, sidewalk opposite side)",
+        "terms": "pso, primary, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "pso"
+    },
+    "highway/residential_sidewalk_both": {
+        "name": "Residential road (separate sidewalk, both sides)",
+        "terms": "rsb, residential, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "rsb"
+    },
+    "highway/residential_sidewalk_left": {
+        "name": "Residential road (separate sidewalk, left)",
+        "terms": "rsl, residential, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "rsl"
+    },
+    "highway/residential_sidewalk_right": {
+        "name": "Residential road (separate sidewalk, right)",
+        "terms": "rsr, residential, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "rsr"
+    },
+    "highway/residential-opposite-use_sidepath": {
+        "name": "Residential road (divided, sidewalk opposite side)",
+        "terms": "rso, residential, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "rso"
+    },
+    "highway/secondary_sidewalk_both": {
+        "name": "Secondary road (separate sidewalk, both sides)",
+        "terms": "ssb, secondary, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "ssb"
+    },
+    "highway/secondary_sidewalk_left": {
+        "name": "Secondary road (separate sidewalk, left)",
+        "terms": "ssl, secondary, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "ssl"
+    },
+    "highway/secondary_sidewalk_right": {
+        "name": "Secondary road (separate sidewalk, right)",
+        "terms": "ssr, secondary, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "ssr"
+    },
+    "highway/secondary-opposite-use_sidepath": {
+        "name": "Secondary road (divided, sidewalk opposite side)",
+        "terms": "sso, secondary, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "sso"
+    },
+    "highway/tertiary_sidewalk_both": {
+        "name": "Tertiary road (separate sidewalk, both sides)",
+        "terms": "tsb, tertiary, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "tsb"
+    },
+    "highway/tertiary_sidewalk_left": {
+        "name": "Tertiary road (separate sidewalk, left)",
+        "terms": "tsl, tertiary, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "tsl"
+    },
+    "highway/tertiary_sidewalk_right": {
+        "name": "Tertiary road (separate sidewalk, right)",
+        "terms": "tsr, tertiary, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "tsr"
+    },
+    "highway/tertiary-opposite-use_sidepath": {
+        "name": "Tertiary road (divided, sidewalk opposite side)",
+        "terms": "tso, tertiary, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "tso"
+    },
+    "highway/trunk_sidewalk_both": {
+        "name": "Trunk road (separate sidewalk, both sides)",
+        "terms": "tksb, trunk, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "tksb"
+    },
+    "highway/trunk_sidewalk_left": {
+        "name": "Trunk road (separate sidewalk, left)",
+        "terms": "tksl, trunk, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "tksl"
+    },
+    "highway/trunk_sidewalk_right": {
+        "name": "Trunk road (separate sidewalk, right)",
+        "terms": "tksr, trunk, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "tksr"
+    },
+    "highway/trunk-opposite-use_sidepath": {
+        "name": "Trunk road (divided, sidewalk opposite side)",
+        "terms": "tkso, trunk, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "tkso"
+    },
+    "highway/unclassified_sidewalk_both": {
+        "name": "Unclassified road (separate sidewalk, both sides)",
+        "terms": "usb, unclassified, road, street, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "usb"
+    },
+    "highway/unclassified_sidewalk_left": {
+        "name": "Unclassified road (separate sidewalk, left)",
+        "terms": "usl, unclassified, road, street, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "usl"
+    },
+    "highway/unclassified_sidewalk_right": {
+        "name": "Unclassified road (separate sidewalk, right)",
+        "terms": "usr, unclassified, road, street, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "usr"
+    },
+    "highway/unclassified-opposite-use_sidepath": {
+        "name": "Unclassified road (divided, sidewalk opposite side)",
+        "terms": "uso, unclassified, road, street, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "uso"
+    },
+    "highway/primary_sidewalk_no": {
+        "name": "Primary road (no sidewalk)",
+        "terms": "psn, primary, road, street, sidewalk, no sidewalk, none",
+        "aliases": "psn"
+    },
+    "highway/residential_sidewalk_no": {
+        "name": "Residential road (no sidewalk)",
+        "terms": "rsn, residential, road, street, sidewalk, no sidewalk, none",
+        "aliases": "rsn"
+    },
+    "highway/secondary_sidewalk_no": {
+        "name": "Secondary road (no sidewalk)",
+        "terms": "ssn, secondary, road, street, sidewalk, no sidewalk, none",
+        "aliases": "ssn"
+    },
+    "highway/tertiary_sidewalk_no": {
+        "name": "Tertiary road (no sidewalk)",
+        "terms": "tsn, tertiary, road, street, sidewalk, no sidewalk, none",
+        "aliases": "tsn"
+    },
+    "highway/trunk_sidewalk_no": {
+        "name": "Trunk road (no sidewalk)",
+        "terms": "tksn, trunk, road, street, sidewalk, no sidewalk, none",
+        "aliases": "tksn"
+    },
+    "highway/unclassified_sidewalk_no": {
+        "name": "Unclassified road (no sidewalk)",
+        "terms": "usn, unclassified, road, street, sidewalk, no sidewalk, none",
+        "aliases": "usn"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -473,5 +473,155 @@
         "name": "Trottoir — vélo autorisé",
         "aliases": "sby",
         "terms": "sby, tva, trottoir, trottoirs, vélo autorisé, cyclisme, chemin piéton"
+    },
+    "highway/primary_sidewalk_both": {
+        "name": "Route primaire (trottoir séparé, deux côtés)",
+        "terms": "pb, route primaire, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "psb"
+    },
+    "highway/primary_sidewalk_left": {
+        "name": "Route primaire (trottoir séparé, gauche)",
+        "terms": "pl, route primaire, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "psl"
+    },
+    "highway/primary_sidewalk_right": {
+        "name": "Route primaire (trottoir séparé, droite)",
+        "terms": "pr, route primaire, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "psr"
+    },
+    "highway/primary-opposite-use_sidepath": {
+        "name": "Route primaire (chaussées séparées, trottoir côté opposé)",
+        "terms": "po, route primaire, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "pso"
+    },
+    "highway/residential_sidewalk_both": {
+        "name": "Rue résidentielle (trottoir séparé, deux côtés)",
+        "terms": "rb, rue résidentielle, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "rsb"
+    },
+    "highway/residential_sidewalk_left": {
+        "name": "Rue résidentielle (trottoir séparé, gauche)",
+        "terms": "rl, rue résidentielle, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "rsl"
+    },
+    "highway/residential_sidewalk_right": {
+        "name": "Rue résidentielle (trottoir séparé, droite)",
+        "terms": "rr, rue résidentielle, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "rsr"
+    },
+    "highway/residential-opposite-use_sidepath": {
+        "name": "Rue résidentielle (chaussées séparées, trottoir côté opposé)",
+        "terms": "ro, rue résidentielle, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "rso"
+    },
+    "highway/secondary_sidewalk_both": {
+        "name": "Route secondaire (trottoir séparé, deux côtés)",
+        "terms": "sb, route secondaire, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "ssb"
+    },
+    "highway/secondary_sidewalk_left": {
+        "name": "Route secondaire (trottoir séparé, gauche)",
+        "terms": "sl, route secondaire, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "ssl"
+    },
+    "highway/secondary_sidewalk_right": {
+        "name": "Route secondaire (trottoir séparé, droite)",
+        "terms": "sr, route secondaire, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "ssr"
+    },
+    "highway/secondary-opposite-use_sidepath": {
+        "name": "Route secondaire (chaussées séparées, trottoir côté opposé)",
+        "terms": "so, route secondaire, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "sso"
+    },
+    "highway/tertiary_sidewalk_both": {
+        "name": "Route tertiaire (trottoir séparé, deux côtés)",
+        "terms": "tb, route tertiaire, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "tsb"
+    },
+    "highway/tertiary_sidewalk_left": {
+        "name": "Route tertiaire (trottoir séparé, gauche)",
+        "terms": "tl, route tertiaire, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "tsl"
+    },
+    "highway/tertiary_sidewalk_right": {
+        "name": "Route tertiaire (trottoir séparé, droite)",
+        "terms": "tr, route tertiaire, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "tsr"
+    },
+    "highway/tertiary-opposite-use_sidepath": {
+        "name": "Route tertiaire (chaussées séparées, trottoir côté opposé)",
+        "terms": "to, route tertiaire, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "tso"
+    },
+    "highway/trunk_sidewalk_both": {
+        "name": "Voie rapide (trottoir séparé, deux côtés)",
+        "terms": "tkb, voie rapide, trunk, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "tksb"
+    },
+    "highway/trunk_sidewalk_left": {
+        "name": "Voie rapide (trottoir séparé, gauche)",
+        "terms": "tkl, voie rapide, trunk, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "tksl"
+    },
+    "highway/trunk_sidewalk_right": {
+        "name": "Voie rapide (trottoir séparé, droite)",
+        "terms": "tkr, voie rapide, trunk, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "tksr"
+    },
+    "highway/trunk-opposite-use_sidepath": {
+        "name": "Voie rapide (chaussées séparées, trottoir côté opposé)",
+        "terms": "tko, voie rapide, trunk, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "tkso"
+    },
+    "highway/unclassified_sidewalk_both": {
+        "name": "Route non classée (trottoir séparé, deux côtés)",
+        "terms": "ub, route non classée, route, rue, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "usb"
+    },
+    "highway/unclassified_sidewalk_left": {
+        "name": "Route non classée (trottoir séparé, gauche)",
+        "terms": "ul, route non classée, route, rue, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "usl"
+    },
+    "highway/unclassified_sidewalk_right": {
+        "name": "Route non classée (trottoir séparé, droite)",
+        "terms": "ur, route non classée, route, rue, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "usr"
+    },
+    "highway/unclassified-opposite-use_sidepath": {
+        "name": "Route non classée (chaussées séparées, trottoir côté opposé)",
+        "terms": "uo, route non classée, route, rue, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "uso"
+    },
+    "highway/primary_sidewalk_no": {
+        "name": "Route primaire (sans trottoir)",
+        "terms": "pn, route primaire, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "psn"
+    },
+    "highway/residential_sidewalk_no": {
+        "name": "Rue résidentielle (sans trottoir)",
+        "terms": "rn, rue résidentielle, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "rsn"
+    },
+    "highway/secondary_sidewalk_no": {
+        "name": "Route secondaire (sans trottoir)",
+        "terms": "sn, route secondaire, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "ssn"
+    },
+    "highway/tertiary_sidewalk_no": {
+        "name": "Route tertiaire (sans trottoir)",
+        "terms": "tn, route tertiaire, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "tsn"
+    },
+    "highway/trunk_sidewalk_no": {
+        "name": "Voie rapide (sans trottoir)",
+        "terms": "tkn, voie rapide, trunk, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "tksn"
+    },
+    "highway/unclassified_sidewalk_no": {
+        "name": "Route non classée (sans trottoir)",
+        "terms": "un, route non classée, route, rue, trottoir, sans trottoir, aucun",
+        "aliases": "usn"
     }
 }

--- a/modules/ui/fields/directional_group.ts
+++ b/modules/ui/fields/directional_group.ts
@@ -94,11 +94,16 @@ export function uiFieldDirectionalGroup(
             .attr('class', 'label directional-group-label')
             .text((m: any) => m.label);
         enter.append('div')
-            .attr('class', 'directional-group-input form-field-input-wrap')
-            .each(function(this: HTMLElement, m: any) { d3_select(this).call(m.impl); });
+            .attr('class', 'directional-group-input form-field-input-wrap');
         rows = enter.merge(rows);
 
-        // feed the full tag set to each visible member renderer
+        // (Re)render every visible member into its input container, then feed it
+        // the tags. Rendering on update (not just enter) is required because the
+        // inspector recycles existing <li> across preset changes: a new member
+        // renderer matched to a recycled row would otherwise stay unrendered
+        // (its input is null) when tags() runs. Member renderers are idempotent.
+        rows.select('.directional-group-input')
+            .each(function(this: HTMLElement, m: any) { d3_select(this).call(m.impl); });
         rows.each((m: any) => m.impl.tags(_tags));
     };
 

--- a/modules/ui/fields/sidewalk.ts
+++ b/modules/ui/fields/sidewalk.ts
@@ -32,13 +32,12 @@ const VALUE_TAGS: Record<string, Record<string, string>> = {
 // `dual_carriageway` is only written when a value sets it, never cleared.
 const RESET_KEYS = ['sidewalk', 'sidewalk:both', 'sidewalk:left', 'sidewalk:right', 'foot'];
 
-// Human-readable labels for the combobox, in menu order.
+// Human-readable labels for the combobox, in menu order. The preferred,
+// "permanent" values come first; `both`/`left`/`right` (meant only as a
+// temporary state while sidewalks are being drawn) and the deprecated `none`
+// are listed last.
 const OPTIONS: { value: string; title: string }[] = [
-    { value: 'both', title: 'Both sides' },
-    { value: 'left', title: 'Left side' },
-    { value: 'right', title: 'Right side' },
     { value: 'no', title: 'None (sidewalk=no)' },
-    { value: 'none', title: 'None (sidewalk=none)' },
     { value: 'separate_both', title: 'Separate, both sides' },
     { value: 'separate_left', title: 'Separate, left side' },
     { value: 'separate_right', title: 'Separate, right side' },
@@ -47,7 +46,11 @@ const OPTIONS: { value: string; title: string }[] = [
     { value: 'shared_right', title: 'Shared, right side' },
     { value: 'shared_left_separate_right', title: 'Shared left, separate right' },
     { value: 'shared_right_separate_left', title: 'Separate left, shared right' },
-    { value: 'opposite_use_sidepath', title: 'Opposite (use_sidepath, dual carriageway)' }
+    { value: 'opposite_use_sidepath', title: 'Opposite (use_sidepath, dual carriageway)' },
+    { value: 'both', title: 'Both sides' },
+    { value: 'left', title: 'Left side' },
+    { value: 'right', title: 'Right side' },
+    { value: 'none', title: 'None (sidewalk=none)' }
 ];
 
 /** Resolve the selector value from a left/right sidewalk pair (and `foot`). */

--- a/test/spec/presets/custom/street_sidewalk.js
+++ b/test/spec/presets/custom/street_sidewalk.js
@@ -1,0 +1,88 @@
+import { loadCustomPresets } from './setup.js';
+
+const HIGHWAYS = ['primary', 'residential', 'secondary', 'tertiary', 'trunk', 'unclassified'];
+
+/** id suffix → { useSidepath, extraTags } (tags besides highway + optional foot=use_sidepath). */
+const VARIANTS = {
+    '_sidewalk_both': { useSidepath: true, extraTags: { 'sidewalk:both': 'separate' } },
+    '_sidewalk_left': { useSidepath: true, extraTags: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no' } },
+    '_sidewalk_right': { useSidepath: true, extraTags: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate' } },
+    '-opposite-use_sidepath': { useSidepath: true, extraTags: { sidewalk: 'no', dual_carriageway: 'yes' } },
+    '_sidewalk_no': { useSidepath: false, extraTags: { sidewalk: 'no' } }
+};
+
+const CASES = HIGHWAYS.flatMap((highway) =>
+    Object.entries(VARIANTS).map(([suffix, { useSidepath, extraTags }]) => ({
+        id: `highway/${highway}${suffix}`,
+        highway,
+        useSidepath,
+        extraTags
+    }))
+);
+
+describe('custom presets — street sidewalk variants', function() {
+    loadCustomPresets();
+
+    CASES.forEach(function({ id, highway, useSidepath, extraTags }) {
+        it(`defines ${id} with expected sidewalk tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.include({ highway, ...extraTags });
+            if (useSidepath) {
+                expect(preset.tags).to.include({ foot: 'use_sidepath' });
+            } else {
+                expect(preset.tags).to.not.have.property('foot');
+            }
+            expect(preset.addTags.surface).to.equal('asphalt');
+            expect(preset.tags).to.not.have.property('surface');
+        });
+    });
+
+    it('omits matchScore so plain roads are not captured', function() {
+        const raw = iD.fileFetcher.cache().preset_custom_presets;
+        expect(raw['highway/primary_sidewalk_both'].matchScore).to.be.undefined;
+        expect(raw['highway/primary-opposite-use_sidepath'].matchScore).to.be.undefined;
+    });
+
+    it('only force-removes foot=use_sidepath on preset change', function() {
+        const raw = iD.fileFetcher.cache().preset_custom_presets;
+        expect(raw['highway/residential_sidewalk_both'].removeTags).to.eql({ foot: 'use_sidepath' });
+        expect(raw['highway/primary-opposite-use_sidepath'].removeTags).to.eql({ foot: 'use_sidepath' });
+    });
+
+    it('defines no-sidewalk variants without foot=use_sidepath', function() {
+        const raw = iD.fileFetcher.cache().preset_custom_presets;
+        const noSidewalk = raw['highway/primary_sidewalk_no'];
+        expect(noSidewalk.tags).to.eql({ highway: 'primary', sidewalk: 'no' });
+        expect(noSidewalk.removeTags).to.eql({});
+    });
+
+    it('finds street presets by alias search', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        const byPsb = pool.search('psb', 'line').collection.map((p) => p.id);
+        expect(byPsb).to.include('highway/primary_sidewalk_both');
+        const byTkso = pool.search('tkso', 'line').collection.map((p) => p.id);
+        expect(byTkso).to.include('highway/trunk-opposite-use_sidepath');
+    });
+
+    it('removes foot=use_sidepath when switching to a plain road', function() {
+        const oldPreset = iD.presetManager.item('highway/residential_sidewalk_both');
+        const newPreset = iD.presetManager.item('highway/residential');
+        const n1 = iD.osmNode({ loc: [0, 0] });
+        const n2 = iD.osmNode({ loc: [1, 1] });
+        const way = iD.osmWay({
+            nodes: [n1.id, n2.id],
+            tags: {
+                highway: 'residential',
+                foot: 'use_sidepath',
+                'sidewalk:both': 'separate',
+                surface: 'asphalt'
+            }
+        });
+        const graph = new iD.coreGraph([n1, n2, way]);
+        const tags = iD.actionChangePreset(way.id, oldPreset, newPreset)(graph).entity(way.id).tags;
+
+        expect(tags).to.include({ highway: 'residential' });
+        expect(tags).to.not.have.property('foot');
+    });
+});

--- a/test/spec/ui/fields/directional_group.js
+++ b/test/spec/ui/fields/directional_group.js
@@ -1,0 +1,53 @@
+import { loadCustomPresets } from '../../presets/custom/setup.js';
+
+// Directional group members are rendered per visible row. The inspector recycles
+// existing <li> across preset changes, so a freshly created field instance can
+// land on recycled rows; member renderers must therefore run on update rows too,
+// not only on enter, or their input stays null and tags() throws. See
+// uiFieldDirectionalGroup.
+describe('iD.uiFieldDirectionalGroup', function() {
+    loadCustomPresets();
+
+    const TAGS = {
+        highway: 'residential',
+        oneway: 'yes',
+        lanes: '4',
+        placement: 'right_of:1',
+        'turn:lanes': 'left|through',
+        'change:lanes': 'yes|no'
+    };
+
+    /** Render a fresh field instance for `fieldId` into `selection`. */
+    function renderInstance(context, fieldId, selection) {
+        const presetField = iD.presetManager.field(fieldId);
+        expect(presetField, fieldId).to.exist;
+        const field = iD.uiField(context, presetField, [], { wrap: true });
+        field.show();
+        field.tags(TAGS);
+        selection.call(field.render);
+    }
+
+    ['placement_group', 'lanes_group', 'turn_lanes_group', 'change_lanes_group'].forEach(function(fieldId) {
+        it(`re-renders ${fieldId} when a new instance lands on recycled DOM`, function() {
+            const context = iD.coreContext().assetPath('../dist/').init();
+            const selection = d3.select(document.createElement('div'));
+            // first instance populates the DOM, second instance reuses the same
+            // recycled rows (the failing case before the fix)
+            renderInstance(context, fieldId, selection);
+            expect(() => renderInstance(context, fieldId, selection), fieldId).to.not.throw();
+        });
+    });
+
+    it('keeps combo member rows rendered with an input after re-render', function() {
+        const context = iD.coreContext().assetPath('../dist/').init();
+        const selection = d3.select(document.createElement('div'));
+        renderInstance(context, 'placement_group', selection);
+        renderInstance(context, 'placement_group', selection);
+
+        const rows = selection.selectAll('li.directional-group-row');
+        expect(rows.size()).to.be.greaterThan(0);
+        rows.each(function() {
+            expect(d3.select(this).selectAll('input').size()).to.be.greaterThan(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Ports the v5 street presets for roads with a separately-mapped sidewalk
(`foot=use_sidepath`), generated from a single TypeScript matrix module
`presets/highway/street_sidewalk_variants.ts` (6 classes × 4 variants = 24
presets): `primary`, `residential`, `secondary`, `tertiary`, `trunk`,
`unclassified` × `_sidewalk_both` / `_sidewalk_left` / `_sidewalk_right` /
`-opposite-use_sidepath`.

Tags (per v5): `highway`, `foot=use_sidepath`, the sidewalk side tags, and for
`opposite` `sidewalk=no` + `dual_carriageway=yes` (divided road whose sidewalk
is mapped along the opposite carriageway). `surface=asphalt` is added.

Improvements over v5:
- **No acronym in display names** — clean names (e.g. `Primary road (separate
  sidewalk, both sides)`); the short code lives in `aliases`.
- **Non-colliding aliases** — v5 reused the same letters for `_right` and
  `-opposite` (e.g. `pr`). New scheme uses class (`p/r/s/t/tk/u`) × variant
  (`b/l/r/o`): `pb pl pr po … tkb tkl tkr tko ub ul ur uo`.
- **matchScore left at default** so the variants only win when their specific
  tags are present (they don't hijack plain `highway=primary` roads).
- **`reference`** points at the real `highway=<class>` wiki tag.

Note: `removeTags` only force-removes `foot=use_sidepath`. The sidewalk tags are
managed by the shared `sidewalk` field, which iD intentionally preserves across
preset changes (`actionChangePreset` preserveKeys), so removeTags cannot clear
them — same effective behaviour as v5.

## Test plan

- [x] `npm run generate:presets:custom && npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/` (65 passing; 24 parametric + 4 street)
- [x] Locale/alias consistency check: 119 presets = 119 EN = 119 FR, no alias collisions
- [x] ESLint clean on touched files