### PR TITLE
Presets: add distributor preset (industrial=distributor)

### DIFF
--- a/data/custom-tagging/src/presets/industrial/distributor.ts
+++ b/data/custom-tagging/src/presets/industrial/distributor.ts
@@ -1,0 +1,19 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// A distributor of some product (industrial=distributor). Does not generally
+// sell to the public (B2B), unlike shop=trade (which also retails to consumers).
+const ID = 'industrial/distributor';
+
+export const distributorPreset: CustomPreset = {
+    icon: 'fas-box',
+    geometry: ['point', 'area'],
+    fields: ['name', 'operator', 'address', 'product', 'opening_hours', 'phone', 'website'],
+    tags: { industrial: 'distributor' },
+    reference: { key: 'industrial', value: 'distributor' },
+    name: presetNameEn(ID)
+};
+
+export const distributorPresets: Record<string, CustomPreset> = {
+    [ID]: distributorPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -21,6 +21,7 @@ import { companyConstructionPresets } from './presets/office/company_constructio
 import { busCompanyPresets } from './presets/office/company_bus';
 import { logisticsPresets } from './presets/office/logistics';
 import { truckingPresets } from './presets/industrial/trucking';
+import { distributorPresets } from './presets/industrial/distributor';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -57,5 +58,6 @@ export const customPresets: Record<string, CustomPreset> = {
     ...companyConstructionPresets,
     ...busCompanyPresets,
     ...logisticsPresets,
-    ...truckingPresets
+    ...truckingPresets,
+    ...distributorPresets
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -787,5 +787,9 @@
     "industrial/trucking": {
         "name": "Trucking Yard",
         "terms": "trucking, truck yard, haulage, hauling, fleet, depot, freight, maintenance"
+    },
+    "industrial/distributor": {
+        "name": "Distributor",
+        "terms": "distributor, distribution, wholesale, supplier, b2b, warehouse"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -787,5 +787,9 @@
     "industrial/trucking": {
         "name": "Cour à camions",
         "terms": "camionnage, cour à camions, transport, flotte, dépôt, entretien, fret, camions"
+    },
+    "industrial/distributor": {
+        "name": "Distributeur",
+        "terms": "distributeur, distribution, grossiste, fournisseur, b2b, entrepôt"
     }
 }

--- a/test/spec/presets/custom/distributor.js
+++ b/test/spec/presets/custom/distributor.js
@@ -1,0 +1,12 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — distributor', function() {
+    loadCustomPresets();
+
+    it('defines industrial/distributor with expected tags', function() {
+        const preset = iD.presetManager.item('industrial/distributor');
+        expect(preset).to.exist;
+        expect(preset.tags).to.eql({ industrial: 'distributor' });
+        expect(preset.name()).to.be.a('string').that.is.not.empty;
+    });
+});


### PR DESCRIPTION
## Summary
- **`industrial/distributor`** (`industrial=distributor`) — a B2B distributor that does not generally sell to the public.

## Notes
- Distinct from the upstream `shop=trade` (a shop that sells to trades but also retails to consumers). `shop=trade` is intentionally left untouched so that "distributor" searches resolve to this preset.
- Manual field set incl. `product`; EN/FR names + terms added; generated JSON gitignored (built via `build:presets:custom`).

## Test plan
- [ ] `industrial/distributor` appears in search (EN/FR) and writes `industrial=distributor`.
- [ ] `npm run build:presets:custom` then `test/spec/presets/custom/distributor.js` passes.