### PR TITLE
Show dual_carriageway on a single row

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -186,7 +186,7 @@ const MANAGED_LANE_FIELDS = [
 // the lane / placement fields fold into directional groups, which lay their
 // sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
 const SMALL_FIELDS = [
-    'oneway', 'maxspeed', 'surface', 'sidewalk', 'ref_road_number'
+    'oneway', 'maxspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
 ];
 
 // highway=* values that should offer the sidewalk field


### PR DESCRIPTION
## Summary
- Add `dual_carriageway` to the `SMALL_FIELDS` list so its label and checkbox render on one row, matching the `oneway` field directly above it (see screenshot in chat).

## Test plan
- [ ] Select a `oneway=yes` road → the `Dual carriageway` row shows label + checkbox on a single line, like `One Way`.