### PR TITLE
Preferences: export/import settings as JSON

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4445,6 +4445,29 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     }
 }
 
+/* Preferences - settings backup (export/import)
+------------------------------------------------------- */
+.settings-backup-container > * {
+    margin-bottom: 8px;
+}
+.settings-backup-container .settings-backup-export {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 10px;
+    border-radius: 4px;
+}
+.settings-backup-container .settings-backup-import-label {
+    display: block;
+    font-weight: bold;
+}
+.settings-backup-container .settings-backup-import-input {
+    width: 100%;
+}
+.settings-backup-container .settings-backup-error {
+    color: var(--error-red, #d4334a);
+}
+
 /* Entity editor location links (street-level imagery + copyable coordinates)
 ------------------------------------------------------- */
 .location-links-container {

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -250,6 +250,13 @@
                 "upload": "Import a CSS file",
                 "upload_description": "Add a custom theme from a .css file kept in your browser.",
                 "remove": "Remove theme"
+            },
+            "backup": {
+                "title": "Backup settings",
+                "description": "Export your settings (preferences, custom imagery, etc.) to a file, or import them on another browser. Login credentials are never exported.",
+                "export": "Export settings",
+                "import": "Import settings",
+                "invalid_file": "This file is not a valid settings backup."
             }
         },
         "lanes": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -250,6 +250,13 @@
                 "upload": "Importer un fichier CSS",
                 "upload_description": "Ajouter un thème personnalisé depuis un fichier .css conservé dans votre navigateur.",
                 "remove": "Supprimer le thème"
+            },
+            "backup": {
+                "title": "Sauvegarde des réglages",
+                "description": "Exportez vos réglages (préférences, imagerie personnalisée, etc.) dans un fichier, ou importez-les sur un autre navigateur. Les identifiants de connexion ne sont jamais exportés.",
+                "export": "Exporter les réglages",
+                "import": "Importer les réglages",
+                "invalid_file": "Ce fichier n'est pas une sauvegarde de réglages valide."
             }
         },
         "lanes": {

--- a/modules/core/settings_backup.ts
+++ b/modules/core/settings_backup.ts
@@ -1,0 +1,137 @@
+import { prefs } from './preferences';
+
+// Export / import of the user's iD settings stored in localStorage so they can
+// be carried to another browser. localStorage is isolated per origin, so this
+// already captures only this iD deployment's keys. We still exclude OAuth
+// credentials and a few transient keys (see below).
+
+/** Envelope identifier written to the backup file. */
+export const BACKUP_TYPE = 'iD-settings-backup';
+/** Backup file format version. */
+export const BACKUP_VERSION = 1;
+
+/**
+ * Key suffixes for OAuth tokens (osm-auth prefixes them with the server URL,
+ * e.g. `https://www.openstreetmap.orgoauth2_access_token`). Never exported.
+ */
+export const SENSITIVE_KEY_SUFFIXES = [
+    'oauth2_access_token',
+    'oauth_token_secret',
+    'oauth_request_token_secret',
+    'oauth_token'
+];
+
+/** Transient / one-shot keys that are not useful to carry over. */
+export const EXCLUDED_KEYS = new Set([
+    'sawSplash',
+    'sawVersion',
+    'sawPrivacyVersion',
+    'walkthrough_started',
+    'walkthrough_progress',
+    'walkthrough_completed',
+    'commentDate',
+    'comment',
+    'hashtags',
+    'source'
+]);
+
+/**
+ * A flat map of preference key to its raw localStorage string value. Values are
+ * stored verbatim, so keys holding serialized data (e.g. `preferences.theme.uploaded`,
+ * a JSON-stringified array of `{ id, name, css }` themes) are kept as their
+ * escaped JSON string rather than being unfolded. This round-trips losslessly.
+ */
+export type SettingsMap = Record<string, string>;
+
+/** The on-disk backup file structure. */
+export interface SettingsBackup {
+    type: string;
+    version: number;
+    exportedAt: string;
+    data: SettingsMap;
+}
+
+/**
+ * Whether a localStorage key may be exported/imported (excludes credentials
+ * and transient keys).
+ * @param key The localStorage key.
+ * @returns `true` when the key is safe to back up.
+ */
+export function isExportableKey(key: string): boolean {
+    if (EXCLUDED_KEYS.has(key)) return false;
+    return !SENSITIVE_KEY_SUFFIXES.some((suffix) => key.endsWith(suffix));
+}
+
+/**
+ * Collect the exportable settings from localStorage.
+ * @returns A map of exportable key/value pairs (empty when localStorage is unavailable).
+ */
+export function exportSettings(): SettingsMap {
+    const data: SettingsMap = {};
+    try {
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key && isExportableKey(key)) {
+                data[key] = localStorage.getItem(key) ?? '';
+            }
+        }
+    } catch {
+        // localStorage unavailable; return whatever was collected
+    }
+    return data;
+}
+
+/**
+ * Build a backup envelope for the current settings.
+ * @returns The serialisable backup object.
+ */
+export function buildBackup(): SettingsBackup {
+    return {
+        type: BACKUP_TYPE,
+        version: BACKUP_VERSION,
+        exportedAt: new Date().toISOString(),
+        data: exportSettings()
+    };
+}
+
+/**
+ * Validate parsed JSON and extract its settings map. Accepts either a backup
+ * envelope or a plain key/value object.
+ * @param parsed The value produced by `JSON.parse`.
+ * @returns The settings map.
+ * @throws If the structure is not a valid settings object.
+ */
+export function parseBackup(parsed: unknown): SettingsMap {
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Invalid settings file');
+    }
+
+    const candidate = parsed as Record<string, unknown>;
+    const raw = ('data' in candidate && candidate.data && typeof candidate.data === 'object')
+        ? candidate.data as Record<string, unknown>
+        : candidate;
+
+    const data: SettingsMap = {};
+    for (const [key, value] of Object.entries(raw)) {
+        if (typeof value === 'string') data[key] = value;
+    }
+    if (Object.keys(data).length === 0) {
+        throw new Error('No settings found in file');
+    }
+    return data;
+}
+
+/**
+ * Merge imported settings into localStorage (overwrites matching keys, leaves
+ * others untouched). Credentials and transient keys are skipped.
+ * @param data The settings map to import.
+ * @returns The number of keys written.
+ */
+export function applyBackup(data: SettingsMap): number {
+    let count = 0;
+    for (const [key, value] of Object.entries(data)) {
+        if (!isExportableKey(key)) continue;
+        if (prefs(key, value)) count++;
+    }
+    return count;
+}

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -2,6 +2,7 @@ import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
 import { uiSectionEditingPreferences } from '../sections/editing_preferences';
 import { uiSectionPrivacy } from '../sections/privacy';
