### PR TITLE
Presets: add truck dealership and truck repair shop

### DIFF
--- a/data/custom-tagging/src/presets/shop/truck.ts
+++ b/data/custom-tagging/src/presets/shop/truck.ts
@@ -1,0 +1,31 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Heavy-goods-vehicle shops, ported from v5.
+const DEALER = 'shop/truck';
+const REPAIR = 'shop/truck_repair';
+
+// A dealer that primarily sells trucks (heavy goods vehicles).
+export const truckDealerPreset: CustomPreset = {
+    icon: 'maki-car',
+    geometry: ['point', 'area'],
+    fields: ['{shop}', 'brand', 'second_hand', 'service/vehicle'],
+    tags: { shop: 'truck' },
+    reference: { key: 'shop', value: 'truck' },
+    name: presetNameEn(DEALER)
+};
+
+// A shop that repairs trucks (heavy goods vehicles).
+export const truckRepairPreset: CustomPreset = {
+    icon: 'maki-car-repair',
+    geometry: ['point', 'area'],
+    fields: ['{shop}', 'service/vehicle'],
+    tags: { shop: 'truck_repair' },
+    reference: { key: 'shop', value: 'truck_repair' },
+    name: presetNameEn(REPAIR)
+};
+
+export const truckShopPresets: Record<string, CustomPreset> = {
+    [DEALER]: truckDealerPreset,
+    [REPAIR]: truckRepairPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -22,6 +22,7 @@ import { busCompanyPresets } from './presets/office/company_bus';
 import { logisticsPresets } from './presets/office/logistics';
 import { truckingPresets } from './presets/industrial/trucking';
 import { distributorPresets } from './presets/industrial/distributor';
+import { truckShopPresets } from './presets/shop/truck';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -59,5 +60,6 @@ export const customPresets: Record<string, CustomPreset> = {
     ...busCompanyPresets,
     ...logisticsPresets,
     ...truckingPresets,
-    ...distributorPresets
+    ...distributorPresets,
+    ...truckShopPresets
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -791,5 +791,13 @@
     "industrial/distributor": {
         "name": "Distributor",
         "terms": "distributor, distribution, wholesale, supplier, b2b, warehouse"
+    },
+    "shop/truck": {
+        "name": "Truck Dealership",
+        "terms": "truck, lorry, commercial vehicle, heavy vehicle, hgv, automotive, dealer"
+    },
+    "shop/truck_repair": {
+        "name": "Truck Repair Shop",
+        "terms": "truck, lorry, commercial vehicle, heavy vehicle, hgv, garage, service, repair"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -791,5 +791,13 @@
     "industrial/distributor": {
         "name": "Distributeur",
         "terms": "distributeur, distribution, grossiste, fournisseur, b2b, entrepôt"
+    },
+    "shop/truck": {
+        "name": "Concessionnaire de camions",
+        "terms": "camion, poids lourd, véhicule commercial, véhicule lourd, concessionnaire, vente"
+    },
+    "shop/truck_repair": {
+        "name": "Atelier de réparation de camions",
+        "terms": "camion, poids lourd, véhicule commercial, véhicule lourd, garage, réparation, entretien"
     }
 }

--- a/test/spec/presets/custom/truck.js
+++ b/test/spec/presets/custom/truck.js
@@ -1,0 +1,20 @@
+import { loadCustomPresets } from './setup.js';
+
+/** Truck shop presets: id → expected exact tags. */
+const TRUCK_CASES = [
+    { id: 'shop/truck', tags: { shop: 'truck' } },
+    { id: 'shop/truck_repair', tags: { shop: 'truck_repair' } }
+];
+
+describe('custom presets — truck shops', function() {
+    loadCustomPresets();
+
+    TRUCK_CASES.forEach(function({ id, tags }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.name(), id).to.be.a('string').that.is.not.empty;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Ports the v5 heavy-goods-vehicle shops:
- **`shop/truck`** (`shop=truck`) — truck dealership.
- **`shop/truck_repair`** (`shop=truck_repair`) — truck repair shop.

## Notes
- Both reuse the upstream `{shop}` field set; the dealership adds `brand`, `second_hand`, `service/vehicle`. Both tags are wiki-documented (`shop=truck` in use ~1.3k; `shop=truck_repair` ~780) and absent upstream.
- EN/FR names + terms; generated JSON gitignored (built via `build:presets:custom`).

## Test plan
- [ ] Both presets appear in search (EN/FR) and write the expected tags.
- [ ] `npm run build:presets:custom` then `test/spec/presets/custom/truck.js` passes (2/2).