### PR TITLE
Presets: add service road and private track presets

### DIFF
--- a/data/custom-tagging/src/presets/highway/service_variants.ts
+++ b/data/custom-tagging/src/presets/highway/service_variants.ts
@@ -1,0 +1,117 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+import { SIDEWALK_VARIANT_TAGS, type SidewalkVariant } from './sidewalk_variant_tags';
+
+// =============================================================================
+// SERVICE ROADS — restricted-access service roads and their driveway /
+// parking-aisle subtypes. Mirrors the street sidewalk variants but adds the
+// access dimension (customers / private / destination) and the service subtypes.
+// =============================================================================
+
+const ICON = 'iD-highway-service';
+const FIELDS = ['{highway/service}'];
+const REFERENCE = { key: 'highway', value: 'service' } as const;
+
+/** Access dimension → the tag(s) that encode it on a service road. */
+const ACCESS_TAGS: Record<string, Record<string, string>> = {
+    customers: { access: 'customers' },
+    private: { access: 'private' },
+    // motor_vehicle=destination keeps general access while limiting through traffic
+    destination: { motor_vehicle: 'destination' }
+};
+const ACCESSES = Object.keys(ACCESS_TAGS);
+
+/** Sidewalk variants offered on service roads (no bare `no` variant, unlike streets). */
+const ROAD_SIDEWALKS: SidewalkVariant[] = ['both', 'left', 'right', 'opposite'];
+
+/** Common preset shell shared by every service-road preset. */
+function servicePreset(
+    id: string,
+    tags: Record<string, string>,
+    addTags: Record<string, string>,
+    removeTags?: Record<string, string>
+): CustomPreset {
+    return {
+        icon: ICON,
+        geometry: ['line'],
+        fields: [...FIELDS],
+        moreFields: [...FIELDS],
+        tags,
+        addTags,
+        ...(removeTags ? { removeTags } : {}),
+        reference: REFERENCE,
+        name: presetNameEn(id)
+    };
+}
+
+/** Sidewalk preset id: `opposite` uses the `_opposite_use_sidepath` suffix. */
+function sidewalkId(access: string, variant: SidewalkVariant): string {
+    return variant === 'opposite'
+        ? `highway/service/${access}_opposite_use_sidepath`
+        : `highway/service/${access}_sidewalk_${variant}`;
+}
+
+/** Base, unpaved, sidewalk and opposite presets for one access level. */
+function accessRoadPresets(access: string): Record<string, CustomPreset> {
+    const base = { highway: 'service', ...ACCESS_TAGS[access] };
+    const out: Record<string, CustomPreset> = {};
+
+    const baseId = `highway/service/${access}`;
+    out[baseId] = servicePreset(baseId, { ...base }, { ...base, surface: 'asphalt' });
+
+    const unpavedId = `highway/service/${access}_unpaved`;
+    const unpaved = { ...base, surface: 'unpaved' };
+    out[unpavedId] = servicePreset(unpavedId, unpaved, { ...unpaved });
+
+    // every sidewalk/opposite variant carries foot=use_sidepath (separate sidepath)
+    for (const variant of ROAD_SIDEWALKS) {
+        const id = sidewalkId(access, variant);
+        const tags = { ...base, foot: 'use_sidepath', ...SIDEWALK_VARIANT_TAGS[variant] };
+        // Only force-remove foot=use_sidepath on preset change; sidewalk tags are
+        // managed by the shared sidewalk field, which iD preserves (preserveKeys).
+        out[id] = servicePreset(id, tags, { ...tags, surface: 'asphalt' }, { foot: 'use_sidepath' });
+    }
+    return out;
+}
+
+interface SubtypeVariant {
+    access: 'customers' | 'private';
+    service: 'driveway' | 'parking_aisle';
+    unpaved?: boolean;
+}
+
+const SUBTYPES: SubtypeVariant[] = [
+    { access: 'customers', service: 'driveway' },
+    { access: 'customers', service: 'parking_aisle' },
+    { access: 'private', service: 'driveway' },
+    { access: 'private', service: 'parking_aisle' },
+    { access: 'private', service: 'driveway', unpaved: true },
+    { access: 'private', service: 'parking_aisle', unpaved: true }
+];
+
+function subtypeId(v: SubtypeVariant): string {
+    const unpaved = v.unpaved ? 'unpaved_' : '';
+    return `highway/service/${v.access}_${unpaved}${v.service}`;
+}
+
+function subtypePreset(v: SubtypeVariant): CustomPreset {
+    const tags: Record<string, string> = { highway: 'service', service: v.service, access: v.access };
+    if (v.unpaved) tags.surface = 'unpaved';
+    const addTags = v.unpaved ? { ...tags } : { ...tags, surface: 'asphalt' };
+
+    return {
+        icon: ICON,
+        geometry: ['line'],
+        fields: [...FIELDS],
+        moreFields: [...FIELDS],
+        tags,
+        addTags,
+        reference: { key: 'service', value: v.service },
+        name: presetNameEn(subtypeId(v))
+    };
+}
+
+export const serviceVariantPresets: Record<string, CustomPreset> = {
+    ...Object.fromEntries(SUBTYPES.map((v) => [subtypeId(v), subtypePreset(v)] as const)),
+    ...ACCESSES.reduce((acc, access) => ({ ...acc, ...accessRoadPresets(access) }), {})
+};

