### PR TITLE
Preferences: add Theme section (picker + CSS import)

### DIFF
--- a/config/id.js
+++ b/config/id.js
@@ -6,6 +6,13 @@ const changesetEditorName = 'Chaire Mobilité iD';
 /** GitHub Pages path to the legacy v5 editor (trailing slash). */
 const legacyV5EditorPath = 'v5/';
 
+/**
+ * Predefined selectable UI themes. `url` points to a CSS file (relative to the
+ * editor or absolute). Empty for now; theme application is not yet implemented.
+ * @type {{ id: string, name: string, url: string }[]}
+ */
+const predefinedThemes = [];
+
 // cdns for external data packages
 const presetsCdnUrl = ENV__ID_PRESETS_CDN_URL
   || 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
@@ -62,6 +69,7 @@ const showDonationMessage = ENV__ID_SHOW_DONATION_MESSAGE !== 'false';
 export {
   changesetEditorName,
   legacyV5EditorPath,
+  predefinedThemes,
   presetsCdnUrl,
   ociCdnUrl,
   wmfSitematrixCdnUrl,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4412,6 +4412,39 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     font-style: italic;
 }
 
+/* Themes preferences - reuse the editing card look (description italic, etc.) */
+.theme-options-container .theme-pref {
+    margin-bottom: 10px;
+}
+.theme-options-container .theme-select {
+    width: 100%;
+}
+.theme-options-container .theme-upload-input {
+    width: 100%;
+}
+.theme-options-container .theme-uploaded-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+}
+.theme-options-container .theme-uploaded-remove {
+    flex: 0 0 auto;
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+/* theme-aware icon color, matching `.form-field-button .icon` */
+.theme-options-container .theme-uploaded-remove .icon {
+    fill: var(--text-color);
+    opacity: 0.5;
+}
+@media (hover: hover) {
+    .theme-options-container .theme-uploaded-remove:hover .icon {
+        opacity: 1;
+    }
+}
+
 .display-control .control-wrap {
     display: flex;
     align-items: center;

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -217,6 +217,14 @@
                     "title": "Compact feature editor",
                     "description": "Reduce padding and row height in the feature editor so more tags fit on screen."
                 }
+            },
+            "theme": {
+                "title": "Theme",
+                "select": "Theme",
+                "default": "Default",
+                "upload": "Import a CSS file",
+                "upload_description": "Add a custom theme from a .css file kept in your browser.",
+                "remove": "Remove theme"
             }
         },
         "lanes": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -217,6 +217,14 @@
                     "title": "Éditeur d'objet compact",
                     "description": "Réduit l'espacement et la hauteur des rangées dans l'éditeur d'objet pour afficher plus de tags à l'écran."
                 }
