### PR TITLE
Presets: post_box:type field + Québec community mailbox

### DIFF
--- a/data/custom-tagging/src/presets/amenity/post_box_community_quebec.ts
+++ b/data/custom-tagging/src/presets/amenity/post_box_community_quebec.ts
@@ -1,0 +1,36 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Québec community mailbox (Postes Canada). Mirrors the NSI "Postes Canada"
+// operator entry for amenity=post_box and adds post_box:type=community, since
+// the NSI has no community-box variant. Provided as a one-click shortcut because
+// Québec has many community mailboxes (avoids setting the type by hand each time).
+//
+// ⚠ Keep the operator/brand/wikidata in sync with the NSI source if it changes:
+// https://github.com/osmlab/name-suggestion-index/blob/main/data/operators/amenity/post_box.json
+// (item "Postes Canada", preset id amenity/post_box/postescanada-2241ae)
+const ID = 'amenity/post_box/community_quebec';
+
+export const communityMailboxQuebecPreset: CustomPreset = {
+    icon: 'temaki-post_box',
+    geometry: ['point', 'vertex'],
+    fields: ['operator', 'collection_times', 'drive_through', 'ref'],
+    moreFields: ['access_simple', 'brand', 'covered', 'height', 'indoor', 'level', 'manufacturer', 'wheelchair'],
+    // Matches QC Postes Canada community boxes; the extra post_box:type tag makes
+    // it win over the plain NSI operator preset (more matching tags).
+    tags: { amenity: 'post_box', 'operator:wikidata': 'Q1032001', 'post_box:type': 'community' },
+    addTags: {
+        amenity: 'post_box',
+        operator: 'Postes Canada',
+        'operator:wikidata': 'Q1032001',
+        brand: 'Postes Canada',
+        'brand:wikidata': 'Q1032001',
+        'post_box:type': 'community'
+    },
+    reference: { key: 'post_box:type', value: 'community' },
+    name: presetNameEn(ID)
+};
+
+export const communityMailboxQuebecPresets: Record<string, CustomPreset> = {
+    [ID]: communityMailboxQuebecPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -23,6 +23,7 @@ import { logisticsPresets } from './presets/office/logistics';
 import { truckingPresets } from './presets/industrial/trucking';
 import { distributorPresets } from './presets/industrial/distributor';
 import { truckShopPresets } from './presets/shop/truck';
+import { communityMailboxQuebecPresets } from './presets/amenity/post_box_community_quebec';
 import { placementLineTemplate } from './presets/templates/placement_line';
 import type { CustomField, CustomPreset, CustomTemplatePreset } from './types';
 
@@ -61,5 +62,6 @@ export const customPresets: Record<string, CustomPreset> = {
     ...logisticsPresets,
     ...truckingPresets,
     ...distributorPresets,
-    ...truckShopPresets
+    ...truckShopPresets,
+    ...communityMailboxQuebecPresets
 };

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -12,6 +12,15 @@
                     "label": "Capacity for charging electric vehicles",
                     "placeholder": "1, 5, 10..."
                 },
+                "post_box/type": {
+                    "label": "Box type",
+                    "options": {
+                        "pillar": "Pillar (freestanding)",
+                        "wall": "Wall-mounted",
+                        "lamp": "Lamp / pole-mounted",
+                        "community": "Community mailbox"
+                    }
+                },
                 "parking/condition": {
                     "label": "Parking condition",
                     "options": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -8,6 +8,15 @@
                         "postal_city": "Municipalité postale (Postes Canada)"
                     }
                 },
+                "post_box/type": {
+                    "label": "Type de boîte",
+                    "options": {
+                        "pillar": "Sur pied (colonne)",
+                        "wall": "Murale",
+                        "lamp": "Sur poteau",
+                        "community": "Boîte postale communautaire"
+                    }
+                },
                 "capacity_charging": {
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -799,5 +799,9 @@
     "shop/truck_repair": {
         "name": "Truck Repair Shop",
         "terms": "truck, lorry, commercial vehicle, heavy vehicle, hgv, garage, service, repair"
+    },
+    "amenity/post_box/community_quebec": {
+        "name": "Community Mailbox (Canada Post)",
+        "terms": "community mailbox, super mailbox, cmb, canada post, postes canada, post box, post_box, courrier communautaire"
     }
 }

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -799,5 +799,9 @@
     "shop/truck_repair": {
         "name": "Atelier de réparation de camions",
         "terms": "camion, poids lourd, véhicule commercial, véhicule lourd, garage, réparation, entretien"
+    },
+    "amenity/post_box/community_quebec": {
+        "name": "Boîte postale communautaire (Postes Canada)",
+        "terms": "boîte postale communautaire, courrier communautaire, multiboîte, postes canada, canada post, boîte aux lettres, community mailbox"
     }
 }

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -140,6 +140,15 @@ export const customFields = {
         customValues: false,
         geometry: ['line'],
         prerequisiteTag: { key: 'oneway', value: 'yes' }
+    },
+    // Box type for post boxes (post_box:type). Upstream only ships a GB-specific
+    // field; this generic one surfaces `community` (Canada community mailboxes)
+    // and the common freestanding/mounted types everywhere.
+    'post_box/type': {
+        key: 'post_box:type',
+        type: 'combo',
+        options: ['pillar', 'wall', 'lamp', 'community'],
+        geometry: ['point', 'vertex']
     }
 };
 
