### PR TITLE
Presets: add logistics and trucking-yard presets

### DIFF
--- a/data/custom-tagging/src/presets/industrial/trucking.ts
+++ b/data/custom-tagging/src/presets/industrial/trucking.ts
@@ -1,0 +1,19 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// A trucking yard (industrial=trucking): where a trucking company parks and
+// maintains its trucks, often with small warehouses for temporary storage.
+const ID = 'industrial/trucking';
+
+export const truckingPreset: CustomPreset = {
+    icon: 'fas-truck-loading',
+    geometry: ['point', 'area'],
+    fields: ['name', 'operator', 'address', 'opening_hours', 'phone', 'website'],
+    tags: { industrial: 'trucking' },
+    reference: { key: 'industrial', value: 'trucking' },
+    name: presetNameEn(ID)
+};
+
+export const truckingPresets: Record<string, CustomPreset> = {
+    [ID]: truckingPreset
+};

--- a/data/custom-tagging/src/presets/office/logistics.ts
+++ b/data/custom-tagging/src/presets/office/logistics.ts
@@ -1,0 +1,21 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Office of a logistics company (office=logistics): manages stock/warehousing,
+// order processing and transport of goods. The warehouse building itself is a
+// separate feature (building=warehouse).
+const ID = 'office/logistics';
+
+export const logisticsPreset: CustomPreset = {
+    icon: 'maki-warehouse',
+    geometry: ['point', 'area'],
+    fields: ['{office}'],
+    moreFields: ['{office}'],
+    tags: { office: 'logistics' },
+    reference: { key: 'office', value: 'logistics' },
+    name: presetNameEn(ID)
+};
+
+export const logisticsPresets: Record<string, CustomPreset> = {
+    [ID]: logisticsPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -19,6 +19,8 @@ import { accessBarrierPresets } from './presets/barrier/access_barriers';
 import { constructionCompanyPresets } from './presets/office/construction_company';
 import { companyConstructionPresets } from './presets/office/company_construction';
 import { busCompanyPresets } from './presets/office/company_bus';
+import { logisticsPresets } from './presets/office/logistics';
+import { truckingPresets } from './presets/industrial/trucking';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -53,5 +55,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...accessBarrierPresets,
     ...constructionCompanyPresets,
     ...companyConstructionPresets,
-    ...busCompanyPresets
+    ...busCompanyPresets,
+    ...logisticsPresets,
+    ...truckingPresets
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -779,5 +779,13 @@
     "office/company/bus/public_transport": {
         "name": "Public Transit Bus Operator",
         "terms": "public transport, public transit, transit, bus, coach, operator, company"
+    },
+    "office/logistics": {
+        "name": "Logistics Company",
+        "terms": "logistics, warehousing, distribution, supply chain, fulfillment, freight, shipping"
+    },
+    "industrial/trucking": {
+        "name": "Trucking Yard",
+        "terms": "trucking, truck yard, haulage, hauling, fleet, depot, freight, maintenance"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -779,5 +779,13 @@
     "office/company/bus/public_transport": {
         "name": "Opérateur de bus (transport collectif)",
         "terms": "transport collectif, transport en commun, autobus, bus, transit, opérateur, compagnie"
+    },
+    "office/logistics": {
+        "name": "Entreprise de logistique",
+        "terms": "logistique, entreposage, distribution, chaîne d'approvisionnement, expédition, fret"
+    },
+    "industrial/trucking": {
+        "name": "Cour à camions",
+        "terms": "camionnage, cour à camions, transport, flotte, dépôt, entretien, fret, camions"
     }
 }

--- a/test/spec/presets/custom/trucking.js
+++ b/test/spec/presets/custom/trucking.js
@@ -1,0 +1,20 @@
+import { loadCustomPresets } from './setup.js';
+
+/** Trucking/logistics presets: id → expected exact tags. */
+const TRUCKING_CASES = [
+    { id: 'office/logistics', tags: { office: 'logistics' } },
+    { id: 'industrial/trucking', tags: { industrial: 'trucking' } }
+];
+
+describe('custom presets — trucking & logistics', function() {
+    loadCustomPresets();
+
+    TRUCKING_CASES.forEach(function({ id, tags }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.name(), id).to.be.a('string').that.is.not.empty;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Two presets for the goods-transport side:
- **`office/logistics`** (`office=logistics`) — logistics companies that manage stock/warehousing, order processing and goods transport. The warehouse building itself stays `building=warehouse` (upstream).
- **`industrial/trucking`** (`industrial=trucking`) — a trucking yard where a company parks and maintains its fleet.

## Notes
- `office/logistics` reuses the upstream `{office}` field set; `industrial/trucking` uses a manual field list (no upstream `industrial` base preset exists).
- Stock vs no-stock is captured by the tag choice itself; we deliberately don't encode warehouse presence as an attribute.
- EN/FR names + terms added; generated JSON is gitignored (built via `build:presets:custom`).

## Test plan
- [ ] Both presets appear in search (EN/FR) and write the expected tags.
- [ ] `npm run build:presets:custom` then `test/spec/presets/custom/trucking.js` passes (2/2).