--- a/data/custom-tagging/src/presets/highway/sidewalk_variant_tags.ts
+++ b/data/custom-tagging/src/presets/highway/sidewalk_variant_tags.ts
@@ -1,0 +1,26 @@
+/**
+ * Sidewalk configuration variants shared by road-like presets (streets and
+ * service roads). The bare `foot=use_sidepath` tag is added separately by each
+ * caller (see SIDEWALK_USE_SIDEPATH) since not every variant carries it.
+ */
+export type SidewalkVariant = 'both' | 'left' | 'right' | 'opposite' | 'no';
+
+/** Sidewalk-related tags for each variant (excluding `foot=use_sidepath`). */
+export const SIDEWALK_VARIANT_TAGS: Record<SidewalkVariant, Record<string, string>> = {
+    both: { 'sidewalk:both': 'separate' },
+    left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no' },
+    right: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate' },
+    // Divided road whose sidewalk is mapped along the opposite carriageway.
+    opposite: { sidewalk: 'no', dual_carriageway: 'yes' },
+    // No sidewalk at all (no separate sidepath to use).
+    no: { sidewalk: 'no' }
+};
+
+/** Variants with a separate sidepath, so the road carries `foot=use_sidepath`. */
+export const SIDEWALK_USE_SIDEPATH: Record<SidewalkVariant, boolean> = {
+    both: true,
+    left: true,
+    right: true,
+    opposite: true,
+    no: false
+};

--- a/data/custom-tagging/src/presets/highway/street_sidewalk_variants.ts
+++ b/data/custom-tagging/src/presets/highway/street_sidewalk_variants.ts
@@ -1,32 +1,15 @@
 import type { CustomPreset } from '../../types';
 import { presetNameEn } from '../../preset_name_en';
+import {
+    SIDEWALK_VARIANT_TAGS,
+    SIDEWALK_USE_SIDEPATH,
+    type SidewalkVariant
+} from './sidewalk_variant_tags';
 
 /** Road classes that get the Québec `foot=use_sidepath` sidewalk variants. */
 const STREETS = ['primary', 'residential', 'secondary', 'tertiary', 'trunk', 'unclassified'] as const;
 
-type SidewalkVariant = 'both' | 'left' | 'right' | 'opposite' | 'no';
-
 const VARIANTS: SidewalkVariant[] = ['both', 'left', 'right', 'opposite', 'no'];
