### PR TITLE
Inspector: location & imagery links + custom street-level imagery URL

### DIFF
--- a/config/id.js
+++ b/config/id.js
@@ -13,6 +13,25 @@ const legacyV5EditorPath = 'v5/';
  */
 const predefinedThemes = [];
 
+/**
+ * Street-level imagery providers shown in the entity editor location links.
+ * `url` is a template with `{lat}`, `{lon}` and `{zoom}` placeholders. Custom
+ * providers will be configurable later (like custom map backgrounds).
+ * @type {{ id: string, name: string, url: string }[]}
+ */
+const streetLevelImagery = [
+  {
+    id: 'panoramax',
+    name: 'Panoramax',
+    url: 'https://api.panoramax.xyz/?focus=map&map={zoom}/{lat}/{lon}'
+  },
+  {
+    id: 'mapillary',
+    name: 'Mapillary',
+    url: 'https://www.mapillary.com/app/?lat={lat}&lng={lon}&z={zoom}'
+  }
+];
+
 // cdns for external data packages
 const presetsCdnUrl = ENV__ID_PRESETS_CDN_URL
   || 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
@@ -70,6 +89,7 @@ export {
   changesetEditorName,
   legacyV5EditorPath,
   predefinedThemes,
+  streetLevelImagery,
   presetsCdnUrl,
   ociCdnUrl,
   wmfSitematrixCdnUrl,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4447,6 +4447,9 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 
 /* Entity editor location links (street-level imagery + copyable coordinates)
 ------------------------------------------------------- */
+.location-links-container {
+    padding: 10px;
+}
 .location-links-container .street-level-imagery-links {
     display: flex;
     flex-wrap: wrap;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4445,6 +4445,39 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     }
 }
 
+/* Entity editor location links (street-level imagery + copyable coordinates)
+------------------------------------------------------- */
+.location-links-container .street-level-imagery-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 15px;
+    margin-bottom: 10px;
+}
+.location-links-container .street-level-imagery-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.location-links-container .location-coordinates {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.location-links-container .location-coordinate {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-bottom: 3px;
+}
+.location-links-container .location-coordinate-value {
+    flex: 1 1 auto;
+    font-family: monospace;
+    word-break: break-all;
+}
+.location-links-container .location-coordinate-copy {
+    flex: 0 0 auto;
+}
+
 .display-control .control-wrap {
     display: flex;
     align-items: center;

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -211,6 +211,11 @@
                 }
             }
         },
+        "inspector": {
+            "location_links": {
+                "title": "Location & imagery"
+            }
+        },
         "preferences": {
             "editing": {
                 "dense": {

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -209,11 +209,31 @@
                         "description": "Name written to the imagery_used tag for the changeset"
                     }
                 }
+            },
+            "custom_street_level_imagery": {
+                "header": "Custom Street-Level Imagery",
+                "instructions": "Enter a URL template for an external street-level imagery viewer. Use the {lat} and {lon} tokens, replaced with the selected node's coordinates. The {zoom} token is optional and is replaced with the map zoom level.",
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Provider name"
+                },
+                "url": {
+                    "label": "URL template",
+                    "placeholder": "https://example.com/?lat={lat}&lon={lon}&z={zoom}"
+                }
+            }
+        },
+        "background": {
+            "street_level_imagery": {
+                "title": "Street-level imagery",
+                "custom": "Custom",
+                "tooltip": "Edit custom street-level imagery URL"
             }
         },
         "inspector": {
             "location_links": {
-                "title": "Location & imagery"
+                "title": "Location & imagery",
+                "custom": "Custom"
             }
         },
         "preferences": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -209,11 +209,31 @@
                         "description": "Nom écrit dans imagery_used pour le changeset"
                     }
                 }
+            },
+            "custom_street_level_imagery": {
+                "header": "Imagerie au sol personnalisée",
+                "instructions": "Saisissez un gabarit d'URL vers un visualiseur d'imagerie au sol externe. Utilisez les jetons {lat} et {lon}, remplacés par les coordonnées du nœud sélectionné. Le jeton {zoom} est facultatif et est remplacé par le niveau de zoom de la carte.",
+                "name": {
+                    "label": "Nom",
+                    "placeholder": "Nom du fournisseur"
+                },
+                "url": {
+                    "label": "Gabarit d'URL",
+                    "placeholder": "https://exemple.com/?lat={lat}&lon={lon}&z={zoom}"
+                }
+            }
+        },
+        "background": {
+            "street_level_imagery": {
+                "title": "Imagerie au sol",
+                "custom": "Personnalisée",
+                "tooltip": "Modifier l'URL d'imagerie au sol personnalisée"
             }
         },
         "inspector": {
             "location_links": {
-                "title": "Localisation et imagerie"
+                "title": "Localisation et imagerie",
+                "custom": "Personnalisée"
             }
         },
         "preferences": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -211,6 +211,11 @@
                 }
             }
         },
