### PR TITLE
Address: add borough and contact:city fields for Canada

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -124,7 +124,8 @@
     "countryCodes": ["ca"],
     "format": [
       ["housenumber", "street", "unit"],
-      ["city", "province", "postcode"]
+      ["city", "province", "postcode"],
+      ["borough", { "id": "postal_city", "key": "contact:city" }]
     ]
   },
   {

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -2,6 +2,12 @@
     "tagging": {
         "presets": {
             "fields": {
+                "address": {
+                    "placeholders": {
+                        "borough": "Borough",
+                        "postal_city": "Postal city (Canada Post)"
+                    }
+                },
                 "capacity_charging": {
                     "label": "Capacity for charging electric vehicles",
                     "placeholder": "1, 5, 10..."

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -2,6 +2,12 @@
     "tagging": {
         "presets": {
             "fields": {
+                "address": {
+                    "placeholders": {
+                        "borough": "Arrondissement",
+                        "postal_city": "Municipalité postale (Postes Canada)"
+                    }
+                },
                 "capacity_charging": {
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -149,6 +149,18 @@ export function uiFieldAddress(field, context) {
         return utilArrayUniqBy(postcodes, item => item.value);
     }
 
+    // Like getNearValues, but for the `contact:city` tag (the postal municipality),
+    // since getNearValues hardcodes the `addr:` prefix.
+    function getNearContactCity() {
+        const tagKey = 'contact:city';
+
+        function hasTag(d) {
+            return _entityIDs.indexOf(d.id) === -1 && d.tags[tagKey];
+        }
+
+        return getNear(hasTag, 'postal_city', 200, tagKey);
+    }
+
     function getNearValues(key) {
         const tagKey = `${field.key}:${key}`;
 
@@ -212,7 +224,9 @@ export function uiFieldAddress(field, context) {
         ]);
         const dropdowns = new Set([
             'block_number',
+            'borough',
             'city',
+            'postal_city',
             'country',
             'county',
             'district',
@@ -237,23 +251,34 @@ export function uiFieldAddress(field, context) {
             city: 2/3, state: 1/4, postcode: 1/3
         };
 
+        // A format entry is either a subfield id string (tag key defaults to
+        // `<field.key>:<id>`, e.g. `addr:city`) or an object `{ id, key }` that
+        // overrides the tag key, allowing cross-namespace subfields (e.g.
+        // `{ id: 'postal_city', key: 'contact:city' }`).
+        function entryId(entry) {
+            return typeof entry === 'string' ? entry : entry.id;
+        }
+
         function row(r) {
             // Normalize widths.
-            var total = r.reduce(function(sum, key) {
-                return sum + (widths[key] || 0.5);
+            var total = r.reduce(function(sum, entry) {
+                return sum + (widths[entryId(entry)] || 0.5);
             }, 0);
 
-            return r.map(function(key) {
-                return {
-                    id: key,
-                    width: (widths[key] || 0.5) / total
+            return r.map(function(entry) {
+                var id = entryId(entry);
+                var subfield = {
+                    id: id,
+                    width: (widths[id] || 0.5) / total
                 };
+                if (typeof entry !== 'string' && entry.key) subfield.key = entry.key;
+                return subfield;
             });
         }
 
         var rows = _wrap.selectAll('.addr-row')
             .data(addressFormat.format, function(d) {
-                return d.toString();
+                return JSON.stringify(d);
             });
 
         rows.exit()
@@ -298,6 +323,9 @@ export function uiFieldAddress(field, context) {
                 break;
                 case 'city':
                     nearValues = getNearCities;
+                break;
+                case 'postal_city':
+                    nearValues = getNearContactCity;
                 break;
                 case 'postcode':
                     nearValues = getNearPostcodes;
@@ -376,13 +404,20 @@ export function uiFieldAddress(field, context) {
     }
 
 
+    // Tag key for a subfield: an explicit override (e.g. `contact:city`) or the
+    // default `<field.key>:<subfield.id>` (e.g. `addr:city`).
+    function tagKey(subfield) {
+        return subfield.key || field.key + ':' + subfield.id;
+    }
+
+
     function change(onInput) {
         return function() {
             var tags = {};
 
             _wrap.selectAll('input')
                 .each(function (subfield) {
-                    var key = field.key + ':' + subfield.id;
+                    var key = tagKey(subfield);
 
                     var value = this.value;
                     if (!onInput) value = context.cleanTagValue(value);
@@ -411,7 +446,7 @@ export function uiFieldAddress(field, context) {
 
     function updatePlaceholder(inputSelection) {
         return inputSelection.attr('placeholder', function(subfield) {
-            if (_tags && Array.isArray(_tags[field.key + ':' + subfield.id])) {
+            if (_tags && Array.isArray(_tags[tagKey(subfield)])) {
                 return t('inspector.multiple_values');
             }
             if (subfield.isAutoStreetPlace) {
@@ -446,16 +481,16 @@ export function uiFieldAddress(field, context) {
                         subfield.id = 'place';
                     }
                 } else {
-                    val = tags[`${field.key}:${subfield.id}`];
+                    val = tags[tagKey(subfield)];
                 }
                 return typeof val === 'string' ? val : '';
             })
             .attr('title', function(subfield) {
-                var val = tags[field.key + ':' + subfield.id];
+                var val = tags[tagKey(subfield)];
                 return (val && Array.isArray(val)) ? val.filter(Boolean).join('\n') : undefined;
             })
             .classed('mixed', function(subfield) {
-                return Array.isArray(tags[field.key + ':' + subfield.id]);
+                return Array.isArray(tags[tagKey(subfield)]);
             })
             .call(updatePlaceholder);
     }


### PR DESCRIPTION
## Summary
- Generalize the address field: a format entry can be a subfield id (tag key defaults to `addr:<id>`) or an object `{ id, key }` overriding the tag key, enabling cross-namespace subfields like `contact:city`.
- Extend the Canada (`ca`) address format with `addr:borough` and `contact:city` (postal municipality), with EN/FR placeholders (Borough/Arrondissement, Postal city/Municipalité postale).
- Nearby-value autocomplete for both new fields: `borough` suggests surrounding `addr:borough` values; `postal_city` suggests surrounding `contact:city` values via a dedicated `getNearContactCity` helper (`getNearValues` hardcodes the `addr:` prefix).
- `clone_address` already included `addr:borough` and `contact:city`, so cloning copies both with no change.

## Notes
- Scope is **Canada** (country-level), since `address_formats` are keyed by country code and country-coder has no Québec subdivision.
- Existing string format entries (incl. `street+place`) are unchanged; only the data-join key switched to `JSON.stringify` to support object entries.

## Test plan
- [ ] Select a node in Canada → address field shows Borough and Postal city inputs.
- [ ] Type in Borough → suggestions from nearby `addr:borough`; saving writes `addr:borough`.
- [ ] Type in Postal city → suggestions from nearby `contact:city`; saving writes `contact:city`.
- [ ] Clone address onto another node copies `addr:borough` and `contact:city`.
- [ ] Placeholders render in EN and FR.