+import { uiSectionSettingsBackup } from '../sections/settings_backup';
 import { uiSectionShortcutList } from '../sections/shortcut_list';
 import { uiSectionThemes } from '../sections/themes';
 
@@ -16,6 +17,7 @@ export function uiPanePreferences(context) {
         uiSectionEditingPreferences(context),
         uiSectionThemes(context),
         uiSectionShortcutList(context),
+        uiSectionSettingsBackup(context),
         uiSectionPrivacy(context)
     ]);
 

--- a/modules/ui/sections/index.js
+++ b/modules/ui/sections/index.js
@@ -17,6 +17,7 @@ export { uiSectionRawMemberEditor } from './raw_member_editor';
 export { uiSectionRawMembershipEditor } from './raw_membership_editor';
 export { uiSectionRawTagEditor } from './raw_tag_editor';
 export { uiSectionSelectionList } from './selection_list';
+export { uiSectionSettingsBackup } from './settings_backup';
 export { uiSectionStreetLevelImagery } from './street_level_imagery';
 export { uiSectionThemes } from './themes';
 export { uiSectionValidationIssues } from './validation_issues';

--- a/modules/ui/sections/settings_backup.ts
+++ b/modules/ui/sections/settings_backup.ts
@@ -1,0 +1,94 @@
+import { t } from '../../core/localizer';
+import { svgIcon } from '../../svg/icon';
+import { uiSection } from '../section';
+import { applyBackup, buildBackup, parseBackup } from '../../core/settings_backup';
+
+/**
+ * Preferences section to export all iD settings (localStorage) to a JSON file
+ * and import them back, e.g. on another browser. OAuth credentials and a few
+ * transient keys are excluded; see `core/settings_backup`.
+ * @param context The iD application context.
+ */
+export function uiSectionSettingsBackup(context: any) {
+
+    const section: any = (uiSection('preferences-backup', context) as any)
+        .label(() => t.append('preferences.backup.title'))
+        .disclosureContent(render);
+
+    /** Serialise the current settings and trigger a file download. */
+    function onExport() {
+        const json = JSON.stringify(buildBackup(), null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = window.URL.createObjectURL(blob);
+        const date = new Date().toISOString().slice(0, 10);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `id-settings-${date}.json`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    }
+
+    /** Read the chosen file, merge its settings and reload to apply them. */
+    function onImportFile(this: HTMLInputElement, container: any) {
+        const file = this.files && this.files[0];
+        this.value = '';  // allow re-importing the same filename
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const data = parseBackup(JSON.parse(String(reader.result || '')));
+                applyBackup(data);
+                window.location.reload();
+            } catch {
+                showError(container);
+            }
+        };
+        reader.onerror = () => showError(container);
+        reader.readAsText(file);
+    }
+
+    function showError(container: any) {
+        container.select('.settings-backup-error')
+            .classed('hide', false)
+            .text('')
+            .call(t.append('preferences.backup.invalid_file'));
+    }
+
+    function render(selection: any) {
+        let container = selection.selectAll('.settings-backup-container').data([0]);
+        const enter = container.enter()
+            .append('div')
+            .attr('class', 'settings-backup-container');
+
+        enter.append('div')
+            .attr('class', 'editing-option-description')
+            .call(t.append('preferences.backup.description'));
+
+        const exportEnter = enter.append('button')
+            .attr('class', 'settings-backup-export')
+            .on('click', onExport);
+        exportEnter.call(svgIcon('#iD-icon-load', 'inline'));
+        exportEnter.append('span').call(t.append('preferences.backup.export'));
+
+        enter.append('label')
+            .attr('class', 'settings-backup-import-label')
+            .call(t.append('preferences.backup.import'));
+        enter.append('input')
+            .attr('type', 'file')
+            .attr('class', 'settings-backup-import-input')
+            .attr('accept', '.json,application/json');
+
+        enter.append('div')
+            .attr('class', 'settings-backup-error hide');
+
+        container = enter.merge(container);
+
+        // bind import here so the handler can target this container for errors
+        container.select('.settings-backup-import-input')
+            .on('change', function(this: HTMLInputElement) { onImportFile.call(this, container); });
+    }
+
+    return section;
+}

