### PR TITLE
Presets: public works office + institutional grounds

### DIFF
--- a/data/custom-tagging/src/presets/landuse/institutional.ts
+++ b/data/custom-tagging/src/presets/landuse/institutional.ts
@@ -1,0 +1,20 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Institutional land (landuse=institutional): land used by an institution such
+// as a government body. Not present in the upstream id-tagging-schema.
+const ID = 'landuse/institutional';
+
+export const institutionalPreset: CustomPreset = {
+    icon: 'fas-landmark',
+    geometry: ['area'],
+    fields: ['name', 'operator', 'address'],
+    moreFields: ['admin_level', 'access_simple'],
+    tags: { landuse: 'institutional' },
+    reference: { key: 'landuse', value: 'institutional' },
+    name: presetNameEn(ID)
+};
+
+export const institutionalPresets: Record<string, CustomPreset> = {
+    [ID]: institutionalPreset
+};

--- a/data/custom-tagging/src/presets/landuse/public_works.ts
+++ b/data/custom-tagging/src/presets/landuse/public_works.ts
@@ -1,0 +1,22 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Public-works land (landuse=public_works): non-military government-owned land
+// not generally open to the public — e.g. highway maintenance yards, vehicle
+// depots, waterworks. More specific than landuse=institutional. Not present in
+// the upstream id-tagging-schema.
+const ID = 'landuse/public_works';
+
+export const landusePublicWorksPreset: CustomPreset = {
+    icon: 'temaki-tools',
+    geometry: ['area'],
+    fields: ['name', 'operator', 'address'],
+    moreFields: ['admin_level', 'access_simple'],
+    tags: { landuse: 'public_works' },
+    reference: { key: 'landuse', value: 'public_works' },
+    name: presetNameEn(ID)
+};
+
+export const landusePublicWorksPresets: Record<string, CustomPreset> = {
+    [ID]: landusePublicWorksPreset
+};

--- a/data/custom-tagging/src/presets/office/government/public_works.ts
+++ b/data/custom-tagging/src/presets/office/government/public_works.ts
@@ -1,0 +1,21 @@
+import type { CustomPreset } from '../../../types';
+import { presetNameEn } from '../../../preset_name_en';
+
+// Public works office (office=government + government=public_works). The agency
+// (often municipal) that handles roads, water/sewer, and similar infrastructure.
+// Ported from our v5 fork; not present in the upstream id-tagging-schema.
+const ID = 'office/government/public_works';
+
+export const publicWorksPreset: CustomPreset = {
+    icon: 'maki-suitcase',
+    geometry: ['point', 'area'],
+    fields: ['{office}'],
+    moreFields: ['{office}', 'admin_level'],
+    tags: { office: 'government', government: 'public_works' },
+    reference: { key: 'government', value: 'public_works' },
+    name: presetNameEn(ID)
+};
+
+export const publicWorksPresets: Record<string, CustomPreset> = {
+    [ID]: publicWorksPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -18,6 +18,9 @@ import { parkingVariantPresets } from './presets/amenity/parking_variants';
 import { accessBarrierPresets } from './presets/barrier/access_barriers';
 import { constructionCompanyPresets } from './presets/office/construction_company';
 import { companyConstructionPresets } from './presets/office/company_construction';
+import { publicWorksPresets } from './presets/office/government/public_works';
+import { institutionalPresets } from './presets/landuse/institutional';
+import { landusePublicWorksPresets } from './presets/landuse/public_works';
 import { busCompanyPresets } from './presets/office/company_bus';
 import { logisticsPresets } from './presets/office/logistics';
 import { truckingPresets } from './presets/industrial/trucking';
@@ -58,6 +61,9 @@ export const customPresets: Record<string, CustomPreset> = {
     ...accessBarrierPresets,
     ...constructionCompanyPresets,
     ...companyConstructionPresets,
+    ...publicWorksPresets,
+    ...institutionalPresets,
+    ...landusePublicWorksPresets,
     ...busCompanyPresets,
     ...logisticsPresets,
     ...truckingPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -768,6 +768,18 @@
         "name": "Building Construction Company",
         "terms": "construction, builder, building, contractor, general contractor"
     },
+    "office/government/public_works": {
+        "name": "Public Works Office",
+        "terms": "public works, utility, works, municipal, roads, transportation, water, sewer"
+    },
+    "landuse/institutional": {
+        "name": "Institutional Grounds",
+        "terms": "institutional, institution, government land"
+    },
+    "landuse/public_works": {
+        "name": "Public Works Grounds",
+        "terms": "public works, highway maintenance yard, works yard, municipal yard, vehicle depot, waterworks, government land, workshops"
+    },
     "office/company/construction": {
         "name": "Construction Company (general)",
         "terms": "construction, contractor, general contractor, civil works, roads, bridges, entrepreneur"

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -768,6 +768,18 @@
         "name": "Entreprise de construction (bâtiments)",
         "terms": "construction, bâtiment, entrepreneur, constructeur, bâtisseur, contracteur"
     },
+    "office/government/public_works": {
+        "name": "Bureau des travaux publics",
+        "terms": "travaux publics, voirie, municipal, services publics, routes, aqueduc, égouts, transport"
+    },
+    "landuse/institutional": {
+        "name": "Terrain institutionnel",
+        "terms": "institutionnel, institution, terrain gouvernemental"
+    },
+    "landuse/public_works": {
+        "name": "Terrain de travaux publics",
+        "terms": "travaux publics, cour de voirie, garage municipal, dépôt de véhicules, ateliers municipaux, aqueduc, terrain gouvernemental"
+    },
     "office/company/construction": {
         "name": "Entrepreneur en construction (général)",
         "terms": "construction, entrepreneur, génie civil, routes, ponts, ouvrages, constructeur"

--- a/test/spec/presets/custom/public_works.js
+++ b/test/spec/presets/custom/public_works.js
@@ -1,0 +1,20 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — public works', function() {
+    loadCustomPresets();
+
+    const CASES = [
+        { id: 'office/government/public_works', tags: { office: 'government', government: 'public_works' } },
+        { id: 'landuse/institutional', tags: { landuse: 'institutional' } },
+        { id: 'landuse/public_works', tags: { landuse: 'public_works' } }
+    ];
+
+    CASES.forEach(function({ id, tags }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.name(), id).to.be.a('string').that.is.not.empty;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Port the v5 **Public Works Office** preset (`office=government` + `government=public_works`) — approved tags, absent from the upstream id-tagging-schema.
- Add a **Institutional Grounds** area preset (`landuse=institutional`) for the site around such an office: e.g. a municipal works yard with workshops/garages. Also absent upstream (2.7k uses on OSM).

## Tagging notes
- `government=public_works` is an approved subtype of `office=government` (wiki). `admin_level` offered in moreFields for the municipal level.
- `landuse=institutional` chosen (per request) for the grounds; covers government/institution land use.

## Test plan
- [x] `yarn test:spec test/spec/presets/custom/public_works.js` — 2 passing
- [x] `yarn generate:presets:custom && yarn build:presets:custom`
- [ ] In-editor: search "public works" → office preset; draw an area, search "institutional" / "cour de voirie" → grounds preset.

Run tests with `NODE_OPTIONS="--localstorage-file=/tmp/idtest_ls"` on Node 25.