### PR TITLE
Presets: add two construction-company presets (Canada)

### DIFF
--- a/data/custom-tagging/src/presets/office/company_construction.ts
+++ b/data/custom-tagging/src/presets/office/company_construction.ts
@@ -1,0 +1,20 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Office of a general construction company (office=company + company=construction):
+// a contractor that builds more than just buildings (roads, civil works, etc.).
+const ID = 'office/company/construction';
+
+export const companyConstructionPreset: CustomPreset = {
+    icon: 'temaki-tools',
+    geometry: ['point', 'area'],
+    fields: ['{office}'],
+    moreFields: ['{office}'],
+    tags: { office: 'company', company: 'construction' },
+    reference: { key: 'company', value: 'construction' },
+    name: presetNameEn(ID)
+};
+
+export const companyConstructionPresets: Record<string, CustomPreset> = {
+    [ID]: companyConstructionPreset
+};

--- a/data/custom-tagging/src/presets/office/construction_company.ts
+++ b/data/custom-tagging/src/presets/office/construction_company.ts
@@ -1,0 +1,20 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Office of a building-construction company (office=construction_company).
+// For contractors that build (mostly) buildings.
+const ID = 'office/construction_company';
+
+export const constructionCompanyPreset: CustomPreset = {
+    icon: 'temaki-tools',
+    geometry: ['point', 'area'],
+    fields: ['{office}'],
+    moreFields: ['{office}'],
+    tags: { office: 'construction_company' },
+    reference: { key: 'office', value: 'construction_company' },
+    name: presetNameEn(ID)
+};
+
+export const constructionCompanyPresets: Record<string, CustomPreset> = {
+    [ID]: constructionCompanyPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -16,6 +16,8 @@ import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycle
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
 import { accessBarrierPresets } from './presets/barrier/access_barriers';
+import { constructionCompanyPresets } from './presets/office/construction_company';
+import { companyConstructionPresets } from './presets/office/company_construction';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -47,5 +49,7 @@ export const customPresets: Record<string, CustomPreset> = {
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,
-    ...accessBarrierPresets
+    ...accessBarrierPresets,
+    ...constructionCompanyPresets,
+    ...companyConstructionPresets
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -763,5 +763,13 @@
         "name": "Steps (dismount bicycle)",
         "terms": "std, dismount, bicycle, steps, stairs, staircase, stairway",
         "aliases": "std"
+    },
+    "office/construction_company": {
+        "name": "Building Construction Company",
+        "terms": "construction, builder, building, contractor, general contractor"
+    },
+    "office/company/construction": {
+        "name": "Construction Company (general)",
+        "terms": "construction, contractor, general contractor, civil works, roads, bridges, entrepreneur"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -763,5 +763,13 @@
         "name": "Escalier (vélo à pied)",
         "terms": "std, vélo à pied, descendre du vélo, escalier, escaliers, marches",
         "aliases": "std"
+    },
+    "office/construction_company": {
+        "name": "Entreprise de construction (bâtiments)",
+        "terms": "construction, bâtiment, entrepreneur, constructeur, bâtisseur, contracteur"
+    },
+    "office/company/construction": {
+        "name": "Entrepreneur en construction (général)",
+        "terms": "construction, entrepreneur, génie civil, routes, ponts, ouvrages, constructeur"
     }
 }

--- a/test/spec/presets/custom/office.js
+++ b/test/spec/presets/custom/office.js
@@ -1,0 +1,20 @@
+import { loadCustomPresets } from './setup.js';
+
+/** Construction-company presets: id → expected exact tags. */
+const CONSTRUCTION_CASES = [
+    { id: 'office/construction_company', tags: { office: 'construction_company' } },
+    { id: 'office/company/construction', tags: { office: 'company', company: 'construction' } }
+];
+
+describe('custom presets — construction companies', function() {
+    loadCustomPresets();
+
+    CONSTRUCTION_CASES.forEach(function({ id, tags }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.name(), id).to.be.a('string').that.is.not.empty;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Ports the v5 "construction" business preset. Instead of the low-use, undocumented `craft=construction` (~460 uses worldwide), it uses the two wiki-recommended tags:
- **`office/construction_company`** (`office=construction_company`, ~4.2k) — building construction companies.
- **`office/company/construction`** (`office=company` + `company=construction`) — general contractors that build more than just buildings (roads, civil works, bridges, etc.).

Both reuse the upstream `{office}` field set, with EN/FR names + search terms. Added a parametric test.

## Notes
- `craft=construction` from v5 is intentionally dropped (not documented on the wiki; `craft=builder` is the contractor analogue, `office=construction_company` / `office=company`+`company=construction` are the company analogues).
- Generated preset JSON is gitignored; built via `build:presets:custom`.

## Test plan
- [ ] `office/construction_company` and `office/company/construction` appear in the preset search (EN/FR).
- [ ] Selecting each writes the expected tags.
- [ ] `npm run build:presets:custom` then `test/spec/presets/custom/office.js` passes.