### PR TITLE
Presets: add steps variants (customers / private / dismount)

### DIFF
--- a/data/custom-tagging/src/presets/highway/steps_variants.ts
+++ b/data/custom-tagging/src/presets/highway/steps_variants.ts
@@ -1,0 +1,34 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Steps variants (highway=steps + a distinguishing tag), all defaulting to a
+// concrete surface. Fields are inherited from the upstream highway/steps preset.
+// These are standalone presets: none overrides the base highway/steps.
+
+/** Suffix -> distinguishing tag(s) added on top of `highway=steps`. */
+const STEPS_VARIANTS: Record<string, Record<string, string>> = {
+    customers: { access: 'customers' },
+    private: { access: 'private' },
+    dismount: { bicycle: 'dismount' }
+};
+
+function stepsPreset(suffix: string, variantTags: Record<string, string>): CustomPreset {
+    const tags = { highway: 'steps', ...variantTags };
+
+    return {
+        icon: 'iD-highway-steps',
+        geometry: ['line'],
+        fields: ['{highway/steps}'],
+        moreFields: ['{highway/steps}'],
+        tags,
+        addTags: { ...tags, surface: 'concrete' },
+        reference: { key: 'highway', value: 'steps' },
+        name: presetNameEn(`highway/steps_${suffix}`)
+    };
+}
+
+export const stepsVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    Object.entries(STEPS_VARIANTS).map(
+        ([suffix, variantTags]) => [`highway/steps_${suffix}`, stepsPreset(suffix, variantTags)] as const
+    )
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -11,6 +11,7 @@ import { restrictedFootwayVariantPresets } from './presets/highway/footway/restr
 import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_variants';
 import { serviceVariantPresets } from './presets/highway/service_variants';
 import { trackPrivatePresets } from './presets/highway/track_private';
+import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -42,6 +43,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...streetSidewalkVariantPresets,
     ...serviceVariantPresets,
     ...trackPrivatePresets,
+    ...stepsVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -748,5 +748,20 @@
         "name": "Private unmaintained track",
         "terms": "put, track, private, woods road, forest road, logging road, fire road, farm road, agricultural road, unmaintained, offroad, 4wd, 4x4",
         "aliases": "put"
+    },
+    "highway/steps_customers": {
+        "name": "Customers steps",
+        "terms": "stc, customers, steps, stairs, staircase, stairway",
+        "aliases": "stc"
+    },
+    "highway/steps_private": {
+        "name": "Private steps",
+        "terms": "stp, private, steps, stairs, staircase, stairway",
+        "aliases": "stp"
+    },
+    "highway/steps_dismount": {
+        "name": "Steps (dismount bicycle)",
+        "terms": "std, dismount, bicycle, steps, stairs, staircase, stairway",
+        "aliases": "std"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -748,5 +748,20 @@
         "name": "Chemin non entretenu privé",
         "terms": "put, chemin, piste, privé, chemin forestier, chemin de ferme, non entretenu, hors route, 4x4",
         "aliases": "put"
+    },
+    "highway/steps_customers": {
+        "name": "Escalier clients",
+        "terms": "stc, clients, escalier, escaliers, marches",
+        "aliases": "stc"
+    },
+    "highway/steps_private": {
+        "name": "Escalier privé",
+        "terms": "stp, privé, escalier, escaliers, marches",
+        "aliases": "stp"
+    },
+    "highway/steps_dismount": {
+        "name": "Escalier (vélo à pied)",
+        "terms": "std, vélo à pied, descendre du vélo, escalier, escaliers, marches",
+        "aliases": "std"
     }
 }

--- a/test/spec/presets/custom/steps.js
+++ b/test/spec/presets/custom/steps.js
@@ -1,0 +1,27 @@
+import { loadCustomPresets } from './setup.js';
+
+const CASES = [
+    { id: 'highway/steps_customers', tags: { highway: 'steps', access: 'customers' }, alias: 'stc' },
+    { id: 'highway/steps_private', tags: { highway: 'steps', access: 'private' }, alias: 'stp' },
+    { id: 'highway/steps_dismount', tags: { highway: 'steps', bicycle: 'dismount' }, alias: 'std' }
+];
+
+describe('custom presets — steps variants', function() {
+    loadCustomPresets();
+
+    CASES.forEach(function({ id, tags, alias }) {
+        it(`defines ${id} with concrete surface default`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.addTags.surface).to.equal('concrete');
+            expect(preset.tags).to.not.have.property('surface');
+        });
+
+        it(`finds ${id} by alias ${alias}`, function() {
+            const pool = iD.presetManager.matchAllGeometry(['line']);
+            const found = pool.search(alias, 'line').collection.map((p) => p.id);
+            expect(found).to.include(id);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add three standalone `highway=steps` presets, each defaulting to `surface=concrete`:
  - `highway/steps_customers` (`access=customers`)
  - `highway/steps_private` (`access=private`)
  - `highway/steps_dismount` (`bicycle=dismount`)
- None overrides the upstream `highway/steps` preset; each is a distinct id matched by its discriminating tag, inheriting fields via `{highway/steps}`.
- EN/FR locales with non-colliding aliases (`stc` / `stp` / `std`) and parametric tests.

## Test plan
- [x] `tsx scripts/compile_custom_presets_sources.ts` + `build_custom_presets.ts` (153 presets, no error)
- [x] `vitest run test/spec/presets/custom/steps.js` — 6/6 green
- [x] No alias collision for `stc` / `stp` / `std`