### PR TITLE
Refine is_sidewalk: label wording and foot=no guard

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -16,7 +16,7 @@
                     "label": "Advisory Speed Limit"
                 },
                 "is_sidewalk": {
-                    "label": "Runs along a sidewalk",
+                    "label": "Is also a sidewalk",
                     "options": {
                         "undefined": "Unknown",
                         "sidewalk": "Yes"

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -21,7 +21,7 @@
                     "label": "Vitesse recommandée"
                 },
                 "is_sidewalk": {
-                    "label": "Longe un trottoir",
+                    "label": "Est aussi un trottoir",
                     "options": {
                         "undefined": "Inconnu",
                         "sidewalk": "Oui"

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -162,15 +162,17 @@ export const customFields = {
             { key: 'junction', value: 'roundabout' }
         ]
     },
-    // Whether a cycleway runs along a sidewalk (footway=sidewalk). Two-state
-    // check: ticked writes footway=sidewalk, unticked removes the tag. The check
-    // field cycles `key` through `options`, so the values are the literal footway
-    // tag values (`undefined` clears it).
+    // Whether a cycleway is also a sidewalk (footway=sidewalk). Two-state check:
+    // ticked writes footway=sidewalk, unticked removes the tag. The check field
+    // cycles `key` through `options`, so the values are the literal footway tag
+    // values (`undefined` clears it). Hidden where foot is not allowed (foot=no),
+    // unless the tag is already set.
     is_sidewalk: {
         key: 'footway',
         type: 'defaultCheck',
         options: ['undefined', 'sidewalk'],
-        geometry: ['line']
+        geometry: ['line'],
+        prerequisiteTag: { key: 'foot', valueNot: 'no' }
     }
 };
 


### PR DESCRIPTION
## Summary
- Rename the `is_sidewalk` check label to **"Is also a sidewalk"** / **"Est aussi un trottoir"** (clearer than "Runs along a sidewalk").
- Only show it where walking is allowed: added `prerequisiteTag { key: 'foot', valueNot: 'no' }`, so it's hidden on `foot=no` ways — unless `footway` is already set (iD ignores tagging prerequisites when the field's key already has a value).

## Test plan
- [ ] `highway=cycleway` without `foot=no` → `Is also a sidewalk` row shows.
- [ ] Add `foot=no` → row hides (unless `footway` is already present).