### PR TITLE
Apply the active theme's CSS to the map (emit tag-* classes + inject CSS)

### DIFF
--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -52,8 +52,15 @@ export const customAccessEmphasisClass = 'custom-access-emphasis';
 // ---------------------------------------------------------------------------
 
 /**
- * Synthetic `tag-*` classes that are not OSM keys (added by tag_classes.js
- * itself). Excluded from extraction so they don't become bogus secondary keys.
+ * Some `tag-*` classes are *computed* by tag_classes.js rather than coming from
+ * an OSM `key=value`. Extraction takes the part before the first `-` as the key
+ * (e.g. `.tag-cuisine-pizza` → `cuisine`), but for these the leading token is not
+ * a real OSM key, so we must skip it — otherwise we'd add a bogus secondary key
+ * and try to read a tag that does not exist:
+ *   - `status`     → from `tag-status` / `tag-status-{lifecycle}` (e.g. abandoned)
+ *   - `wikidata`   → from `tag-wikidata` (any `*:wikidata` present)
+ *   - `paved` / `unpaved` / `semipaved` → inferred highway surface classes
+ *   - `custom`     → from `tag-custom-access-emphasis` (access-emphasis styling)
  */
 const SYNTHETIC_TAG_TOKENS = new Set([
     'status', 'wikidata', 'paved', 'unpaved', 'semipaved', 'custom'

--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -59,7 +59,12 @@ export const customAccessEmphasisClass = 'custom-access-emphasis';
  * and try to read a tag that does not exist:
  *   - `status`     → from `tag-status` / `tag-status-{lifecycle}` (e.g. abandoned)
  *   - `wikidata`   → from `tag-wikidata` (any `*:wikidata` present)
- *   - `paved` / `unpaved` / `semipaved` → inferred highway surface classes
+ *   - `paved` / `unpaved` / `semipaved` → inferred highway surface *category*,
+ *       not the literal `surface` tag. tag_classes.js derives it from several
+ *       keys/values (asphalt/concrete… → paved, gravel/dirt… → unpaved,
+ *       compacted → semipaved) and even emits it with no `surface` tag (default
+ *       paved; unpaved for highway=track). The exact value stays available via
+ *       the secondary `tag-surface-{value}`.
  *   - `custom`     → from `tag-custom-access-emphasis` (access-emphasis styling)
  */
 const SYNTHETIC_TAG_TOKENS = new Set([

--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -41,6 +41,80 @@ export const customAccessEmphasisExcludeHighways = [
 /** Class name added on motor roads when access emphasis applies (without `tag-` prefix). */
 export const customAccessEmphasisClass = 'custom-access-emphasis';
 
+// ---------------------------------------------------------------------------
+// Theme-driven tag classes
+//
+// A user theme's CSS may style features by OSM tag using `tag-{key}` /
+// `tag-{key}-{value}` selectors. So map elements actually get those classes, we
+// read the active theme's CSS, collect the referenced keys, and emit them like
+// secondary tags. The list is replaced whenever the theme changes (so classes a
+// previous theme needed are dropped), while the static keys above always stay.
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthetic `tag-*` classes that are not OSM keys (added by tag_classes.js
+ * itself). Excluded from extraction so they don't become bogus secondary keys.
+ */
+const SYNTHETIC_TAG_TOKENS = new Set([
+    'status', 'wikidata', 'paved', 'unpaved', 'semipaved', 'custom'
+]);
+
+/** Theme-required secondary keys, in their CSS-class form (`:` written as `_`). */
+let themeSecondaryTagKeys = new Set();
+
+/** @param {string[]} keys - secondary keys required by the active theme's CSS */
+export function setThemeSecondaryTagKeys(keys) {
+    themeSecondaryTagKeys = new Set(Array.isArray(keys) ? keys : []);
+}
+
+/** @returns {string[]} the theme-required secondary keys (CSS-class form) */
+export function getThemeSecondaryTagKeys() {
+    return [...themeSecondaryTagKeys];
+}
+
+/**
+ * Collect the OSM keys referenced by `tag-*` selectors in a theme's CSS. The key
+ * is the part after `tag-` up to the first `-` (OSM keys never contain `-`; the
+ * `-` separates key from value). Synthetic tokens are skipped.
+ *
+ * @param {string} css - raw CSS text
+ * @returns {string[]} unique keys (CSS-class form, e.g. `cuisine`, `piste_type`)
+ */
+export function extractTagKeysFromCss(css) {
+    const keys = new Set();
+    if (typeof css !== 'string') return [];
+    const re = /\.tag-([a-z0-9_]+)/g;
+    let match;
+    while ((match = re.exec(css)) !== null) {
+        const key = match[1];
+        if (!SYNTHETIC_TAG_TOKENS.has(key)) keys.add(key);
+    }
+    return [...keys];
+}
+
+/**
+ * Append theme-required secondary tag classes for an entity. Iterates the
+ * entity's actual tags and converts each key to its CSS-class form (`:` → `_`)
+ * before matching the theme set. Using the real key avoids any `_`-vs-`:`
+ * ambiguity (e.g. `piste:type` and a hypothetical `piste_type` both map to the
+ * class `tag-piste_type`, and keys like `piste:type_for_x` round-trip cleanly).
+ *
+ * @param {string[]} classes - class list being built (mutated)
+ * @param {Record<string, string>} t - entity tags
+ */
+export function appendThemeTagClasses(classes, t) {
+    if (themeSecondaryTagKeys.size === 0) return;
+    for (const realKey in t) {
+        const classKey = realKey.replace(/:/g, '_');
+        if (!themeSecondaryTagKeys.has(classKey)) continue;
+        const value = t[realKey];
+        if (!value || value === 'no') continue;
+        if (classes.indexOf('tag-' + classKey) === -1) classes.push('tag-' + classKey);
+        const valueClass = 'tag-' + classKey + '-' + value;
+        if (classes.indexOf(valueClass) === -1) classes.push(valueClass);
+    }
+}
+
 /**
  * Append fork-specific tag classes for custom map styling.
  *

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -10,6 +10,7 @@ import { t } from '../core/localizer';
 
 import { fileFetcher } from './file_fetcher';
 import { localizer } from './localizer';
+import { refreshThemeTagKeys } from './themes';
 import { coreHistory } from './history';
 import { coreValidator } from './validator';
 import { coreUploader } from './uploader';
@@ -602,6 +603,9 @@ export function coreContext() {
       if (context.initialHashParams.theme) {
         context.theme(context.initialHashParams.theme);
       }
+
+      // register the active CSS theme's tag classes so map elements get them
+      refreshThemeTagKeys();
 
       // kick off some async work
       localizer.ensureLoaded();

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -10,7 +10,8 @@ import { t } from '../core/localizer';
 
 import { fileFetcher } from './file_fetcher';
 import { localizer } from './localizer';
-import { refreshThemeTagKeys } from './themes';
+import { prefs } from './preferences';
+import { applyTheme, THEME_PREF, UPLOADED_THEMES_PREF } from './themes';
 import { coreHistory } from './history';
 import { coreValidator } from './validator';
 import { coreUploader } from './uploader';
@@ -604,8 +605,15 @@ export function coreContext() {
         context.theme(context.initialHashParams.theme);
       }
 
-      // register the active CSS theme's tag classes so map elements get them
-      refreshThemeTagKeys();
+      // apply the active CSS theme (tag classes + injected CSS), and re-apply +
+      // redraw whenever the selected theme or the stored themes change
+      applyTheme();
+      function onThemeChange() {
+        applyTheme();
+        if (_map) _map.pan([0, 0]);   // force a redraw so classes are recomputed
+      }
+      prefs.onChange(THEME_PREF, onThemeChange);
+      prefs.onChange(UPLOADED_THEMES_PREF, onThemeChange);
 
       // kick off some async work
       localizer.ensureLoaded();

--- a/modules/core/themes.ts
+++ b/modules/core/themes.ts
@@ -1,5 +1,9 @@
 import { prefs } from './preferences';
 import { predefinedThemes } from '../../config/id.js';
+import {
+    extractTagKeysFromCss,
+    setThemeSecondaryTagKeys
+} from '../../config/tag_classes_custom.js';
 
 // UI theme selection and storage. Uploaded CSS themes are kept in localStorage
 // alongside the other preferences (a single CSS file is well within the ~5 MB
@@ -75,6 +79,23 @@ export function getSelectedThemeId(): string {
 /** @param id - the theme id to select */
 export function setSelectedThemeId(id: string): void {
     prefs(THEME_PREF, id);
+    refreshThemeTagKeys();
+}
+
+/** @returns the CSS of the active theme (empty for the default/built-in theme). */
+export function getActiveThemeCss(): string {
+    const id = getSelectedThemeId();
+    if (id === DEFAULT_THEME_ID) return '';
+    const uploaded = getUploadedThemes().find((t) => t.id === id);
+    return uploaded ? uploaded.css : '';
+}
+
+/**
+ * Refresh the tag keys that the active theme's CSS needs, so map elements get the
+ * matching `tag-*` classes. Call on theme change and at startup.
+ */
+export function refreshThemeTagKeys(): void {
+    setThemeSecondaryTagKeys(extractTagKeysFromCss(getActiveThemeCss()));
 }
 
 /**

--- a/modules/core/themes.ts
+++ b/modules/core/themes.ts
@@ -98,6 +98,31 @@ export function refreshThemeTagKeys(): void {
     setThemeSecondaryTagKeys(extractTagKeysFromCss(getActiveThemeCss()));
 }
 
+/** id of the <style> element holding the active theme's CSS. */
+const THEME_STYLE_ELEMENT_ID = 'id-custom-theme-css';
+
+/**
+ * Inject the active theme's CSS into a dedicated <style> in the document head
+ * (created on first use). Switching themes replaces its content, so the previous
+ * theme's rules are dropped. No-op outside a browser (e.g. tests without a DOM).
+ */
+export function injectThemeCss(): void {
+    if (typeof document === 'undefined') return;
+    let style = document.getElementById(THEME_STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+    if (!style) {
+        style = document.createElement('style');
+        style.id = THEME_STYLE_ELEMENT_ID;
+        document.head.appendChild(style);
+    }
+    style.textContent = getActiveThemeCss();
+}
+
+/** Apply the active theme: refresh its tag keys and inject its CSS. */
+export function applyTheme(): void {
+    refreshThemeTagKeys();
+    injectThemeCss();
+}
+
 /**
  * All selectable themes: built-in default, predefined (from config), uploaded.
  */

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -1,6 +1,7 @@
 import { select as d3_select } from 'd3-selection';
 import {
     appendCustomTagClasses,
+    appendThemeTagClasses,
     customSecondaryTagKeys
 } from '../../config/tag_classes_custom.js';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
@@ -155,6 +156,7 @@ export function svgTagClasses() {
         }
 
         appendCustomTagClasses(classes, t);
+        appendThemeTagClasses(classes, t);
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)

--- a/test/spec/svg/theme_tag_classes.js
+++ b/test/spec/svg/theme_tag_classes.js
@@ -1,0 +1,74 @@
+import {
+    appendThemeTagClasses,
+    extractTagKeysFromCss,
+    getThemeSecondaryTagKeys,
+    setThemeSecondaryTagKeys
+} from '../../../config/tag_classes_custom.js';
+
+describe('theme tag classes', function() {
+
+    afterEach(function() {
+        setThemeSecondaryTagKeys([]);
+    });
+
+    describe('extractTagKeysFromCss', function() {
+        // [name, css, expected keys (sorted)]
+        const cases = [
+            ['simple key-value', '.tag-cuisine-pizza { color: red; }', ['cuisine']],
+            ['key only', '.tag-piste_type { fill: blue; }', ['piste_type']],
+            ['colon key (written with _)', '.tag-public_transport-platform {}', ['public_transport']],
+            ['underscore key', '.tag-man_made-pier {}', ['man_made']],
+            ['compound selector', '.tag-highway-footway.tag-crossing-marked {}', ['crossing', 'highway']],
+            ['value with underscore', '.tag-highway-living_street {}', ['highway']],
+            ['mixed : and _ in key', '.tag-piste_type_for_x-downhill {}', ['piste_type_for_x']],
+            ['several rules', '.tag-cuisine-pizza{}\n.tag-amenity-cafe{}\n.tag-cuisine{}', ['amenity', 'cuisine']],
+            ['synthetic tokens skipped', '.tag-status-abandoned{} .tag-wikidata{} .tag-paved{} .tag-custom-access-emphasis{}', []],
+            ['non-string', null, []],
+            ['no tag classes', '.foo .bar { color: red; }', []]
+        ];
+
+        cases.forEach(function([name, css, expected]) {
+            it(name, function() {
+                expect(extractTagKeysFromCss(css).sort()).to.eql(expected);
+            });
+        });
+    });
+
+    describe('appendThemeTagClasses', function() {
+        // [name, theme keys, tags, expected appended classes]
+        const cases = [
+            ['plain key', ['cuisine'], { cuisine: 'pizza' }, ['tag-cuisine', 'tag-cuisine-pizza']],
+            ['colon real key matches _ class', ['piste_type'], { 'piste:type': 'downhill' }, ['tag-piste_type', 'tag-piste_type-downhill']],
+            ['underscore real key', ['man_made'], { man_made: 'pier' }, ['tag-man_made', 'tag-man_made-pier']],
+            ['mixed : and _', ['piste_type_for_x'], { 'piste:type_for_x': 'a' }, ['tag-piste_type_for_x', 'tag-piste_type_for_x-a']],
+            ['value no is skipped', ['tunnel'], { tunnel: 'no' }, []],
+            ['key absent', ['cuisine'], { amenity: 'cafe' }, []],
+            ['no theme keys', [], { cuisine: 'pizza' }, []]
+        ];
+
+        cases.forEach(function([name, keys, tags, expected]) {
+            it(name, function() {
+                setThemeSecondaryTagKeys(keys);
+                const classes = [];
+                appendThemeTagClasses(classes, tags);
+                expect(classes).to.eql(expected);
+            });
+        });
+
+        it('does not duplicate classes already present', function() {
+            setThemeSecondaryTagKeys(['cuisine']);
+            const classes = ['tag-cuisine'];
+            appendThemeTagClasses(classes, { cuisine: 'pizza' });
+            expect(classes).to.eql(['tag-cuisine', 'tag-cuisine-pizza']);
+        });
+    });
+
+    describe('set/getThemeSecondaryTagKeys', function() {
+        it('round-trips and resets', function() {
+            setThemeSecondaryTagKeys(['a', 'b', 'a']);
+            expect(getThemeSecondaryTagKeys().sort()).to.eql(['a', 'b']);
+            setThemeSecondaryTagKeys([]);
+            expect(getThemeSecondaryTagKeys()).to.eql([]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Parse the active theme's CSS, extract the `tag-*` selectors it relies on, and make `svgTagClasses` emit those classes on map elements so themes can style any OSM key/value.
- Inject the active theme's CSS into a dedicated `<style>` element, replaced on every theme change (so the previous theme's rules are dropped).
- Re-apply the theme and redraw the map whenever the selected theme or the stored themes change; apply once at startup.
- Disambiguate `:` vs `_` in tag keys by matching against each entity's real tags, and skip synthetic `tag-*` tokens (status/wikidata/paved…) that aren't real OSM key/values.

## Test plan
- [x] Unit tests for CSS extraction, colon/underscore disambiguation, and secondary key get/set (20 passing).
- [x] Manual: load a theme CSS (e.g. `tasks/theme-test.css`); themed features (pizza restaurant, etc.) get styled, and reverting to the default theme clears both the classes and the injected CSS.