### PR TITLE
Add "runs along a sidewalk" check on cycleways

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -15,6 +15,13 @@
                 "maxspeed_advisory": {
                     "label": "Advisory Speed Limit"
                 },
+                "is_sidewalk": {
+                    "label": "Runs along a sidewalk",
+                    "options": {
+                        "undefined": "Unknown",
+                        "sidewalk": "Yes"
+                    }
+                },
                 "post_box/type": {
                     "label": "Box type",
                     "options": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -20,6 +20,13 @@
                 "maxspeed_advisory": {
                     "label": "Vitesse recommandée"
                 },
+                "is_sidewalk": {
+                    "label": "Longe un trottoir",
+                    "options": {
+                        "undefined": "Inconnu",
+                        "sidewalk": "Oui"
+                    }
+                },
                 "capacity_charging": {
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -456,19 +456,25 @@ function customizePostBox(presetManager) {
     fields.splice(refIndex === -1 ? fields.length : refIndex + 1, 0, 'post_box/type');
 }
 
+// Presets that should offer the `is_sidewalk` check. Their `{...}` variants
+// (e.g. highway/path/bicycle_foot → {highway/cycleway/bicycle_foot}) inherit it.
+const IS_SIDEWALK_PRESETS = ['highway/cycleway', 'highway/cycleway/bicycle_foot'];
+
 /**
- * Offer the `is_sidewalk` check on the base highway=cycleway preset (inherited by
- * its `{highway/cycleway}` variants), to flag a cycleway that runs along a
- * sidewalk (footway=sidewalk). Inserted after `oneway`; idempotent.
+ * Offer the `is_sidewalk` check on the cycleway / cycle-and-foot-path presets, to
+ * flag a way that runs along a sidewalk (footway=sidewalk). Inserted after
+ * `oneway`; idempotent.
  *
  * @param {Object} presetManager - the preset system (`presetManager`)
  */
 function customizeCyclewaySidewalk(presetManager) {
-    const preset = presetManager.item('highway/cycleway');
-    if (!preset) return;
-    const fields = preset.originalFields;
-    if (fields.indexOf('is_sidewalk') !== -1) return;
-    const onewayIndex = fields.indexOf('oneway');
-    fields.splice(onewayIndex === -1 ? fields.length : onewayIndex + 1, 0, 'is_sidewalk');
+    IS_SIDEWALK_PRESETS.forEach(id => {
+        const preset = presetManager.item(id);
+        if (!preset) return;
+        const fields = preset.originalFields;
+        if (fields.indexOf('is_sidewalk') !== -1) return;
+        const onewayIndex = fields.indexOf('oneway');
+        fields.splice(onewayIndex === -1 ? fields.length : onewayIndex + 1, 0, 'is_sidewalk');
+    });
 }
 

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -161,6 +161,16 @@ export const customFields = {
             { key: 'highway', value: 'motorway_link' },
             { key: 'junction', value: 'roundabout' }
         ]
+    },
+    // Whether a cycleway runs along a sidewalk (footway=sidewalk). Two-state
+    // check: ticked writes footway=sidewalk, unticked removes the tag. The check
+    // field cycles `key` through `options`, so the values are the literal footway
+    // tag values (`undefined` clears it).
+    is_sidewalk: {
+        key: 'footway',
+        type: 'defaultCheck',
+        options: ['undefined', 'sidewalk'],
+        geometry: ['line']
     }
 };
 
@@ -198,7 +208,7 @@ const MANAGED_LANE_FIELDS = [
 // the lane / placement fields fold into directional groups, which lay their
 // sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
 const SMALL_FIELDS = [
-    'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway'
+    'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway', 'is_sidewalk'
 ];
 
 // highway=* values that should offer the sidewalk field
@@ -236,6 +246,7 @@ export function applyCustomFields(presetManager) {
     customizeOnewayBicycle(presetManager);
     customizeAccess(presetManager);
     customizePostBox(presetManager);
+    customizeCyclewaySidewalk(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
@@ -443,5 +454,21 @@ function customizePostBox(presetManager) {
     if (fields.indexOf('post_box/type') !== -1) return;
     const refIndex = fields.indexOf('ref');
     fields.splice(refIndex === -1 ? fields.length : refIndex + 1, 0, 'post_box/type');
+}
+
+/**
+ * Offer the `is_sidewalk` check on the base highway=cycleway preset (inherited by
+ * its `{highway/cycleway}` variants), to flag a cycleway that runs along a
+ * sidewalk (footway=sidewalk). Inserted after `oneway`; idempotent.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizeCyclewaySidewalk(presetManager) {
+    const preset = presetManager.item('highway/cycleway');
+    if (!preset) return;
+    const fields = preset.originalFields;
+    if (fields.indexOf('is_sidewalk') !== -1) return;
+    const onewayIndex = fields.indexOf('oneway');
+    fields.splice(onewayIndex === -1 ? fields.length : onewayIndex + 1, 0, 'is_sidewalk');
 }
 

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -247,6 +247,7 @@ export function applyCustomFields(presetManager) {
     customizeAccess(presetManager);
     customizePostBox(presetManager);
     customizeCyclewaySidewalk(presetManager);
+    setCycleFootPathDefaultSurface(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
@@ -476,5 +477,18 @@ function customizeCyclewaySidewalk(presetManager) {
         const onewayIndex = fields.indexOf('oneway');
         fields.splice(onewayIndex === -1 ? fields.length : onewayIndex + 1, 0, 'is_sidewalk');
     });
+}
+
+/**
+ * Default the Cycle & Foot Path preset (highway/cycleway/bicycle_foot) to
+ * surface=asphalt: added to `addTags` so it is written when the preset is chosen,
+ * without affecting matching (which uses `tags`). Idempotent.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function setCycleFootPathDefaultSurface(presetManager) {
+    const preset = presetManager.item('highway/cycleway/bicycle_foot');
+    if (!preset) return;
+    preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
 }
 


### PR DESCRIPTION
## Summary
- Add an `is_sidewalk` two-state check to the `highway=cycleway` preset (inherited by its `{highway/cycleway}` variants).
- Ticked → writes `footway=sidewalk`; unticked → removes the `footway` tag.
- Implemented purely with the existing `check` field: it cycles `key` through `options`, so `options: ['undefined', 'sidewalk']` on `key: footway` yields exactly the desired two states (no new field type/renderer).
- Flagged `small` so it renders on a single row; inserted right after `oneway`.

## Test plan
- [ ] Select a `highway=cycleway` → a `Runs along a sidewalk` row appears (Unknown by default).
- [ ] Tick it → `footway=sidewalk` is added (raw tag view).
- [ ] Untick it → the `footway` tag is removed.