### PR TITLE
Presets: add bus-operator presets (school / public transit)

### DIFF
--- a/data/custom-tagging/src/presets/office/company_bus.ts
+++ b/data/custom-tagging/src/presets/office/company_bus.ts
@@ -1,0 +1,25 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Bus operator companies (office=company + company=bus). The kind of service is
+// encoded with bus:type=* rather than the bus=* access key (which means "buses
+// allowed"), to avoid overloading that namespace on a company POI.
+function busCompany(id: string, busType: string): CustomPreset {
+    return {
+        icon: 'maki-bus',
+        geometry: ['point', 'area'],
+        fields: ['{office}'],
+        moreFields: ['{office}'],
+        tags: { office: 'company', company: 'bus', 'bus:type': busType },
+        reference: { key: 'company', value: 'bus' },
+        name: presetNameEn(id)
+    };
+}
+
+const SCHOOL = 'office/company/bus/school';
+const PUBLIC_TRANSPORT = 'office/company/bus/public_transport';
+
+export const busCompanyPresets: Record<string, CustomPreset> = {
+    [SCHOOL]: busCompany(SCHOOL, 'school'),
+    [PUBLIC_TRANSPORT]: busCompany(PUBLIC_TRANSPORT, 'public_transport')
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -18,6 +18,7 @@ import { parkingVariantPresets } from './presets/amenity/parking_variants';
 import { accessBarrierPresets } from './presets/barrier/access_barriers';
 import { constructionCompanyPresets } from './presets/office/construction_company';
 import { companyConstructionPresets } from './presets/office/company_construction';
+import { busCompanyPresets } from './presets/office/company_bus';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -51,5 +52,6 @@ export const customPresets: Record<string, CustomPreset> = {
     ...parkingVariantPresets,
     ...accessBarrierPresets,
     ...constructionCompanyPresets,
-    ...companyConstructionPresets
+    ...companyConstructionPresets,
+    ...busCompanyPresets
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -771,5 +771,13 @@
     "office/company/construction": {
         "name": "Construction Company (general)",
         "terms": "construction, contractor, general contractor, civil works, roads, bridges, entrepreneur"
+    },
+    "office/company/bus/school": {
+        "name": "School Bus Operator",
+        "terms": "school bus, bus, transport, busing, yellow bus, operator, company"
+    },
+    "office/company/bus/public_transport": {
+        "name": "Public Transit Bus Operator",
+        "terms": "public transport, public transit, transit, bus, coach, operator, company"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -771,5 +771,13 @@
     "office/company/construction": {
         "name": "Entrepreneur en construction (général)",
         "terms": "construction, entrepreneur, génie civil, routes, ponts, ouvrages, constructeur"
+    },
+    "office/company/bus/school": {
+        "name": "Opérateur de bus scolaire",
+        "terms": "autobus scolaire, bus scolaire, transport scolaire, berline scolaire, opérateur, compagnie"
+    },
+    "office/company/bus/public_transport": {
+        "name": "Opérateur de bus (transport collectif)",
+        "terms": "transport collectif, transport en commun, autobus, bus, transit, opérateur, compagnie"
     }
 }

--- a/test/spec/presets/custom/bus.js
+++ b/test/spec/presets/custom/bus.js
@@ -1,0 +1,26 @@
+import { loadCustomPresets } from './setup.js';
+
+/** Bus-operator presets: id → expected exact tags. */
+const BUS_CASES = [
+    {
+        id: 'office/company/bus/school',
+        tags: { office: 'company', company: 'bus', 'bus:type': 'school' }
+    },
+    {
+        id: 'office/company/bus/public_transport',
+        tags: { office: 'company', company: 'bus', 'bus:type': 'public_transport' }
+    }
+];
+
+describe('custom presets — bus operators', function() {
+    loadCustomPresets();
+
+    BUS_CASES.forEach(function({ id, tags }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.name(), id).to.be.a('string').that.is.not.empty;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Two presets for bus operator companies (premises/office):
- **`office/company/bus/school`** — `office=company` + `company=bus` + `bus:type=school`
- **`office/company/bus/public_transport`** — `office=company` + `company=bus` + `bus:type=public_transport`

## Why bus:type and not bus=*
The `bus=*` key is an **access** key (taginfo: ~4.9M uses, almost all `bus=yes` = "buses allowed"); `school_bus=*` is likewise access (mostly `designated`). Putting `bus=yes`/`school_bus=yes` on a company POI would mean "buses are allowed here", not "this is a bus operator". So the service kind is recorded with a dedicated `bus:type=*` qualifier on top of `company=bus`, without overloading the access namespace.

## Notes
- Reuses the upstream `{office}` field set; EN/FR names + search terms added.
- `bus:type=*` for this purpose is non-standard (no documented tag exists for operator sub-type); worth raising on talk-ca eventually.
- Generated preset JSON is gitignored; built via `build:presets:custom`.

## Test plan
- [ ] Both presets appear in search (EN/FR) and write the expected tags.
- [ ] `npm run build:presets:custom` then `test/spec/presets/custom/bus.js` passes (2/2).