--- a/test/spec/core/settings_backup.ts
+++ b/test/spec/core/settings_backup.ts
@@ -1,0 +1,50 @@
+import {
+    BACKUP_TYPE,
+    isExportableKey,
+    parseBackup
+} from '../../../modules/core/settings_backup';
+
+describe('core/settings_backup', function() {
+
+    describe('isExportableKey', function() {
+        const cases: [string, boolean][] = [
+            ['preferences.theme', true],
+            ['background-custom-template', true],
+            ['streetlevel-custom-url', true],
+            ['https://www.openstreetmap.orgoauth2_access_token', false],
+            ['https://api06.dev.openstreetmap.orgoauth_token_secret', false],
+            ['https://www.openstreetmap.orgoauth_token', false],
+            ['sawSplash', false],
+            ['walkthrough_progress', false],
+            ['comment', false]
+        ];
+
+        cases.forEach(([key, expected]) => {
+            it(`${expected ? 'keeps' : 'excludes'} "${key}"`, function() {
+                expect(isExportableKey(key)).to.equal(expected);
+            });
+        });
+    });
+
+    describe('parseBackup', function() {
+        it('reads the data map from a backup envelope', function() {
+            const parsed = { type: BACKUP_TYPE, version: 1, data: { 'area-fill': 'partial' } };
+            expect(parseBackup(parsed)).to.eql({ 'area-fill': 'partial' });
+        });
+
+        it('accepts a plain key/value object', function() {
+            expect(parseBackup({ 'area-fill': 'partial' })).to.eql({ 'area-fill': 'partial' });
+        });
+
+        it('keeps only string values', function() {
+            expect(parseBackup({ a: 'x', b: 3, c: { nested: true } })).to.eql({ a: 'x' });
+        });
+
+        const invalid: unknown[] = [null, undefined, 'string', 42, {}, { data: {} }];
+        invalid.forEach((value, i) => {
+            it(`throws on invalid input #${i}`, function() {
+                expect(() => parseBackup(value)).to.throw();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add a **Backup settings** section in the Preferences pane to:
  - **Export** all iD settings stored in `localStorage` to a JSON file (`id-settings-<date>.json`).
  - **Import** a previously exported file (e.g. on another browser); settings are **merged** (matching keys overwritten, others kept) and the page reloads to apply them.
- **Excluded from export/import**:
  - OAuth credentials — any key ending with `oauth2_access_token`, `oauth_token`, `oauth_token_secret`, `oauth_request_token_secret` (osm-auth prefixes these with the server URL).
  - Transient/one-shot keys: `sawSplash`, `sawVersion`, `sawPrivacyVersion`, `walkthrough_*`, `commentDate`, and changeset draft text (`comment`, `hashtags`, `source`).

## Notes
- `localStorage` is partitioned per origin, so this already captures only this iD deployment's keys.
- Values are kept verbatim (strings), so serialized entries like `preferences.theme.uploaded` (uploaded CSS themes) round-trip losslessly.
- Pure helpers (`isExportableKey`, `parseBackup`) are covered by parametric tests.

## Test plan
- [ ] Preferences → Backup settings → Export downloads a JSON file with your settings.
- [ ] Confirm the file contains no `oauth*` token keys.
- [ ] Import the file in another browser/profile → settings applied after reload (theme, custom imagery, background, editor options, preset shortcuts/favorites).
- [ ] Import an invalid file → error message, no reload.
- [ ] `yarn test` (CI, Node 22).