### PR TITLE
Add over-stroke line layer for highways

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -32,6 +32,14 @@ path.line.stroke.tag-highway {
     stroke-width: 5;
 }
 
+/* Over-stroke: an extra stroke drawn on top of each highway, transparent by
+   default. Paths are only created for ways with a `highway` tag (see svgLines).
+   Give it a width/color via `.line.over-stroke.tag-*` rules (e.g. an imported
+   theme) to draw a second/contrasting stroke. */
+path.line.over-stroke {
+    fill: none;
+}
+
 .preset-icon .icon.tag-highway-motorway,
 .preset-icon .icon.tag-highway-motorway_link {
     color: #CF2081;

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -127,7 +127,9 @@ export function svgLines(projection, context) {
         }
 
 
-        function drawLineGroup(selection, klass, isSelected) {
+        // `wayFilter` (optional) restricts the group to a subset of ways, e.g. the
+        // `over-stroke` group is only drawn for highways.
+        function drawLineGroup(selection, klass, isSelected, wayFilter) {
             // Note: Don't add `.selected` class in draw modes
             var mode = context.mode();
             var isDrawing = mode && /^draw/.test(mode.id);
@@ -136,7 +138,7 @@ export function svgLines(projection, context) {
             var lines = selection
                 .selectAll('path')
                 .filter(filter)
-                .data(getPathData(isSelected), osmEntity.key);
+                .data(getPathData(isSelected, wayFilter), osmEntity.key);
 
             lines.exit()
                 .remove();
@@ -192,11 +194,12 @@ export function svgLines(projection, context) {
         }
 
 
-        function getPathData(isSelected) {
+        function getPathData(isSelected, wayFilter) {
             return function() {
                 var layer = this.parentNode.__data__;
                 var data = pathdata[layer] || [];
                 return data.filter(function(d) {
+                    if (wayFilter && !wayFilter(d)) return false;
                     if (isSelected) {
                         return context.selectedIDs().indexOf(d.id) !== -1;
                     } else {
@@ -296,7 +299,7 @@ export function svgLines(projection, context) {
 
             layergroup
                 .selectAll('g.linegroup')
-                .data(['shadow', 'casing', 'stroke', 'shadow-highlighted', 'casing-highlighted', 'stroke-highlighted'])
+                .data(['shadow', 'casing', 'stroke', 'over-stroke', 'shadow-highlighted', 'casing-highlighted', 'stroke-highlighted'])
                 .enter()
                 .append('g')
                 .attr('class', function(d) { return 'linegroup line-' + d; });
@@ -307,6 +310,11 @@ export function svgLines(projection, context) {
                 .call(drawLineGroup, 'casing', false);
             layergroup.selectAll('g.line-stroke')
                 .call(drawLineGroup, 'stroke', false);
+            // Extra stroke drawn on top of each highway, transparent by default.
+            // Only created for ways with a `highway` tag so it can be styled via
+            // `.line.over-stroke.tag-*` rules (e.g. an imported theme).
+            layergroup.selectAll('g.line-over-stroke')
+                .call(drawLineGroup, 'over-stroke', false, (d) => !!d.tags.highway);
 
             layergroup.selectAll('g.line-shadow-highlighted')
                 .call(drawLineGroup, 'shadow', true);

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -182,6 +182,30 @@ describe('iD.svgLines', function () {
         });
     });
 
+    describe('over-stroke', function() {
+        // [name, tags, expectsOverStrokePath]
+        var cases = [
+            ['highway way', {highway: 'residential'}, true],
+            ['non-highway line', {waterway: 'stream'}, false],
+            ['untagged way', {}, false]
+        ];
+
+        cases.forEach(function(testCase) {
+            var name = testCase[0], tags = testCase[1], expected = testCase[2];
+            it(name + (expected ? ' gets an over-stroke path' : ' gets no over-stroke path'), function() {
+                var a = new iD.osmNode({loc: [0, 0]});
+                var b = new iD.osmNode({loc: [1, 1]});
+                var line = new iD.osmWay({nodes: [a.id, b.id], tags: tags});
+                var graph = new iD.coreGraph([a, b, line]);
+
+                surface.call(iD.svgLines(projection, context), graph, [line], all);
+
+                var selection = surface.selectAll('g.line-over-stroke > path.line');
+                expect(selection.size()).to.eql(expected ? 1 : 0);
+            });
+        });
+    });
+
     describe('sided-markers', function() {
         it('has marker layer for sided way', function() {
             var a = new iD.osmNode({id: 'a', loc: [0, 0]});


### PR DESCRIPTION
## Summary
Adds an extra `over-stroke` line layer drawn on top of each highway, transparent by default, so it can be styled via `.line.over-stroke.tag-*` CSS rules (e.g. from an imported theme) to render a second/contrasting stroke — like a colored center line for cycle/bus lanes.

- New `over-stroke` line group in `svgLines`, drawn above `stroke`.
- `drawLineGroup`/`getPathData` gain an optional `wayFilter`; the over-stroke group only creates paths for ways with a `highway` tag, keeping the cost minimal (no extra geometry: `svgPath` results are cached and shared across line groups).
- Base CSS rule `path.line.over-stroke { fill: none; }` (no visual style shipped — meant to be set by custom/imported CSS).

## Test plan
- [x] `test/spec/svg/lines.js`: over-stroke path is created for highways, not for non-highway lines or untagged ways.
- [x] Manual: a `.line.over-stroke.tag-highway-residential { stroke: red; stroke-width: 2 }` rule renders a red center line on residential roads.