-
-/** Sidewalk tags per variant (added to `highway`, plus `foot=use_sidepath` where it applies). */
-const VARIANT_TAGS: Record<SidewalkVariant, Record<string, string>> = {
-    both: { 'sidewalk:both': 'separate' },
-    left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no' },
-    right: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate' },
-    // Divided road whose sidewalk is mapped along the opposite carriageway.
-    opposite: { sidewalk: 'no', dual_carriageway: 'yes' },
-    // Road with no sidewalk at all (no separate sidepath to use).
-    no: { sidewalk: 'no' }
-};
-
-/** Variants where a separate sidepath exists, so the road carries `foot=use_sidepath`. */
-const USE_SIDEPATH: Record<SidewalkVariant, boolean> = {
-    both: true,
-    left: true,
-    right: true,
-    opposite: true,
-    no: false
-};
 
 /** Preset id: `opposite` keeps the v5 `-opposite-use_sidepath` suffix. */
 function streetId(highway: string, variant: SidewalkVariant): string {
@@ -36,11 +19,11 @@ function streetId(highway: string, variant: SidewalkVariant): string {
 }
 
 function streetPreset(highway: string, variant: SidewalkVariant): CustomPreset {
-    const useSidepath = USE_SIDEPATH[variant];
+    const useSidepath = SIDEWALK_USE_SIDEPATH[variant];
     const tags: Record<string, string> = {
         highway,
         ...(useSidepath ? { foot: 'use_sidepath' } : {}),
-        ...VARIANT_TAGS[variant]
+        ...SIDEWALK_VARIANT_TAGS[variant]
     };
 
     return {

--- a/data/custom-tagging/src/presets/highway/track_private.ts
+++ b/data/custom-tagging/src/presets/highway/track_private.ts
@@ -1,0 +1,21 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Private, unmaintained track (highway=track + access=private), defaulting to an
+// unpaved surface. Unrelated to the service-road family but ported alongside it.
+const ID = 'highway/track_private';
+
+export const trackPrivatePreset: CustomPreset = {
+    icon: 'fas-truck-monster',
+    geometry: ['line'],
+    fields: ['{highway/track}'],
+    moreFields: ['{highway/track}'],
+    tags: { highway: 'track', access: 'private' },
+    addTags: { highway: 'track', access: 'private', surface: 'unpaved' },
+    reference: { key: 'highway', value: 'track' },
+    name: presetNameEn(ID)
+};
+
+export const trackPrivatePresets: Record<string, CustomPreset> = {
+    [ID]: trackPrivatePreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -9,6 +9,8 @@ import { footwayCrossingVariantPresets } from './presets/highway/footway/footway
 import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_variants';
 import { restrictedFootwayVariantPresets } from './presets/highway/footway/restricted_footway_variants';
 import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_variants';
+import { serviceVariantPresets } from './presets/highway/service_variants';
+import { trackPrivatePresets } from './presets/highway/track_private';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -38,6 +40,8 @@ export const customPresets: Record<string, CustomPreset> = {
     ...sidewalkVariantPresets,
     ...footwayCrossingVariantPresets,
     ...streetSidewalkVariantPresets,
+    ...serviceVariantPresets,
+    ...trackPrivatePresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -623,5 +623,130 @@
         "name": "Unclassified road (no sidewalk)",
         "terms": "usn, unclassified, road, street, sidewalk, no sidewalk, none",
         "aliases": "usn"
+    },
+    "highway/service/customers_driveway": {
+        "name": "Customers driveway",
+        "terms": "scd, customers, driveway, service, access road",
+        "aliases": "scd"
+    },
+    "highway/service/customers_parking_aisle": {
+        "name": "Customers parking aisle",
+        "terms": "scpa, customers, parking aisle, service, access road",
+        "aliases": "scpa"
+    },
+    "highway/service/private_driveway": {
+        "name": "Private driveway",
+        "terms": "spd, private, driveway, service, access road",
+        "aliases": "spd"
+    },
+    "highway/service/private_parking_aisle": {
+        "name": "Private parking aisle",
+        "terms": "sppa, private, parking aisle, service, access road",
+        "aliases": "sppa"
+    },
+    "highway/service/private_unpaved_driveway": {
+        "name": "Private unpaved driveway",
+        "terms": "spud, private, unpaved, driveway, service, access road",
+        "aliases": "spud"
+    },
+    "highway/service/private_unpaved_parking_aisle": {
+        "name": "Private unpaved parking aisle",
+        "terms": "spupa, private, unpaved, parking aisle, service, access road",
+        "aliases": "spupa"
+    },
+    "highway/service/customers": {
+        "name": "Customers service road",
+        "terms": "sc, customers, service, road, access",
+        "aliases": "sc"
+    },
+    "highway/service/customers_unpaved": {
+        "name": "Customers service road (unpaved)",
+        "terms": "scu, customers, service, road, unpaved",
+        "aliases": "scu"
+    },
+    "highway/service/customers_sidewalk_both": {
+        "name": "Customers service road (separate sidewalk, both sides)",
+        "terms": "scsb, customers, service, road, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "scsb"
+    },
+    "highway/service/customers_sidewalk_left": {
+        "name": "Customers service road (separate sidewalk, left)",
+        "terms": "scsl, customers, service, road, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "scsl"
+    },
+    "highway/service/customers_sidewalk_right": {
+        "name": "Customers service road (separate sidewalk, right)",
+        "terms": "scsr, customers, service, road, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "scsr"
+    },
+    "highway/service/customers_opposite_use_sidepath": {
+        "name": "Customers service road (divided, sidewalk opposite side)",
+        "terms": "sco, customers, service, road, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "sco"
+    },
+    "highway/service/private": {
+        "name": "Private service road",
+        "terms": "sp, private, service, road, access",
+        "aliases": "sp"
+    },
+    "highway/service/private_unpaved": {
+        "name": "Private service road (unpaved)",
+        "terms": "spu, private, service, road, unpaved",
+        "aliases": "spu"
+    },
+    "highway/service/private_sidewalk_both": {
+        "name": "Private service road (separate sidewalk, both sides)",
+        "terms": "spsb, private, service, road, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "spsb"
+    },
+    "highway/service/private_sidewalk_left": {
+        "name": "Private service road (separate sidewalk, left)",
+        "terms": "spsl, private, service, road, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "spsl"
+    },
+    "highway/service/private_sidewalk_right": {
+        "name": "Private service road (separate sidewalk, right)",
+        "terms": "spsr, private, service, road, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "spsr"
+    },
+    "highway/service/private_opposite_use_sidepath": {
+        "name": "Private service road (divided, sidewalk opposite side)",
+        "terms": "spo, private, service, road, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "spo"
+    },
+    "highway/service/destination": {
+        "name": "Destination service road",
+        "terms": "sd, destination, service, road, motor_vehicle",
+        "aliases": "sd"
+    },
+    "highway/service/destination_unpaved": {
+        "name": "Destination service road (unpaved)",
+        "terms": "sdu, destination, service, road, unpaved",
+        "aliases": "sdu"
+    },
+    "highway/service/destination_sidewalk_both": {
+        "name": "Destination service road (separate sidewalk, both sides)",
+        "terms": "sdsb, destination, service, road, sidewalk, sidepath, separate, both, use_sidepath",
+        "aliases": "sdsb"
+    },
+    "highway/service/destination_sidewalk_left": {
+        "name": "Destination service road (separate sidewalk, left)",
+        "terms": "sdsl, destination, service, road, sidewalk, sidepath, separate, left, use_sidepath",
+        "aliases": "sdsl"
+    },
+    "highway/service/destination_sidewalk_right": {
+        "name": "Destination service road (separate sidewalk, right)",
+        "terms": "sdsr, destination, service, road, sidewalk, sidepath, separate, right, use_sidepath",
+        "aliases": "sdsr"
+    },
+    "highway/service/destination_opposite_use_sidepath": {
+        "name": "Destination service road (divided, sidewalk opposite side)",
+        "terms": "sdo, destination, service, road, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
+        "aliases": "sdo"
+    },
+    "highway/track_private": {
+        "name": "Private unmaintained track",
+        "terms": "put, track, private, woods road, forest road, logging road, fire road, farm road, agricultural road, unmaintained, offroad, 4wd, 4x4",
+        "aliases": "put"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -623,5 +623,130 @@
         "name": "Route non classée (sans trottoir)",
         "terms": "un, route non classée, route, rue, trottoir, sans trottoir, aucun",
         "aliases": "usn"
+    },
+    "highway/service/customers_driveway": {
+        "name": "Entrée clients",
+        "terms": "scd, clients, entrée, allée, voie de service, service",
+        "aliases": "scd"
+    },
+    "highway/service/customers_parking_aisle": {
+        "name": "Allée de stationnement clients",
+        "terms": "scpa, clients, allée de stationnement, voie de service, service",
+        "aliases": "scpa"
+    },
+    "highway/service/private_driveway": {
+        "name": "Entrée privée",
+        "terms": "spd, privé, entrée, allée, voie de service, service",
+        "aliases": "spd"
+    },
+    "highway/service/private_parking_aisle": {
+        "name": "Allée de stationnement privée",
+        "terms": "sppa, privé, allée de stationnement, voie de service, service",
+        "aliases": "sppa"
+    },
+    "highway/service/private_unpaved_driveway": {
+        "name": "Entrée privée non revêtue",
+        "terms": "spud, privé, non revêtue, entrée, allée, voie de service",
+        "aliases": "spud"
+    },
+    "highway/service/private_unpaved_parking_aisle": {
+        "name": "Allée de stationnement privée non revêtue",
+        "terms": "spupa, privé, non revêtue, allée de stationnement, voie de service",
+        "aliases": "spupa"
+    },
+    "highway/service/customers": {
+        "name": "Voie de service clients",
+        "terms": "sc, clients, voie de service, service, accès",
+        "aliases": "sc"
+    },
+    "highway/service/customers_unpaved": {
+        "name": "Voie de service clients (non revêtue)",
+        "terms": "scu, clients, voie de service, service, non revêtue",
+        "aliases": "scu"
+    },
+    "highway/service/customers_sidewalk_both": {
+        "name": "Voie de service clients (trottoir séparé, deux côtés)",
+        "terms": "scsb, clients, voie de service, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "scsb"
+    },
+    "highway/service/customers_sidewalk_left": {
+        "name": "Voie de service clients (trottoir séparé, gauche)",
+        "terms": "scsl, clients, voie de service, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "scsl"
+    },
+    "highway/service/customers_sidewalk_right": {
+        "name": "Voie de service clients (trottoir séparé, droite)",
+        "terms": "scsr, clients, voie de service, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "scsr"
+    },
+    "highway/service/customers_opposite_use_sidepath": {
+        "name": "Voie de service clients (chaussées séparées, trottoir côté opposé)",
+        "terms": "sco, clients, voie de service, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "sco"
+    },
+    "highway/service/private": {
+        "name": "Voie de service privée",
+        "terms": "sp, privé, voie de service, service, accès",
+        "aliases": "sp"
+    },
+    "highway/service/private_unpaved": {
+        "name": "Voie de service privée (non revêtue)",
+        "terms": "spu, privé, voie de service, service, non revêtue",
+        "aliases": "spu"
+    },
+    "highway/service/private_sidewalk_both": {
+        "name": "Voie de service privée (trottoir séparé, deux côtés)",
+        "terms": "spsb, privé, voie de service, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "spsb"
+    },
+    "highway/service/private_sidewalk_left": {
+        "name": "Voie de service privée (trottoir séparé, gauche)",
+        "terms": "spsl, privé, voie de service, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "spsl"
+    },
+    "highway/service/private_sidewalk_right": {
+        "name": "Voie de service privée (trottoir séparé, droite)",
+        "terms": "spsr, privé, voie de service, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "spsr"
+    },
+    "highway/service/private_opposite_use_sidepath": {
+        "name": "Voie de service privée (chaussées séparées, trottoir côté opposé)",
+        "terms": "spo, privé, voie de service, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "spo"
+    },
+    "highway/service/destination": {
+        "name": "Voie de service (desserte locale)",
+        "terms": "sd, desserte locale, circulation locale, destination, voie de service, motor_vehicle",
+        "aliases": "sd"
+    },
+    "highway/service/destination_unpaved": {
+        "name": "Voie de service (desserte locale, non revêtue)",
+        "terms": "sdu, desserte locale, destination, voie de service, non revêtue",
+        "aliases": "sdu"
+    },
+    "highway/service/destination_sidewalk_both": {
+        "name": "Voie de service (desserte locale, trottoir séparé, deux côtés)",
+        "terms": "sdsb, desserte locale, destination, voie de service, trottoir, sidepath, séparé, deux côtés, use_sidepath",
+        "aliases": "sdsb"
+    },
+    "highway/service/destination_sidewalk_left": {
+        "name": "Voie de service (desserte locale, trottoir séparé, gauche)",
+        "terms": "sdsl, desserte locale, destination, voie de service, trottoir, sidepath, séparé, gauche, use_sidepath",
+        "aliases": "sdsl"
+    },
+    "highway/service/destination_sidewalk_right": {
+        "name": "Voie de service (desserte locale, trottoir séparé, droite)",
+        "terms": "sdsr, desserte locale, destination, voie de service, trottoir, sidepath, séparé, droite, use_sidepath",
+        "aliases": "sdsr"
+    },
+    "highway/service/destination_opposite_use_sidepath": {
+        "name": "Voie de service (desserte locale, chaussées séparées, trottoir côté opposé)",
+        "terms": "sdo, desserte locale, destination, voie de service, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
+        "aliases": "sdo"
+    },
+    "highway/track_private": {
+        "name": "Chemin non entretenu privé",
+        "terms": "put, chemin, piste, privé, chemin forestier, chemin de ferme, non entretenu, hors route, 4x4",
+        "aliases": "put"
     }
 }

--- a/test/spec/presets/custom/service.js
+++ b/test/spec/presets/custom/service.js
@@ -1,0 +1,106 @@
+import { loadCustomPresets } from './setup.js';
+
+/** Access dimension → tags that encode it on a service road. */
+const ACCESS = {
+    customers: { access: 'customers' },
+    private: { access: 'private' },
+    destination: { motor_vehicle: 'destination' }
+};
+
+/** Sidewalk/opposite suffix → sidewalk tags (all also carry foot=use_sidepath). */
+const SIDEWALK = {
+    sidewalk_both: { 'sidewalk:both': 'separate' },
+    sidewalk_left: { 'sidewalk:left': 'separate', 'sidewalk:right': 'no' },
+    sidewalk_right: { 'sidewalk:left': 'no', 'sidewalk:right': 'separate' },
+    opposite_use_sidepath: { sidewalk: 'no', dual_carriageway: 'yes' }
+};
+
+/** Build the full list of access-road cases (base / unpaved / sidewalk variants). */
+const ROAD_CASES = Object.keys(ACCESS).flatMap((access) => {
+    const accessTags = ACCESS[access];
+    const cases = [
+        { id: `highway/service/${access}`, tags: { highway: 'service', ...accessTags }, paved: true },
+        {
+            id: `highway/service/${access}_unpaved`,
+            tags: { highway: 'service', ...accessTags, surface: 'unpaved' },
+            paved: false
+        }
+    ];
+    Object.entries(SIDEWALK).forEach(([suffix, sw]) => {
+        cases.push({
+            id: `highway/service/${access}_${suffix}`,
+            tags: { highway: 'service', ...accessTags, foot: 'use_sidepath', ...sw },
+            paved: true,
+            sidepath: true
+        });
+    });
+    return cases;
+});
+
+const SUBTYPE_CASES = [
+    { id: 'highway/service/customers_driveway', service: 'driveway', access: 'customers', paved: true },
+    { id: 'highway/service/customers_parking_aisle', service: 'parking_aisle', access: 'customers', paved: true },
+    { id: 'highway/service/private_driveway', service: 'driveway', access: 'private', paved: true },
+    { id: 'highway/service/private_parking_aisle', service: 'parking_aisle', access: 'private', paved: true },
+    { id: 'highway/service/private_unpaved_driveway', service: 'driveway', access: 'private', paved: false },
+    { id: 'highway/service/private_unpaved_parking_aisle', service: 'parking_aisle', access: 'private', paved: false }
+];
+
+describe('custom presets — service roads', function() {
+    loadCustomPresets();
+
+    ROAD_CASES.forEach(function({ id, tags, paved, sidepath }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            // paved variants add surface=asphalt without baking it into tags
+            expect(preset.addTags.surface).to.equal(paved ? 'asphalt' : 'unpaved');
+            if (paved) expect(preset.tags).to.not.have.property('surface');
+            if (sidepath) {
+                expect(preset.addTags.foot).to.equal('use_sidepath');
+            } else {
+                expect(preset.tags).to.not.have.property('foot');
+            }
+        });
+    });
+
+    SUBTYPE_CASES.forEach(function({ id, service, access, paved }) {
+        it(`defines subtype ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.include({ highway: 'service', service, access });
+            expect(preset.addTags.surface).to.equal(paved ? 'asphalt' : 'unpaved');
+        });
+    });
+
+    it('only force-removes foot=use_sidepath on sidewalk variants', function() {
+        const raw = iD.fileFetcher.cache().preset_custom_presets;
+        expect(raw['highway/service/customers_sidewalk_both'].removeTags).to.eql({ foot: 'use_sidepath' });
+        expect(raw['highway/service/destination_opposite_use_sidepath'].removeTags).to.eql({ foot: 'use_sidepath' });
+        // base / unpaved / subtype presets carry no removeTags
+        expect(raw['highway/service/customers'].removeTags).to.be.undefined;
+        expect(raw['highway/service/private_driveway'].removeTags).to.be.undefined;
+    });
+
+    it('omits matchScore so plain service roads are not captured', function() {
+        const raw = iD.fileFetcher.cache().preset_custom_presets;
+        expect(raw['highway/service/customers'].matchScore).to.be.undefined;
+        expect(raw['highway/service/destination_sidewalk_left'].matchScore).to.be.undefined;
+    });
+
+    it('finds service presets by alias search', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        const byScsb = pool.search('scsb', 'line').collection.map((p) => p.id);
+        expect(byScsb).to.include('highway/service/customers_sidewalk_both');
+        const bySpud = pool.search('spud', 'line').collection.map((p) => p.id);
+        expect(bySpud).to.include('highway/service/private_unpaved_driveway');
+    });
+
+    it('defines the private unmaintained track preset', function() {
+        const preset = iD.presetManager.item('highway/track_private');
+        expect(preset).to.exist;
+        expect(preset.tags).to.eql({ highway: 'track', access: 'private' });
+        expect(preset.addTags.surface).to.equal('unpaved');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `highway=service` presets across the access dimension (customers / private / `motor_vehicle=destination`) and the `driveway` / `parking_aisle` subtypes, each with paved/unpaved, separate-sidewalk (both/left/right, `foot=use_sidepath`) and divided "opposite side" variants.
- Add the standalone `highway=track` + `access=private` preset.
- Refactor: extract the per-variant sidewalk tag map into a shared `sidewalk_variant_tags` module, reused by both the street and service presets (no behaviour change for streets).

## Notes / decisions
- Variant ids normalised footway-style (`highway/service/*` with `_sidewalk_*` / `_opposite_use_sidepath` suffixes), replacing v5's inconsistent `-`/`_separate_` naming.
- Access matrix made symmetric vs v5: adds `customers_sidewalk_right` and `destination_unpaved`.
- `matchScore` omitted (v5 used 0.9) so plain service roads are not captured.
- Pre-existing alias collision noted (`tsn` between `footway/crossing/traffic_signals` and `tertiary_sidewalk_no`) — not introduced here.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/` (100 passed)
- [x] preset/locale consistency + alias collision check (no new collisions)