### PR TITLE
Offer advisory speed on motorway links and roundabouts

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -12,6 +12,9 @@
                     "label": "Capacity for charging electric vehicles",
                     "placeholder": "1, 5, 10..."
                 },
+                "maxspeed_advisory": {
+                    "label": "Advisory Speed Limit"
+                },
                 "post_box/type": {
                     "label": "Box type",
                     "options": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -17,6 +17,9 @@
                         "community": "Boîte postale communautaire"
                     }
                 },
+                "maxspeed_advisory": {
+                    "label": "Vitesse recommandée"
+                },
                 "capacity_charging": {
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -198,7 +198,7 @@ const MANAGED_LANE_FIELDS = [
 // the lane / placement fields fold into directional groups, which lay their
 // sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
 const SMALL_FIELDS = [
-    'oneway', 'maxspeed', 'maxspeed_advisory', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
+    'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
 ];
 
 // highway=* values that should offer the sidewalk field
@@ -325,12 +325,26 @@ export function applyCustomFields(presetManager) {
         fields.splice(junctionAt < 0 ? fields.length : junctionAt, 0, 'junction_oneway');
 
         // advisory speed: default field right after `maxspeed` (hidden by its
-        // prerequisite until highway=motorway_link or junction=roundabout).
+        // prerequisite until highway=motorway_link or junction=roundabout). Drop
+        // the upstream `maxspeed/advisory` (some presets list it in moreFields)
+        // so the same key isn't edited by two fields.
+        removeField(fields, 'maxspeed/advisory');
+        removeField(moreFields, 'maxspeed/advisory');
         removeField(fields, 'maxspeed_advisory');
         removeField(moreFields, 'maxspeed_advisory');
         const maxspeedIndex = fields.indexOf('maxspeed');
         if (maxspeedIndex === -1) moreFields.push('maxspeed_advisory');
         else fields.splice(maxspeedIndex + 1, 0, 'maxspeed_advisory');
+
+        // minimum speed: default field on motorways (common in Québec), just
+        // below the advisory/maxspeed rows. Upstream keeps it in moreFields.
+        if (highway === 'motorway') {
+            removeField(fields, 'minspeed');
+            removeField(moreFields, 'minspeed');
+            const advisoryIndex = fields.indexOf('maxspeed_advisory');
+            const minspeedAnchor = advisoryIndex === -1 ? fields.indexOf('maxspeed') : advisoryIndex;
+            fields.splice(minspeedAnchor < 0 ? fields.length : minspeedAnchor + 1, 0, 'minspeed');
+        }
     });
 }
 

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -149,6 +149,18 @@ export const customFields = {
         type: 'combo',
         options: ['pillar', 'wall', 'lamp', 'community'],
         geometry: ['point', 'vertex']
+    },
+    // Advisory (recommended) speed (maxspeed:advisory). Same roadspeed editor as
+    // maxspeed. Common in Québec on motorway links and roundabouts, so it shows
+    // there by default (or wherever the tag is already set).
+    maxspeed_advisory: {
+        key: 'maxspeed:advisory',
+        type: 'roadspeed',
+        geometry: ['line'],
+        prerequisiteTag: [
+            { key: 'highway', value: 'motorway_link' },
+            { key: 'junction', value: 'roundabout' }
+        ]
     }
 };
 
@@ -186,7 +198,7 @@ const MANAGED_LANE_FIELDS = [
 // the lane / placement fields fold into directional groups, which lay their
 // sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
 const SMALL_FIELDS = [
-    'oneway', 'maxspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
+    'oneway', 'maxspeed', 'maxspeed_advisory', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
 ];
 
 // highway=* values that should offer the sidewalk field
@@ -311,6 +323,14 @@ export function applyCustomFields(presetManager) {
         const afterDual = fields.indexOf('dual_carriageway');
         const junctionAt = afterDual === -1 ? dualAt : afterDual + 1;
         fields.splice(junctionAt < 0 ? fields.length : junctionAt, 0, 'junction_oneway');
+
+        // advisory speed: default field right after `maxspeed` (hidden by its
+        // prerequisite until highway=motorway_link or junction=roundabout).
+        removeField(fields, 'maxspeed_advisory');
+        removeField(moreFields, 'maxspeed_advisory');
+        const maxspeedIndex = fields.indexOf('maxspeed');
+        if (maxspeedIndex === -1) moreFields.push('maxspeed_advisory');
+        else fields.splice(maxspeedIndex + 1, 0, 'maxspeed_advisory');
     });
 }
 


### PR DESCRIPTION
## Summary
- **Advisory speed** (`maxspeed:advisory`): new custom `maxspeed_advisory` field reusing the upstream `roadspeed` editor (same format as `maxspeed`), inserted right below `maxspeed`. Shown by default when `highway=motorway_link` **or** `junction=roundabout` (OR `prerequisiteTag`), and wherever the tag already exists. Common in Québec.
- **Minimum speed** (`minspeed`): the upstream field is moved into the default fields of `highway=motorway` (it was in moreFields), just below the speed rows. Common in Québec.
- Both flagged `small` so they render on a single row like `maxspeed`.
- Removes the upstream `maxspeed/advisory` entry from presets so `maxspeed:advisory` isn't edited by two fields.

## Notes
- No new field types: `maxspeed:advisory` and `minspeed` both already exist upstream (type `roadspeed`). The custom `maxspeed_advisory` only adds the QC-relevant prerequisite + placement without mutating the shared upstream field.

## Test plan
- [ ] `highway=motorway_link` → `Advisory Speed Limit` row appears just under `Speed Limit`.
- [ ] `junction=roundabout` on a road → advisory row appears.
- [ ] `highway=motorway` → `Minimum Speed Limit` row appears by default under the speed rows; advisory stays hidden.
- [ ] Other roads: advisory/minspeed hidden unless the tag is already present.