@@ -214,6 +223,7 @@ export function applyCustomFields(presetManager) {
     customizeCycleway(presetManager);
     customizeOnewayBicycle(presetManager);
     customizeAccess(presetManager);
+    customizePostBox(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
@@ -382,5 +392,22 @@ function customizeAccess(presetManager) {
         'access', 'foot', 'motor_vehicle', 'routing:motor_vehicle',
         'bicycle', 'routing:bicycle', 'bus', 'routing:bus', 'psv'
     ];
+}
+
+/**
+ * Offer the generic `post_box/type` field on the base `amenity/post_box` preset
+ * (and, by inheritance, on the NSI operator presets like Canada Post), so the
+ * box type — notably `community` — can be set from a dropdown. Inserted right
+ * after `ref`; idempotent.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizePostBox(presetManager) {
+    const preset = presetManager.item('amenity/post_box');
+    if (!preset) return;
+    const fields = preset.originalFields;
+    if (fields.indexOf('post_box/type') !== -1) return;
+    const refIndex = fields.indexOf('ref');
+    fields.splice(refIndex === -1 ? fields.length : refIndex + 1, 0, 'post_box/type');
 }
 

--- a/test/spec/presets/custom/post_box_community_quebec.js
+++ b/test/spec/presets/custom/post_box_community_quebec.js
@@ -1,0 +1,30 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — community mailbox (Québec)', function() {
+    loadCustomPresets();
+
+    const ID = 'amenity/post_box/community_quebec';
+
+    it('matches QC Postes Canada community boxes', function() {
+        const preset = iD.presetManager.item(ID);
+        expect(preset).to.exist;
+        expect(preset.tags).to.eql({
+            amenity: 'post_box',
+            'operator:wikidata': 'Q1032001',
+            'post_box:type': 'community'
+        });
+        expect(preset.name()).to.be.a('string').that.is.not.empty;
+    });
+
+    it('clones the NSI operator tags and sets post_box:type=community on create', function() {
+        const preset = iD.presetManager.item(ID);
+        expect(preset.addTags).to.eql({
+            amenity: 'post_box',
+            operator: 'Postes Canada',
+            'operator:wikidata': 'Q1032001',
+            brand: 'Postes Canada',
+            'brand:wikidata': 'Q1032001',
+            'post_box:type': 'community'
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add a generic `post_box:type` combo field (pillar / wall / lamp / community) on the base `amenity/post_box` preset. It is inherited by the NSI operator presets (e.g. Canada Post), so the box type — notably `community` — can be set from a dropdown. Upstream only ships a GB-specific field.
- Add a one-click **Québec community mailbox** preset that clones the NSI "Postes Canada" operator entry and adds `post_box:type=community`. Québec has many community mailboxes, so this avoids picking the type by hand each time. The extra matching tag makes it win over the plain NSI operator preset.
- The preset file carries a comment + link to the NSI source to keep operator/brand/wikidata in sync.

## Notes
- The field lives in `modules/presets/custom_fields.js` and is attached additively (after `ref`), consistent with the other custom fields.
- The preset clones NSI faithfully (no extra `:en`/`:fr`/wikipedia tags) so it stays easy to reconcile with NSI updates.

## Test plan
- [x] `yarn test:spec test/spec/presets/custom/` — 117 passing (incl. new `post_box_community_quebec.js`)
- [x] `yarn generate:presets:custom && yarn build:presets:custom && yarn build:data`
- [ ] In-editor: create a post box → `Box type` dropdown shows; pick `Community mailbox`. Search "community mailbox" → Québec preset sets `operator=Postes Canada` + `post_box:type=community`.

Run tests locally with `NODE_OPTIONS="--localstorage-file=/tmp/idtest_ls"` on Node 25.