### PR TITLE
Presets: stop adding lcn=yes on new cycleway crossings

### DIFF
--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
@@ -111,7 +111,6 @@ function cyclewayCrossingPreset(variant: CyclewayCrossingVariant): CustomPreset 
 
     const addTags: Record<string, string> = {
         ...tags,
-        lcn: 'yes',
         surface: 'asphalt'
     };
 


### PR DESCRIPTION
## Summary
- Remove `lcn=yes` from the `addTags` of the cycleway-crossing presets so it is no longer written automatically for new crossings.
- Existing `lcn` tags are preserved: since `lcn` is no longer in `addTags`, it's also absent from the derived `removeTags`, so switching presets won't strip a manually-added `lcn`.

## Notes
- This was the only `lcn` occurrence in the custom presets. `lcn` in `modules/operations/clone.ts` is the clone tag list (left untouched — cloning intentionally copies existing tags).

## Test plan
- [x] `yarn build:presets:custom` + `yarn test:spec test/spec/presets/custom/` (120 passing)
- [ ] New cycleway crossing → no `lcn` tag added.
- [ ] A crossing that already has `lcn=yes` → tag stays after editing/re-selecting the preset.