+        "inspector": {
+            "location_links": {
+                "title": "Localisation et imagerie"
+            }
+        },
         "preferences": {
             "editing": {
                 "dense": {

--- a/modules/core/street_level_imagery.ts
+++ b/modules/core/street_level_imagery.ts
@@ -1,0 +1,43 @@
+import { prefs } from './preferences';
+import { streetLevelImagery } from '../../config/id.js';
+
+/** Preference key for the custom street-level imagery URL template. */
+export const STREET_LEVEL_CUSTOM_URL_PREF = 'streetlevel-custom-url';
+/** Preference key for the custom street-level imagery display name. */
+export const STREET_LEVEL_CUSTOM_NAME_PREF = 'streetlevel-custom-name';
+/** Id used for the user-defined provider. */
+export const STREET_LEVEL_CUSTOM_ID = 'custom';
+
+/** A street-level imagery provider whose `url` is a {lat}/{lon}/{zoom} template. */
+export interface StreetLevelProvider {
+    id: string;
+    name: string;
+    url: string;
+}
+
+/**
+ * The user-defined custom street-level imagery provider, or `null` when no
+ * custom URL is configured.
+ * @returns The custom provider, or `null`.
+ */
+export function getCustomStreetLevelImagery(): StreetLevelProvider | null {
+    const rawUrl = prefs(STREET_LEVEL_CUSTOM_URL_PREF);
+    const url = (typeof rawUrl === 'string' ? rawUrl : '').trim();
+    if (url === '') return null;
+
+    const rawName = prefs(STREET_LEVEL_CUSTOM_NAME_PREF);
+    return {
+        id: STREET_LEVEL_CUSTOM_ID,
+        name: (typeof rawName === 'string' ? rawName : '').trim(),
+        url
+    };
+}
+
+/**
+ * Built-in street-level imagery providers plus the custom one when configured.
+ * @returns Ordered list of providers (built-ins first, custom last).
+ */
+export function listStreetLevelImagery(): StreetLevelProvider[] {
+    const custom = getCustomStreetLevelImagery();
+    return custom ? [...streetLevelImagery, custom] : [...streetLevelImagery];
+}

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -12,6 +12,7 @@ import { utilCleanTags, utilCombinedTags, utilRebind } from '../util';
 
 import { uiSectionEntityIssues } from './sections/entity_issues';
 import { uiSectionFeatureType } from './sections/feature_type';
+import { uiSectionLocationLinks } from './sections/location_links';
 import { uiSectionPresetFields } from './sections/preset_fields';
 import { uiSectionRawMemberEditor } from './sections/raw_member_editor';
 import { uiSectionRawMembershipEditor } from './sections/raw_membership_editor';
@@ -97,7 +98,8 @@ export function uiEntityEditor(context) {
                 uiSectionPresetFields(context).on('change', changeTags).on('revert', revertTags),
                 uiSectionRawTagEditor('raw-tag-editor', context).on('change', changeTags),
                 uiSectionRawMemberEditor(context),
-                uiSectionRawMembershipEditor(context)
+                uiSectionRawMembershipEditor(context),
+                uiSectionLocationLinks(context)
             ];
         }
 

--- a/modules/ui/panes/background.js
+++ b/modules/ui/panes/background.js
@@ -5,6 +5,7 @@ import { uiSectionBackgroundDisplayOptions } from '../sections/background_displa
 import { uiSectionBackgroundList } from '../sections/background_list';
 import { uiSectionBackgroundOffset } from '../sections/background_offset';
 import { uiSectionOverlayList } from '../sections/overlay_list';
+import { uiSectionStreetLevelImagery } from '../sections/street_level_imagery';
 
 export function uiPaneBackground(context) {
 
@@ -16,6 +17,7 @@ export function uiPaneBackground(context) {
         .sections([
             uiSectionBackgroundList(context),
             uiSectionOverlayList(context),
+            uiSectionStreetLevelImagery(context),
             uiSectionBackgroundDisplayOptions(context),
             uiSectionBackgroundOffset(context)
         ]);

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -10,6 +10,7 @@ import { uiTooltip } from './tooltip';
 import { geoExtent } from '../geo/extent';
 import { uiPresetIcon } from './preset_icon';
 import { uiTagReference } from './tag_reference';
+import { uiSectionLocationLinks } from './sections/location_links';
 import { utilKeybinding, utilNoAuto, utilRebind } from '../util';
 
 
@@ -19,6 +20,9 @@ export function uiPresetList(context) {
     var _currLoc;
     var _currentPresets;
     var _autofocus = false;
+    // tagless nodes (e.g. vertices) default to this list instead of the entity
+    // editor, so surface the same location/imagery section here too
+    var locationLinks = uiSectionLocationLinks(context);
 
 
     function presetList(selection) {
@@ -142,6 +146,9 @@ export function uiPresetList(context) {
 
         listWrap.node().scrollTo({ top: 0 });
         context.features().on('change.preset-list', updateForFeatureHiddenState);
+
+        locationLinks.entityIDs(_entityIDs);
+        selection.call(locationLinks.render);
     }
 
 

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -148,7 +148,7 @@ export function uiPresetList(context) {
         context.features().on('change.preset-list', updateForFeatureHiddenState);
 
         locationLinks.entityIDs(_entityIDs);
-        selection.call(locationLinks.render);
+        listWrap.call(locationLinks.render);
     }
 
 

--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -17,6 +17,7 @@ export { uiSectionRawMemberEditor } from './raw_member_editor';
 export { uiSectionRawMembershipEditor } from './raw_membership_editor';
 export { uiSectionRawTagEditor } from './raw_tag_editor';
 export { uiSectionSelectionList } from './selection_list';
+export { uiSectionStreetLevelImagery } from './street_level_imagery';
 export { uiSectionThemes } from './themes';
 export { uiSectionValidationIssues } from './validation_issues';
 export { uiSectionValidationOptions } from './validation_options';

--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -6,6 +6,7 @@ export { uiSectionDataLayers } from './data_layers';
 export { uiSectionEditingPreferences } from './editing_preferences';
 export { uiSectionEntityIssues } from './entity_issues';
 export { uiSectionFeatureType } from './feature_type';
+export { uiSectionLocationLinks } from './location_links';
 export { uiSectionMapFeatures } from './map_features';
 export { uiSectionMapStyleOptions } from './map_style_options';
 export { uiSectionOverlayList } from './overlay_list';

--- a/modules/ui/sections/location_links.ts
+++ b/modules/ui/sections/location_links.ts
@@ -1,0 +1,133 @@
+import { t } from '../../core/localizer';
+import { svgIcon } from '../../svg/icon';
+import { uiSection } from '../section';
+import { streetLevelImagery } from '../../../config/id.js';
+
+/** Map zoom level used in street-level imagery permalinks. */
+const IMAGERY_ZOOM = 18;
+
+/** A copyable coordinate representation of a node. */
+interface CoordinateFormat {
+    id: string;
+    value: string;
+}
+
+/**
+ * Build the copyable coordinate strings for a node, mirroring the legacy v5
+ * formats: `lat,lon`, `[lon,lat]` and `osmId,lat,lon`.
+ * @param loc Node location as `[lon, lat]` (iD convention).
+ * @param osmId Numeric OSM id of the node.
+ * @returns Ordered list of `{ id, value }` formats.
+ */
+export function formatCoordinates(loc: [number, number], osmId: number): CoordinateFormat[] {
+    const [lon, lat] = loc;
+    return [
+        { id: 'latlon', value: `${lat},${lon}` },
+        { id: 'lonlat', value: `[${lon},${lat}]` },
+        { id: 'id_latlon', value: `${osmId},${lat},${lon}` }
+    ];
+}
+
+/**
+ * Fill an imagery URL template, replacing the `{lat}`, `{lon}` and `{zoom}`
+ * placeholders.
+ * @param template URL template, e.g. `https://.../?map={zoom}/{lat}/{lon}`.
+ * @param loc Node location as `[lon, lat]` (iD convention).
+ * @param zoom Map zoom level to embed in the permalink.
+ * @returns The resolved URL.
+ */
+export function fillImageryUrl(template: string, loc: [number, number], zoom: number): string {
+    const [lon, lat] = loc;
+    return template
+        .replaceAll('{lat}', String(lat))
+        .replaceAll('{lon}', String(lon))
+        .replaceAll('{zoom}', String(zoom));
+}
+
+/**
+ * Entity editor section shown below the tag form for a single existing node:
+ * street-level imagery links (Panoramax, Mapillary) and copyable coordinates.
+ * @param context The global iD context.
+ */
+export function uiSectionLocationLinks(context: any) {
+    let _entityIDs: string[] = [];
+
+    const section: any = (uiSection('location-links', context) as any)
+        .shouldDisplay(() => selectedNode() !== null)
+        .label(() => t.append('inspector.location_links.title'))
+        .disclosureContent(render);
+
+    // Only a single, already-uploaded node has a stable location and OSM id.
+    function selectedNode() {
+        if (_entityIDs.length !== 1) return null;
+        const entity = context.hasEntity(_entityIDs[0]);
+        return (entity && entity.type === 'node' && !entity.isNew()) ? entity : null;
+    }
+
+    function render(selection: any) {
+        const node = selectedNode();
+        if (!node) return;
+
+        const loc = node.loc as [number, number];
+
+        let container = selection.selectAll('.location-links-container').data([0]);
+        const containerEnter = container.enter()
+            .append('div')
+            .attr('class', 'location-links-container');
+        containerEnter.append('div').attr('class', 'street-level-imagery-links');
+        containerEnter.append('ul').attr('class', 'location-coordinates');
+        container = containerEnter.merge(container);
+
+        renderImageryLinks(container.select('.street-level-imagery-links'), loc);
+        renderCoordinates(container.select('.location-coordinates'), loc, node.osmId());
+    }
+
+    function renderImageryLinks(selection: any, loc: [number, number]) {
+        const links = selection.selectAll('a.street-level-imagery-link')
+            .data(streetLevelImagery, (d: any) => d.id);
+        links.exit().remove();
+
+        const linksEnter = links.enter()
+            .append('a')
+            .attr('class', 'street-level-imagery-link')
+            .attr('target', '_blank')
+            .attr('rel', 'noopener')
+            .call(svgIcon('#iD-icon-out-link', 'inline'));
+        linksEnter.append('span');
+
+        linksEnter.merge(links)
+            .attr('href', (d: any) => fillImageryUrl(d.url, loc, IMAGERY_ZOOM))
+            .select('span')
+            .text((d: any) => d.name);
+    }
+
+    function renderCoordinates(selection: any, loc: [number, number], osmId: number) {
+        const rows = selection.selectAll('li.location-coordinate')
+            .data(formatCoordinates(loc, osmId), (d: CoordinateFormat) => d.id);
+        rows.exit().remove();
+
+        const rowsEnter = rows.enter()
+            .append('li')
+            .attr('class', 'location-coordinate');
+        rowsEnter.append('span').attr('class', 'location-coordinate-value');
+        rowsEnter.append('button')
+            .attr('class', 'form-field-button location-coordinate-copy')
+            .attr('title', t('icons.copy'))
+            .call(svgIcon('#iD-operation-copy'))
+            .on('click', (d3_event: Event, d: CoordinateFormat) => {
+                d3_event.preventDefault();
+                navigator.clipboard?.writeText(d.value);
+            });
+
+        rowsEnter.merge(rows)
+            .select('.location-coordinate-value')
+            .text((d: CoordinateFormat) => d.value);
+    }
+
+    section.entityIDs = function(val: string[]) {
+        _entityIDs = val || [];
+        return section;
+    };
+
+    return section;
+}

--- a/modules/ui/sections/location_links.ts
+++ b/modules/ui/sections/location_links.ts
@@ -1,7 +1,12 @@
 import { t } from '../../core/localizer';
+import { prefs } from '../../core/preferences';
 import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
-import { streetLevelImagery } from '../../../config/id.js';
+import {
+    STREET_LEVEL_CUSTOM_NAME_PREF,
+    STREET_LEVEL_CUSTOM_URL_PREF,
+    listStreetLevelImagery
+} from '../../core/street_level_imagery';
 
 /** Map zoom level used in street-level imagery permalinks. */
 const IMAGERY_ZOOM = 18;
@@ -84,7 +89,7 @@ export function uiSectionLocationLinks(context: any) {
 
     function renderImageryLinks(selection: any, loc: [number, number]) {
         const links = selection.selectAll('a.street-level-imagery-link')
-            .data(streetLevelImagery, (d: any) => d.id);
+            .data(listStreetLevelImagery(), (d: any) => d.id);
         links.exit().remove();
 
         const linksEnter = links.enter()
@@ -98,7 +103,7 @@ export function uiSectionLocationLinks(context: any) {
         linksEnter.merge(links)
             .attr('href', (d: any) => fillImageryUrl(d.url, loc, IMAGERY_ZOOM))
             .select('span')
-            .text((d: any) => d.name);
+            .text((d: any) => d.name || t('inspector.location_links.custom'));
     }
 
     function renderCoordinates(selection: any, loc: [number, number], osmId: number) {
@@ -128,6 +133,10 @@ export function uiSectionLocationLinks(context: any) {
         _entityIDs = val || [];
         return section;
     };
+
+    // refresh imagery links when the custom street-level provider changes
+    prefs.onChange(STREET_LEVEL_CUSTOM_URL_PREF, section.reRender);
+    prefs.onChange(STREET_LEVEL_CUSTOM_NAME_PREF, section.reRender);
 
     return section;
 }

--- a/modules/ui/sections/location_links.ts
+++ b/modules/ui/sections/location_links.ts
@@ -19,18 +19,22 @@ interface CoordinateFormat {
 
 /**
  * Build the copyable coordinate strings for a node, mirroring the legacy v5
- * formats: `lat,lon`, `[lon,lat]` and `osmId,lat,lon`.
+ * formats: `lat,lon`, `[lon,lat]` and (when a stable OSM id exists) `osmId,lat,lon`.
  * @param loc Node location as `[lon, lat]` (iD convention).
- * @param osmId Numeric OSM id of the node.
+ * @param osmId Numeric OSM id of the node, or `null` for an unsaved node.
  * @returns Ordered list of `{ id, value }` formats.
  */
-export function formatCoordinates(loc: [number, number], osmId: number): CoordinateFormat[] {
+export function formatCoordinates(loc: [number, number], osmId: number | null): CoordinateFormat[] {
     const [lon, lat] = loc;
-    return [
+    const formats: CoordinateFormat[] = [
         { id: 'latlon', value: `${lat},${lon}` },
-        { id: 'lonlat', value: `[${lon},${lat}]` },
-        { id: 'id_latlon', value: `${osmId},${lat},${lon}` }
+        { id: 'lonlat', value: `[${lon},${lat}]` }
     ];
+    // a brand-new node only has a temporary negative id, which is not useful
+    if (osmId !== null) {
+        formats.push({ id: 'id_latlon', value: `${osmId},${lat},${lon}` });
+    }
+    return formats;
 }
 
 /**
@@ -62,11 +66,11 @@ export function uiSectionLocationLinks(context: any) {
         .label(() => t.append('inspector.location_links.title'))
         .disclosureContent(render);
 
-    // Only a single, already-uploaded node has a stable location and OSM id.
+    // A single selected node (saved or not); unsaved nodes still have a location.
     function selectedNode() {
         if (_entityIDs.length !== 1) return null;
         const entity = context.hasEntity(_entityIDs[0]);
-        return (entity && entity.type === 'node' && !entity.isNew()) ? entity : null;
+        return (entity && entity.type === 'node') ? entity : null;
     }
 
     function render(selection: any) {
@@ -83,8 +87,9 @@ export function uiSectionLocationLinks(context: any) {
         containerEnter.append('ul').attr('class', 'location-coordinates');
         container = containerEnter.merge(container);
 
+        const osmId = node.isNew() ? null : node.osmId();
         renderImageryLinks(container.select('.street-level-imagery-links'), loc);
-        renderCoordinates(container.select('.location-coordinates'), loc, node.osmId());
+        renderCoordinates(container.select('.location-coordinates'), loc, osmId);
     }
 
     function renderImageryLinks(selection: any, loc: [number, number]) {
@@ -106,7 +111,7 @@ export function uiSectionLocationLinks(context: any) {
             .text((d: any) => d.name || t('inspector.location_links.custom'));
     }
 
-    function renderCoordinates(selection: any, loc: [number, number], osmId: number) {
+    function renderCoordinates(selection: any, loc: [number, number], osmId: number | null) {
         const rows = selection.selectAll('li.location-coordinate')
             .data(formatCoordinates(loc, osmId), (d: CoordinateFormat) => d.id);
         rows.exit().remove();

--- a/modules/ui/sections/street_level_imagery.ts
+++ b/modules/ui/sections/street_level_imagery.ts
@@ -1,0 +1,57 @@
+import { t, localizer } from '../../core/localizer';
+import { svgIcon } from '../../svg/icon';
+import { uiSection } from '../section';
+import { uiTooltip } from '../tooltip';
+import { uiSettingsCustomStreetLevelImagery } from '../settings/custom_street_level_imagery';
+import { getCustomStreetLevelImagery } from '../../core/street_level_imagery';
+
+/**
+ * Background-pane section to configure a custom street-level imagery provider
+ * (a `{lat}/{lon}/{zoom}` permalink) used by the entity editor location links.
+ * @param context The global iD context.
+ */
+export function uiSectionStreetLevelImagery(context: any) {
+    const settings = uiSettingsCustomStreetLevelImagery()
+        .on('change', () => section.reRender());
+
+    const section: any = (uiSection('street-level-imagery', context) as any)
+        .label(() => t.append('background.street_level_imagery.title'))
+        .disclosureContent(render);
+
+    function customLabel(): string {
+        const custom = getCustomStreetLevelImagery();
+        if (custom && custom.name) return custom.name;
+        return t('background.street_level_imagery.custom');
+    }
+
+    function render(selection: any) {
+        let list = selection.selectAll('ul.layer-list').data([0]);
+        list = list.enter()
+            .append('ul')
+            .attr('class', 'layer-list layer-list-street-level-imagery')
+            .merge(list);
+
+        let item = list.selectAll('li.layer-custom').data([0]);
+        const itemEnter = item.enter()
+            .append('li')
+            .attr('class', 'layer-custom');
+
+        itemEnter.append('label').append('span');
+
+        itemEnter.append('button')
+            .attr('class', 'layer-browse')
+            .call((uiTooltip() as any)
+                .title(() => t.append('background.street_level_imagery.tooltip'))
+                .placement(localizer.textDirection() === 'rtl' ? 'right' : 'left'))
+            .on('click', (d3_event: Event) => {
+                d3_event.preventDefault();
+                context.container().call(settings);
+            })
+            .call(svgIcon('#iD-icon-more'));
+
+        item = itemEnter.merge(item);
+        item.select('label span').text(customLabel());
+    }
+
+    return section;
+}

--- a/modules/ui/settings/custom_street_level_imagery.ts
+++ b/modules/ui/settings/custom_street_level_imagery.ts
@@ -1,0 +1,88 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+
+import { prefs } from '../../core/preferences';
+import { t } from '../../core/localizer';
+import { uiConfirm } from '../confirm';
+import { utilNoAuto, utilRebind } from '../../util';
+import {
+    STREET_LEVEL_CUSTOM_NAME_PREF,
+    STREET_LEVEL_CUSTOM_URL_PREF
+} from '../../core/street_level_imagery';
+
+/**
+ * Modal editor for the custom street-level imagery permalink. The URL is a
+ * template using the `{lat}`, `{lon}` and `{zoom}` tokens, stored in prefs.
+ * @returns d3-callable component dispatching `change` on save.
+ */
+export function uiSettingsCustomStreetLevelImagery() {
+    const dispatch = d3_dispatch('change');
+
+    function render(selection: any) {
+        const orig = {
+            url: prefs(STREET_LEVEL_CUSTOM_URL_PREF) || '',
+            name: prefs(STREET_LEVEL_CUSTOM_NAME_PREF) || ''
+        };
+
+        const modal: any = uiConfirm(selection).okButton();
+        modal.classed('settings-modal settings-custom-street-level-imagery', true);
+
+        modal.select('.modal-section.header')
+            .append('h3')
+            .call(t.append('settings.custom_street_level_imagery.header'));
+
+        const textSection = modal.select('.modal-section.message-text');
+
+        textSection
+            .append('p')
+            .call(t.append('settings.custom_street_level_imagery.instructions'));
+
+        textSection
+            .append('label')
+            .attr('class', 'field-name-label')
+            .call(t.append('settings.custom_street_level_imagery.name.label'));
+        textSection
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'field-name')
+            .attr('placeholder', t('settings.custom_street_level_imagery.name.placeholder'))
+            .call(utilNoAuto)
+            .property('value', orig.name);
+
+        textSection
+            .append('label')
+            .attr('class', 'field-url-label')
+            .call(t.append('settings.custom_street_level_imagery.url.label'));
+        textSection
+            .append('textarea')
+            .attr('class', 'field-url')
+            .attr('placeholder', t('settings.custom_street_level_imagery.url.placeholder'))
+            .call(utilNoAuto)
+            .property('value', orig.url);
+
+        const buttonSection = modal.select('.modal-section.buttons');
+
+        buttonSection
+            .insert('button', '.ok-button')
+            .attr('class', 'button cancel-button secondary-action')
+            .call(t.append('confirm.cancel'));
+
+        buttonSection.select('.cancel-button')
+            .on('click.cancel', () => modal.close());
+
+        buttonSection.select('.ok-button')
+            .on('click.save', clickSave);
+
+        function clickSave(this: any) {
+            const url = textSection.select('.field-url').property('value').trim();
+            const name = textSection.select('.field-name').property('value').trim();
+            // store null to clear the preference entirely when emptied
+            prefs(STREET_LEVEL_CUSTOM_URL_PREF, url || null);
+            prefs(STREET_LEVEL_CUSTOM_NAME_PREF, name || null);
+            this.blur();
+            modal.close();
+            dispatch.call('change', this, { url, name });
+        }
+    }
+
+    return utilRebind(render, dispatch, 'on');
+}

--- a/test/spec/core/street_level_imagery.ts
+++ b/test/spec/core/street_level_imagery.ts
@@ -1,0 +1,55 @@
+import { prefs } from '../../../modules/core/preferences';
+import {
+    STREET_LEVEL_CUSTOM_ID,
+    STREET_LEVEL_CUSTOM_NAME_PREF,
+    STREET_LEVEL_CUSTOM_URL_PREF,
+    getCustomStreetLevelImagery,
+    listStreetLevelImagery
+} from '../../../modules/core/street_level_imagery';
+
+describe('core/street_level_imagery', function() {
+
+    beforeEach(function() {
+        prefs(STREET_LEVEL_CUSTOM_URL_PREF, null);
+        prefs(STREET_LEVEL_CUSTOM_NAME_PREF, null);
+    });
+
+    describe('getCustomStreetLevelImagery', function() {
+        const blankUrls: (string | null)[] = [null, '', '   '];
+
+        blankUrls.forEach((url) => {
+            it(`returns null for a blank url (${JSON.stringify(url)})`, function() {
+                if (url !== null) prefs(STREET_LEVEL_CUSTOM_URL_PREF, url);
+                expect(getCustomStreetLevelImagery()).to.equal(null);
+            });
+        });
+
+        it('returns the trimmed custom provider when set', function() {
+            prefs(STREET_LEVEL_CUSTOM_URL_PREF, '  https://x/{lat}/{lon}  ');
+            prefs(STREET_LEVEL_CUSTOM_NAME_PREF, '  My viewer  ');
+            expect(getCustomStreetLevelImagery()).to.eql({
+                id: STREET_LEVEL_CUSTOM_ID,
+                name: 'My viewer',
+                url: 'https://x/{lat}/{lon}'
+            });
+        });
+
+        it('defaults the name to an empty string', function() {
+            prefs(STREET_LEVEL_CUSTOM_URL_PREF, 'https://x/{lat}/{lon}');
+            expect(getCustomStreetLevelImagery()?.name).to.equal('');
+        });
+    });
+
+    describe('listStreetLevelImagery', function() {
+        it('lists only the built-in providers by default', function() {
+            const ids = listStreetLevelImagery().map((p) => p.id);
+            expect(ids).to.eql(['panoramax', 'mapillary']);
+        });
+
+        it('appends the custom provider last when configured', function() {
+            prefs(STREET_LEVEL_CUSTOM_URL_PREF, 'https://x/{lat}/{lon}');
+            const ids = listStreetLevelImagery().map((p) => p.id);
+            expect(ids).to.eql(['panoramax', 'mapillary', STREET_LEVEL_CUSTOM_ID]);
+        });
+    });
+});

--- a/test/spec/ui/sections/location_links.ts
+++ b/test/spec/ui/sections/location_links.ts
@@ -1,0 +1,46 @@
+import { fillImageryUrl, formatCoordinates } from '../../../../modules/ui/sections/location_links';
+
+describe('uiSectionLocationLinks helpers', function() {
+
+    const loc: [number, number] = [-73.5956629, 45.5411637];
+    const osmId = 3458747903;
+
+    describe('formatCoordinates', function() {
+        const cases: [string, string][] = [
+            ['latlon', '45.5411637,-73.5956629'],
+            ['lonlat', '[-73.5956629,45.5411637]'],
+            ['id_latlon', '3458747903,45.5411637,-73.5956629']
+        ];
+
+        cases.forEach(([id, expected]) => {
+            it(`formats "${id}"`, function() {
+                const match = formatCoordinates(loc, osmId).find(c => c.id === id);
+                expect(match?.value).to.equal(expected);
+            });
+        });
+
+        it('returns the formats in a stable order', function() {
+            expect(formatCoordinates(loc, osmId).map(c => c.id))
+                .to.eql(['latlon', 'lonlat', 'id_latlon']);
+        });
+    });
+
+    describe('fillImageryUrl', function() {
+        const cases: [string, string][] = [
+            [
+                'https://api.panoramax.xyz/?focus=map&map={zoom}/{lat}/{lon}',
+                'https://api.panoramax.xyz/?focus=map&map=18/45.5411637/-73.5956629'
+            ],
+            [
+                'https://www.mapillary.com/app/?lat={lat}&lng={lon}&z={zoom}',
+                'https://www.mapillary.com/app/?lat=45.5411637&lng=-73.5956629&z=18'
+            ]
+        ];
+
+        cases.forEach(([template, expected]) => {
+            it(`fills "${template}"`, function() {
+                expect(fillImageryUrl(template, loc, 18)).to.equal(expected);
+            });
+        });
+    });
+});

--- a/test/spec/ui/sections/location_links.ts
+++ b/test/spec/ui/sections/location_links.ts
@@ -23,6 +23,11 @@ describe('uiSectionLocationLinks helpers', function() {
             expect(formatCoordinates(loc, osmId).map(c => c.id))
                 .to.eql(['latlon', 'lonlat', 'id_latlon']);
         });
+
+        it('omits the id format for an unsaved node (null id)', function() {
+            expect(formatCoordinates(loc, null).map(c => c.id))
+                .to.eql(['latlon', 'lonlat']);
+        });
     });
 
     describe('fillImageryUrl', function() {


### PR DESCRIPTION
## Summary
- Add a **Location & imagery** section under the tag form (and at the bottom of the preset list for tagless nodes) for any single selected node, showing:
  - Street-level imagery permalinks (Panoramax, Mapillary, + optional custom)
  - Copyable coordinate formats (`lat,lon`, `[lon,lat]`, and `id,lat,lon` when the node is saved), each with a clipboard button.
  - Works for unsaved nodes too (coordinates computed from the node's location; the id-based format is omitted until a stable OSM id exists).
- Add a **Street-level imagery** section in the Background pane with a modal editor for a custom `{lat}/{lon}/{zoom}` permalink (`{zoom}` optional), stored in prefs — alongside the custom background imagery. The custom provider is appended to the built-in links.
- The legacy "Open on OSM" footer link is unchanged.

## Implementation notes
- Built-in providers live in `config/id.js` (`streetLevelImagery`) so custom URLs can be extended later, like map backgrounds.
- Pure helpers (`formatCoordinates`, `fillImageryUrl`) and the prefs layer (`core/street_level_imagery`) are covered by parametric tests.

## Test plan
- [ ] Select a saved node → section appears under tags with 3 coordinate formats + copy buttons; Panoramax/Mapillary links open at the node.
- [ ] Select a tagless vertex → section appears at the bottom of the (scrollable) preset list.
- [ ] Create a new node → section appears; only `lat,lon` and `[lon,lat]` shown.
- [ ] Background pane → "Street-level imagery" → edit custom URL; custom link appears in the node section and refreshes live.
- [ ] `yarn test` (CI, Node 22).

### Local test note (Node 23+)
Node's experimental built-in `localStorage` can throw "quota exceeded" in the test env. If `core/street_level_imagery` persistence tests fail locally, run with:
`NODE_OPTIONS="--localstorage-file=/tmp/idtest_ls" yarn test:spec`
This is a local-env quirk only; CI (Node 22) is unaffected.