+            },
+            "theme": {
+                "title": "Thème",
+                "select": "Thème",
+                "default": "Défaut",
+                "upload": "Importer un fichier CSS",
+                "upload_description": "Ajouter un thème personnalisé depuis un fichier .css conservé dans votre navigateur.",
+                "remove": "Supprimer le thème"
             }
         },
         "lanes": {

--- a/modules/core/themes.ts
+++ b/modules/core/themes.ts
@@ -1,0 +1,89 @@
+import { prefs } from './preferences';
+import { predefinedThemes } from '../../config/id.js';
+
+// UI theme selection and storage. Uploaded CSS themes are kept in localStorage
+// alongside the other preferences (a single CSS file is well within the ~5 MB
+// quota). Applying the selected theme to the page is not implemented yet.
+
+/** Preference key holding the selected theme id. */
+export const THEME_PREF = 'preferences.theme';
+/** Preference key holding the JSON array of uploaded themes. */
+export const UPLOADED_THEMES_PREF = 'preferences.theme.uploaded';
+/** Id of the built-in (no custom CSS) theme. */
+export const DEFAULT_THEME_ID = 'default';
+
+/** A CSS theme imported by the user and stored in localStorage. */
+export interface UploadedTheme {
+    id: string;
+    name: string;
+    css: string;
+}
+
+/** A selectable entry in the theme picker. */
+export interface ThemeEntry {
+    id: string;
+    name?: string;
+    source: 'default' | 'predefined' | 'uploaded';
+}
+
+/**
+ * Uploaded themes stored in localStorage.
+ * @returns the stored themes (empty array on missing/invalid data)
+ */
+export function getUploadedThemes(): UploadedTheme[] {
+    try {
+        const raw = prefs(UPLOADED_THEMES_PREF);
+        const parsed = JSON.parse((typeof raw === 'string' ? raw : '') || '[]');
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+function saveUploadedThemes(themes: UploadedTheme[]): void {
+    prefs(UPLOADED_THEMES_PREF, JSON.stringify(themes));
+}
+
+/**
+ * Persist a new uploaded CSS theme.
+ * @param theme - display name and raw CSS text
+ * @returns the stored theme, with its generated id
+ */
+export function addUploadedTheme({ name, css }: { name: string; css: string }): UploadedTheme {
+    // Date.now() alone is not unique for files added in the same millisecond.
+    const id = `uploaded-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const theme: UploadedTheme = { id, name, css };
+    saveUploadedThemes([...getUploadedThemes(), theme]);
+    return theme;
+}
+
+/**
+ * Remove an uploaded theme; resets the selection to default if it was active.
+ * @param id - id of the theme to remove
+ */
+export function removeUploadedTheme(id: string): void {
+    saveUploadedThemes(getUploadedThemes().filter((t) => t.id !== id));
+    if (getSelectedThemeId() === id) setSelectedThemeId(DEFAULT_THEME_ID);
+}
+
+/** @returns the selected theme id (DEFAULT_THEME_ID when unset). */
+export function getSelectedThemeId(): string {
+    const raw = prefs(THEME_PREF);
+    return (typeof raw === 'string' && raw) ? raw : DEFAULT_THEME_ID;
+}
+
+/** @param id - the theme id to select */
+export function setSelectedThemeId(id: string): void {
+    prefs(THEME_PREF, id);
+}
+
+/**
+ * All selectable themes: built-in default, predefined (from config), uploaded.
+ */
+export function listThemes(): ThemeEntry[] {
+    return [
+        { id: DEFAULT_THEME_ID, source: 'default' },
+        ...predefinedThemes.map((t) => ({ id: t.id, name: t.name, source: 'predefined' as const })),
+        ...getUploadedThemes().map((t) => ({ id: t.id, name: t.name, source: 'uploaded' as const }))
+    ];
+}

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -3,6 +3,7 @@ import { uiPane } from '../pane';
 import { uiSectionEditingPreferences } from '../sections/editing_preferences';
 import { uiSectionPrivacy } from '../sections/privacy';
 import { uiSectionShortcutList } from '../sections/shortcut_list';
+import { uiSectionThemes } from '../sections/themes';
 
 export function uiPanePreferences(context) {
 
@@ -13,6 +14,7 @@ export function uiPanePreferences(context) {
     .iconName('fas-user-cog')
     .sections([
         uiSectionEditingPreferences(context),
+        uiSectionThemes(context),
         uiSectionShortcutList(context),
         uiSectionPrivacy(context)
     ]);

--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -16,6 +16,7 @@ export { uiSectionRawMemberEditor } from './raw_member_editor';
 export { uiSectionRawMembershipEditor } from './raw_membership_editor';
 export { uiSectionRawTagEditor } from './raw_tag_editor';
 export { uiSectionSelectionList } from './selection_list';
+export { uiSectionThemes } from './themes';
 export { uiSectionValidationIssues } from './validation_issues';
 export { uiSectionValidationOptions } from './validation_options';
 export { uiSectionValidationRules } from './validation_rules';

--- a/modules/ui/sections/themes.ts
+++ b/modules/ui/sections/themes.ts
@@ -1,0 +1,130 @@
+import { prefs } from '../../core/preferences';
+import { t } from '../../core/localizer';
+import { svgIcon } from '../../svg/icon';
+import { uiSection } from '../section';
+import type { ThemeEntry } from '../../core/themes';
+import {
+    THEME_PREF,
+    UPLOADED_THEMES_PREF,
+    addUploadedTheme,
+    getSelectedThemeId,
+    getUploadedThemes,
+    listThemes,
+    removeUploadedTheme,
+    setSelectedThemeId
+} from '../../core/themes';
+
+/**
+ * Preferences section to pick a UI theme from a predefined list or from CSS
+ * files imported by the user (kept in localStorage). The selected theme is only
+ * stored for now; applying it to the page is not implemented yet.
+ *
+ * @param context - the iD application context
+ * @returns the section
+ */
+export function uiSectionThemes(context: any) {
+
+    // uiSection is authored in JS; its fluent setters are added dynamically and
+    // are not visible to TS, hence the `any`.
+    const section: any = (uiSection('preferences-themes', context) as any)
+        .label(() => t.append('preferences.theme.title'))
+        .disclosureContent(renderDisclosureContent);
+
+    /** Display label for a theme entry (the built-in one is localized). */
+    function themeLabel(entry: ThemeEntry): string {
+        return entry.source === 'default' ? t('preferences.theme.default') : (entry.name || entry.id);
+    }
+
+    /** Read the selected CSS file, store it as a theme and select it. */
+    function onUploadFile(this: HTMLInputElement) {
+        const file = this.files && this.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = () => {
+            const theme = addUploadedTheme({
+                name: file.name.replace(/\.css$/i, ''),
+                css: String(reader.result || '')
+            });
+            setSelectedThemeId(theme.id);
+        };
+        reader.readAsText(file);
+        this.value = '';  // allow re-importing the same filename
+    }
+
+    function renderDisclosureContent(selection: any) {
+        let container = selection.selectAll('.theme-options-container').data([0]);
+
+        const containerEnter = container.enter()
+            .append('div')
+            .attr('class', 'display-options-container theme-options-container');
+
+        // theme picker
+        const pickerEnter = containerEnter.append('div').attr('class', 'theme-pref');
+        pickerEnter.append('label')
+            .attr('class', 'theme-select-label')
+            .call(t.append('preferences.theme.select'));
+        pickerEnter.append('select')
+            .attr('class', 'theme-select')
+            .on('change', function(this: HTMLSelectElement) { setSelectedThemeId(this.value); });
+
+        // inline CSS import
+        const uploadEnter = containerEnter.append('div').attr('class', 'theme-pref theme-upload');
+        uploadEnter.append('label')
+            .attr('class', 'theme-upload-label')
+            .call(t.append('preferences.theme.upload'));
+        uploadEnter.append('input')
+            .attr('type', 'file')
+            .attr('class', 'theme-upload-input')
+            .attr('accept', '.css,text/css')
+            .on('change', onUploadFile);
+        uploadEnter.append('div')
+            .attr('class', 'editing-option-description')
+            .call(t.append('preferences.theme.upload_description'));
+
+        container = containerEnter.merge(container);
+
+        // update: theme options
+        const options = container.select('.theme-select')
+            .selectAll('option')
+            .data(listThemes(), (d: ThemeEntry) => d.id);
+        options.exit().remove();
+        options.enter().append('option')
+            .merge(options)
+            .attr('value', (d: ThemeEntry) => d.id)
+            .text(themeLabel);
+        container.select('.theme-select').property('value', getSelectedThemeId());
+
+        // update: uploaded themes list with remove buttons
+        renderUploadedList(container);
+    }
+
+    function renderUploadedList(container: any) {
+        const list = container.selectAll('.theme-uploaded-list').data([0]);
+        const listMerged = list.enter()
+            .append('ul')
+            .attr('class', 'layer-list theme-uploaded-list')
+            .merge(list);
+
+        const items = listMerged.selectAll('.theme-uploaded-item')
+            .data(getUploadedThemes(), (d: any) => d.id);
+        items.exit().remove();
+
+        const itemsEnter = items.enter()
+            .append('li')
+            .attr('class', 'theme-uploaded-item');
+        itemsEnter.append('span').attr('class', 'theme-uploaded-name');
+        itemsEnter.append('button')
+            .attr('class', 'theme-uploaded-remove')
+            .attr('title', () => t('preferences.theme.remove'))
+            .on('click', (_d3_event: any, d: any) => removeUploadedTheme(d.id))
+            .call(svgIcon('#iD-operation-delete'));
+
+        itemsEnter.merge(items).select('.theme-uploaded-name').text((d: any) => d.name);
+    }
+
+    prefs.onChange(THEME_PREF, section.reRender);
+    prefs.onChange(UPLOADED_THEMES_PREF, section.reRender);
+
+    return section;
+}

--- a/test/spec/core/themes.ts
+++ b/test/spec/core/themes.ts
@@ -1,0 +1,78 @@
+import { prefs } from '../../../modules/core/preferences';
+import {
+    DEFAULT_THEME_ID,
+    THEME_PREF,
+    UPLOADED_THEMES_PREF,
+    addUploadedTheme,
+    getSelectedThemeId,
+    getUploadedThemes,
+    listThemes,
+    removeUploadedTheme,
+    setSelectedThemeId
+} from '../../../modules/core/themes';
+
+describe('core/themes', function() {
+
+    beforeEach(function() {
+        prefs(THEME_PREF, null);
+        prefs(UPLOADED_THEMES_PREF, null);
+    });
+
+    describe('selection', function() {
+        it('defaults to the built-in theme', function() {
+            expect(getSelectedThemeId()).to.equal(DEFAULT_THEME_ID);
+        });
+
+        it('persists the selected theme id', function() {
+            setSelectedThemeId('predefined-x');
+            expect(getSelectedThemeId()).to.equal('predefined-x');
+        });
+    });
+
+    describe('uploaded themes', function() {
+        it('stores an uploaded theme and returns it with an id', function() {
+            const theme = addUploadedTheme({ name: 'Dark', css: 'body{}' });
+            expect(theme.id).to.be.a('string');
+            expect(theme.id.length).to.be.greaterThan(0);
+            expect(getUploadedThemes()).to.eql([theme]);
+        });
+
+        it('lists uploaded themes after the default with source "uploaded"', function() {
+            const theme = addUploadedTheme({ name: 'Dark', css: 'body{}' });
+            const entries = listThemes();
+            expect(entries[0]).to.include({ id: DEFAULT_THEME_ID, source: 'default' });
+            expect(entries).to.deep.include({ id: theme.id, name: 'Dark', source: 'uploaded' });
+        });
+
+        it('removes an uploaded theme', function() {
+            const theme = addUploadedTheme({ name: 'Dark', css: 'body{}' });
+            removeUploadedTheme(theme.id);
+            expect(getUploadedThemes()).to.eql([]);
+        });
+
+        it('resets the selection to default when the active theme is removed', function() {
+            const theme = addUploadedTheme({ name: 'Dark', css: 'body{}' });
+            setSelectedThemeId(theme.id);
+            removeUploadedTheme(theme.id);
+            expect(getSelectedThemeId()).to.equal(DEFAULT_THEME_ID);
+        });
+
+        it('keeps the selection when another theme is removed', function() {
+            const keep = addUploadedTheme({ name: 'Keep', css: 'a{}' });
+            const drop = addUploadedTheme({ name: 'Drop', css: 'b{}' });
+            setSelectedThemeId(keep.id);
+            removeUploadedTheme(drop.id);
+            expect(getSelectedThemeId()).to.equal(keep.id);
+        });
+    });
+
+    describe('robust parsing of stored value', function() {
+        // malformed stored values must degrade to an empty list, never throw
+        ['not json', '{}', '"x"', '42', 'null'].forEach(function(raw) {
+            it(`returns [] for stored value ${JSON.stringify(raw)}`, function() {
+                prefs(UPLOADED_THEMES_PREF, raw);
+                expect(getUploadedThemes()).to.eql([]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add a **Theme** section to the Preferences pane to pick a UI theme from a predefined list (configured in `config/id.js`) or from CSS files imported by the user.
- Uploaded themes are stored in `localStorage` (a single CSS file is well within the ~5 MB quota); the selected theme id is stored under a preference key.
- **Scope: form only** — storing/selecting/importing/removing themes. The selected theme is **not applied** to the page yet (no CSS injection); that comes in a follow-up.

## Changes
- `modules/core/themes.ts` — localStorage-backed helpers (`listThemes`, `getUploadedThemes`, `addUploadedTheme`, `removeUploadedTheme`, `get/setSelectedThemeId`), robust parsing that degrades to `[]` on invalid data.
- `modules/ui/sections/themes.ts` — theme `<select>`, inline CSS file import, list of uploaded themes with theme-aware remove buttons.
- `config/id.js` — `predefinedThemes` (empty for now).
- EN/FR locales under `general.preferences.theme.*`.
- `css/80_app.css` — section styling; remove-button icon uses `--text-color` (matches `.form-field-button .icon`) so it is visible in dark mode.
- `test/spec/core/themes.ts` — parametric tests for the theme helpers.

## Test plan
- [x] `yarn lint` — clean
- [x] `tsc` — new files clean (a pre-existing `directional_group.ts` error is unrelated and untouched here)
- [x] Theme helper tests green (12/12)

### Running the tests locally (localStorage note)
The theme helpers persist through `localStorage`. Vitest runs under jsdom, whose `localStorage` works out of the box on **Node 22** (the version used in CI). On **Node 23+**, Node ships an experimental built-in `localStorage` that requires a valid `--localstorage-file`; without it every `setItem` throws and the persistence tests fail locally (not a product bug). Two ways to run them:

- Use Node 22 (CI parity): `nvm use 22 && yarn test:once test/spec/core/themes.ts`
- Or, on newer Node, point Node's built-in localStorage at a scratch file:
  `NODE_OPTIONS="--localstorage-file=$(mktemp)" yarn test:once test/spec/core/themes.ts`