### PR TITLE
dual_carriageway: compact check field instead of radio

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -52,11 +52,7 @@
                     "label": "Bus lanes"
                 },
                 "dual_carriageway": {
-                    "label": "Dual carriageway",
-                    "options": {
-                        "yes": "Yes",
-                        "no": "No"
-                    }
+                    "label": "Dual carriageway"
                 },
                 "junction_oneway": {
                     "label": "Junction",

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -52,11 +52,7 @@
                     "label": "Voies réservées bus"
                 },
                 "dual_carriageway": {
-                    "label": "Chaussée séparée",
-                    "options": {
-                        "yes": "Oui",
-                        "no": "Non"
-                    }
+                    "label": "Chaussée séparée"
                 },
                 "junction_oneway": {
                     "label": "Jonction",

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -122,11 +122,10 @@ export const customFields = {
         prerequisiteTag: { key: 'lanes', valueGreaterThan: 1 }
     },
     // Marks a one-way carriageway that is half of a divided road (`dual_carriageway=yes`).
-    // Shown only when `oneway=yes` (same as v5).
+    // Shown only when `oneway=yes`. A compact tri-state check (unset/yes/no).
     dual_carriageway: {
         key: 'dual_carriageway',
-        type: 'radio',
-        options: ['yes', 'no'],
+        type: 'check',
         geometry: ['line'],
         prerequisiteTag: { key: 'oneway', value: 'yes' }
     },


### PR DESCRIPTION
## Summary
- Switch the `dual_carriageway` field from a yes/no `radio` (label + two rows) to a tri-state `check` (single row), reducing its vertical size in the editor.
- Remove the now-unused option strings (EN/FR); the check uses the global yes/no labels.

## Notes
- Behaviour unchanged otherwise: still shown only when `oneway=yes`, still writes `dual_carriageway=yes`/`no` (check cycles unset → yes → no).
- Preset tests that tag `dual_carriageway=yes` (opposite/use_sidepath) are unaffected (63 passing).

## Test plan
- [ ] Select a one-way road → `Dual carriageway` shows as a single-row checkbox.
- [ ] Toggle it: cycles unset → yes → no, writing the matching tag.
- [ ] Label renders in EN and FR.