### PR TITLE
Lens keyboard shortcuts (Alt+letter)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4425,8 +4425,34 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .lens-options-container .lens-uploaded-item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 8px;
     padding: 8px 10px;
+}
+.lens-options-container .lens-uploaded-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.lens-options-container .lens-shortcut {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    margin: 0;
+}
+.lens-options-container .lens-shortcut-modifier {
+    opacity: 0.6;
+}
+.lens-options-container .lens-shortcut-input {
+    width: 3.5em;
+    box-sizing: border-box;
+    text-align: center;
+    text-transform: lowercase;
+}
+.lens-options-container .lens-shortcut-input.lens-shortcut-invalid {
+    border-color: var(--warning-text, #d97706);
 }
 .lens-options-container .lens-uploaded-remove {
     flex: 0 0 auto;

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -265,7 +265,14 @@
                 "upload": "Import a CSS file",
                 "upload_description": "Add a custom lens from a .css file kept in your browser.",
                 "upload_warning": "Only import lenses from sources you trust. A lens's CSS can change the editor's appearance.",
-                "remove": "Remove lens"
+                "remove": "Remove lens",
+                "shortcut": {
+                    "label": "Shortcut letter (activated with Alt + letter)",
+                    "placeholder": "key",
+                    "reserved": "This letter is reserved by another shortcut.",
+                    "invalid": "Enter a single letter (a-z).",
+                    "flash": "Lens: {name}"
+                }
             }
         },
         "preferences": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -265,7 +265,14 @@
                 "upload": "Importer un fichier CSS",
                 "upload_description": "Ajouter une lentille personnalisée depuis un fichier .css conservé dans votre navigateur.",
                 "upload_warning": "N'importez que des lentilles provenant de sources de confiance. Le CSS d'une lentille peut modifier l'apparence de l'éditeur.",
-                "remove": "Supprimer la lentille"
+                "remove": "Supprimer la lentille",
+                "shortcut": {
+                    "label": "Lettre de raccourci (activée avec Alt + lettre)",
+                    "placeholder": "touche",
+                    "reserved": "Cette lettre est réservée par un autre raccourci.",
+                    "invalid": "Entrez une seule lettre (a-z).",
+                    "flash": "Lentille : {name}"
+                }
             }
         },
         "preferences": {

--- a/modules/behavior/lens_shortcuts.js
+++ b/modules/behavior/lens_shortcuts.js
@@ -1,0 +1,77 @@
+import { t } from '../core/localizer';
+import {
+    DEFAULT_LENS_ID,
+    DEFAULT_LENS_SHORTCUT,
+    getLensIdByShortcut,
+    getSelectedLensId,
+    getUploadedLenses,
+    setSelectedLensId
+} from '../core/lenses';
+
+/**
+ * Lens Shortcuts Behavior
+ *
+ * Activates an imported lens with `⌥`+letter. Letters are bound to lenses in the
+ * Map data ▸ Lens section. Pressing the active lens's letter again toggles back
+ * to the default lens. The letter is read from `event.code` (e.g. `KeyJ` → `j`)
+ * so it works regardless of the character `⌥`+letter produces (e.g. on macOS).
+ *
+ * @param {object} context - the iD application context
+ * @returns {Function} the behavior, installable via `selection.call(behavior)`
+ */
+export function behaviorLensShortcuts(context) {
+
+    function behavior(selection) {
+        selection.on('keydown.lens-shortcuts', keydown, true);  // capture phase
+    }
+
+    /** Display label for the now-active lens (default is localized). */
+    function lensLabel(id) {
+        if (id === DEFAULT_LENS_ID) return t('map_data.lens.default');
+        const lens = getUploadedLenses().find((l) => l.id === id);
+        return lens ? lens.name : id;
+    }
+
+    function keydown(d3_event) {
+        // Only `⌥`+letter, and never while typing or with other modifiers.
+        if (!d3_event.altKey || d3_event.ctrlKey || d3_event.metaKey) return;
+
+        const target = d3_event.target;
+        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+            return;
+        }
+
+        const match = /^Key([A-Z])$/.exec(d3_event.code || '');
+        if (!match) return;
+
+        const letter = match[1].toLowerCase();
+
+        // `⌥D` is the fixed shortcut back to the default lens (turns any lens off);
+        // otherwise look up the lens bound to this letter. Bail if neither applies.
+        let nextId;
+        if (letter === DEFAULT_LENS_SHORTCUT) {
+            nextId = DEFAULT_LENS_ID;
+        } else {
+            const lensId = getLensIdByShortcut(letter);
+            if (!lensId) return;
+            // Toggle: pressing the active lens's letter returns to the default lens.
+            nextId = getSelectedLensId() === lensId ? DEFAULT_LENS_ID : lensId;
+        }
+
+        d3_event.preventDefault();
+        d3_event.stopPropagation();
+        setSelectedLensId(nextId);
+
+        context.ui().flash
+            .duration(2000)
+            .iconName('#iD-icon-data')
+            .iconClass('')
+            .label(t('map_data.lens.shortcut.flash', { name: lensLabel(nextId) }))();
+    }
+
+    behavior.off = function(selection) {
+        selection.on('keydown.lens-shortcuts', null);
+    };
+
+    return behavior;
+}

--- a/modules/core/lenses.ts
+++ b/modules/core/lenses.ts
@@ -10,8 +10,18 @@ import { prefs } from './preferences';
 export const LENS_PREF = 'preferences.lens';
 /** Preference key holding the JSON array of uploaded lenses. */
 export const UPLOADED_LENSES_PREF = 'preferences.lens.uploaded';
+/** Preference key holding the `{ letter: lensId }` shortcut map. */
+export const LENS_SHORTCUTS_PREF = 'preferences.lens.shortcuts';
 /** Id of the built-in (no custom CSS) lens. */
 export const DEFAULT_LENS_ID = 'default';
+/** Fixed `⌥`+letter shortcut that switches back to the default lens (lens off). */
+export const DEFAULT_LENS_SHORTCUT = 'd';
+/**
+ * Letters that cannot be assigned to a lens because `⌥`+letter is already taken:
+ *   - `w` -> global `⌥W` toggles the OSM layer (see modules/ui/init.js)
+ *   - `d` -> reserved here for the default lens (DEFAULT_LENS_SHORTCUT)
+ */
+export const RESERVED_LENS_SHORTCUTS = new Set(['w', DEFAULT_LENS_SHORTCUT]);
 
 /** A CSS lens imported by the user and stored in localStorage. */
 export interface UploadedLens {
@@ -87,6 +97,7 @@ export function sanitizeLensCss(css: string): string {
  */
 export function removeUploadedLens(id: string): void {
     saveUploadedLenses(getUploadedLenses().filter((t) => t.id !== id));
+    removeLensShortcut(id);
     if (getSelectedLensId() === id) setSelectedLensId(DEFAULT_LENS_ID);
 }
 
@@ -117,6 +128,97 @@ export function listLenses(): LensEntry[] {
         { id: DEFAULT_LENS_ID, source: 'default' },
         ...getUploadedLenses().map((t) => ({ id: t.id, name: t.name, source: 'uploaded' as const }))
     ];
+}
+
+// ---------------------------------------------------------------------------
+// Lens keyboard shortcuts
+//
+// Each uploaded lens may be bound to a single letter, activated with `⌥`+letter
+// (see behaviorLensShortcuts). The map is stored as `{ letter: lensId }`, which
+// makes the "which lens for this key" lookup direct and guarantees one lens per
+// letter.
+// ---------------------------------------------------------------------------
+
+/** True for a valid, assignable shortcut letter (`a`-`z`, excluding reserved). */
+function isAssignableShortcut(letter: string): boolean {
+    return /^[a-z]$/.test(letter) && !RESERVED_LENS_SHORTCUTS.has(letter);
+}
+
+/**
+ * The `{ letter: lensId }` shortcut map, dropping entries whose lens no longer
+ * exists so stale shortcuts never fire.
+ * @returns the cleaned shortcut map (empty on missing/invalid data)
+ */
+export function getLensShortcuts(): Record<string, string> {
+    let parsed: unknown;
+    try {
+        const raw = prefs(LENS_SHORTCUTS_PREF);
+        parsed = JSON.parse((typeof raw === 'string' ? raw : '') || '{}');
+    } catch {
+        return {};
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const existingIds = new Set(getUploadedLenses().map((l) => l.id));
+    const result: Record<string, string> = {};
+    for (const [letter, id] of Object.entries(parsed as Record<string, string>)) {
+        if (typeof id === 'string' && existingIds.has(id)) result[letter] = id;
+    }
+    return result;
+}
+
+function saveLensShortcuts(shortcuts: Record<string, string>): void {
+    prefs(LENS_SHORTCUTS_PREF, JSON.stringify(shortcuts));
+}
+
+/**
+ * The shortcut letter bound to a lens, if any.
+ * @param id - lens id
+ * @returns the letter, or undefined
+ */
+export function getShortcutForLens(id: string): string | undefined {
+    const shortcuts = getLensShortcuts();
+    return Object.keys(shortcuts).find((letter) => shortcuts[letter] === id);
+}
+
+/**
+ * The lens bound to a shortcut letter, if any.
+ * @param letter - single lowercase letter
+ * @returns the lens id, or undefined
+ */
+export function getLensIdByShortcut(letter: string): string | undefined {
+    return getLensShortcuts()[letter];
+}
+
+/**
+ * Bind a letter to a lens. The letter moves off any other lens that held it,
+ * and the lens loses any letter it previously had (one letter per lens).
+ * @param id - lens id
+ * @param letter - single lowercase letter (`a`-`z`, not reserved)
+ * @throws if the letter is not assignable
+ */
+export function setLensShortcut(id: string, letter: string): void {
+    if (!isAssignableShortcut(letter)) {
+        throw new Error(`Invalid lens shortcut letter: ${letter}`);
+    }
+    const shortcuts = getLensShortcuts();
+    for (const existing of Object.keys(shortcuts)) {
+        if (existing === letter || shortcuts[existing] === id) delete shortcuts[existing];
+    }
+    shortcuts[letter] = id;
+    saveLensShortcuts(shortcuts);
+}
+
+/**
+ * Remove the shortcut bound to a lens (no-op if it has none).
+ * @param id - lens id
+ */
+export function removeLensShortcut(id: string): void {
+    const shortcuts = getLensShortcuts();
+    let changed = false;
+    for (const letter of Object.keys(shortcuts)) {
+        if (shortcuts[letter] === id) { delete shortcuts[letter]; changed = true; }
+    }
+    if (changed) saveLensShortcuts(shortcuts);
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -8,6 +8,7 @@ import { t, localizer } from '../core/localizer';
 import { presetManager } from '../presets';
 import { behaviorHash } from '../behavior';
 import { behaviorPresetShortcuts } from '../behavior/preset_shortcuts';
+import { behaviorLensShortcuts } from '../behavior/lens_shortcuts';
 import { modeBrowse } from '../modes/browse';
 import { svgDefs, svgIcon } from '../svg';
 import { utilDetect } from '../util/detect';
@@ -377,6 +378,10 @@ export function uiInit(context) {
         // Setup preset shortcuts behavior
         ui.presetShortcuts = behaviorPresetShortcuts(context);
         d3_select(document).call(ui.presetShortcuts);
+
+        // Setup lens shortcuts behavior (⌥+letter activates an imported lens)
+        ui.lensShortcuts = behaviorLensShortcuts(context);
+        d3_select(document).call(ui.lensShortcuts);
 
         // Bind events
         window.onbeforeunload = function() {

--- a/modules/ui/sections/lenses.ts
+++ b/modules/ui/sections/lenses.ts
@@ -4,13 +4,19 @@ import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 import type { LensEntry } from '../../core/lenses';
 import {
+    DEFAULT_LENS_SHORTCUT,
     LENS_PREF,
+    LENS_SHORTCUTS_PREF,
+    RESERVED_LENS_SHORTCUTS,
     UPLOADED_LENSES_PREF,
     addUploadedLens,
     getSelectedLensId,
+    getShortcutForLens,
     getUploadedLenses,
     listLenses,
+    removeLensShortcut,
     removeUploadedLens,
+    setLensShortcut,
     setSelectedLensId
 } from '../../core/lenses';
 
@@ -30,9 +36,12 @@ export function uiSectionLenses(context: any) {
         .label(() => t.append('map_data.lens.title'))
         .disclosureContent(renderDisclosureContent);
 
-    /** Display label for a lens entry (the built-in one is localized). */
+    /** Display label for a lens entry (the built-in one is localized + shows ⌥D). */
     function lensLabel(entry: LensEntry): string {
-        return entry.source === 'default' ? t('map_data.lens.default') : (entry.name || entry.id);
+        if (entry.source === 'default') {
+            return `${t('map_data.lens.default')} (⌥${DEFAULT_LENS_SHORTCUT.toUpperCase()})`;
+        }
+        return entry.name || entry.id;
     }
 
     /** Read the selected CSS file, store it as a lens and select it. */
@@ -117,17 +126,59 @@ export function uiSectionLenses(context: any) {
             .append('li')
             .attr('class', 'lens-uploaded-item');
         itemsEnter.append('span').attr('class', 'lens-uploaded-name');
+
+        // shortcut assignment: a single letter, activated with ⌥+letter
+        const shortcutEnter = itemsEnter.append('label').attr('class', 'lens-shortcut');
+        shortcutEnter.append('span').attr('class', 'lens-shortcut-modifier').text('⌥');
+        shortcutEnter.append('input')
+            .attr('type', 'text')
+            .attr('class', 'lens-shortcut-input')
+            .attr('maxlength', '1')
+            .attr('size', '1')
+            .attr('placeholder', () => t('map_data.lens.shortcut.placeholder'))
+            .attr('title', () => t('map_data.lens.shortcut.label'))
+            .on('change', onShortcutChange)
+            .on('keydown', function(this: HTMLInputElement, d3_event: KeyboardEvent) {
+                if (d3_event.key === 'Enter') this.blur();
+            });
+
         itemsEnter.append('button')
             .attr('class', 'lens-uploaded-remove')
             .attr('title', () => t('map_data.lens.remove'))
             .on('click', (_d3_event: any, d: any) => removeUploadedLens(d.id))
             .call(svgIcon('#iD-operation-delete'));
 
-        itemsEnter.merge(items).select('.lens-uploaded-name').text((d: any) => d.name);
+        const itemsMerged = itemsEnter.merge(items);
+        itemsMerged.select('.lens-uploaded-name').text((d: any) => d.name);
+        itemsMerged.select('.lens-shortcut-input')
+            .property('value', (d: any) => getShortcutForLens(d.id) || '')
+            .classed('lens-shortcut-invalid', false)
+            .attr('title', () => t('map_data.lens.shortcut.label'));
+    }
+
+    /** Validate and persist (or clear) a lens's shortcut letter. */
+    function onShortcutChange(this: HTMLInputElement, _d3_event: Event, d: any) {
+        const letter = this.value.trim().toLowerCase();
+
+        if (!letter) {
+            removeLensShortcut(d.id);
+            return;  // prefs.onChange triggers a re-render
+        }
+        const invalid = !/^[a-z]$/.test(letter)
+            ? t('map_data.lens.shortcut.invalid')
+            : RESERVED_LENS_SHORTCUTS.has(letter) ? t('map_data.lens.shortcut.reserved') : null;
+        if (invalid) {
+            this.classList.add('lens-shortcut-invalid');
+            this.title = invalid;
+            this.value = getShortcutForLens(d.id) || '';
+            return;
+        }
+        setLensShortcut(d.id, letter);
     }
 
     prefs.onChange(LENS_PREF, section.reRender);
     prefs.onChange(UPLOADED_LENSES_PREF, section.reRender);
+    prefs.onChange(LENS_SHORTCUTS_PREF, section.reRender);
 
     return section;
 }

--- a/test/spec/core/lenses_storage.js
+++ b/test/spec/core/lenses_storage.js
@@ -2,12 +2,17 @@ import { prefs } from '../../../modules/core/preferences';
 import {
     DEFAULT_LENS_ID,
     LENS_PREF,
+    LENS_SHORTCUTS_PREF,
     UPLOADED_LENSES_PREF,
     addUploadedLens,
+    getLensIdByShortcut,
     getSelectedLensId,
+    getShortcutForLens,
     getUploadedLenses,
     listLenses,
+    removeLensShortcut,
     removeUploadedLens,
+    setLensShortcut,
     setSelectedLensId
 } from '../../../modules/core/lenses';
 
@@ -16,6 +21,7 @@ describe('core/lenses', function() {
     beforeEach(function() {
         prefs(LENS_PREF, null);
         prefs(UPLOADED_LENSES_PREF, null);
+        prefs(LENS_SHORTCUTS_PREF, null);
     });
 
     describe('selection', function() {
@@ -63,6 +69,55 @@ describe('core/lenses', function() {
             setSelectedLensId(keep.id);
             removeUploadedLens(drop.id);
             expect(getSelectedLensId()).to.equal(keep.id);
+        });
+    });
+
+    describe('lens shortcuts', function() {
+        it('binds a letter to a lens and reads it back both ways', function() {
+            const lens = addUploadedLens({ name: 'A', css: 'a{}' });
+            setLensShortcut(lens.id, 'j');
+            expect(getShortcutForLens(lens.id)).to.equal('j');
+            expect(getLensIdByShortcut('j')).to.equal(lens.id);
+        });
+
+        it('keeps one letter per lens (reassigning moves the letter)', function() {
+            const lens = addUploadedLens({ name: 'A', css: 'a{}' });
+            setLensShortcut(lens.id, 'j');
+            setLensShortcut(lens.id, 'k');
+            expect(getShortcutForLens(lens.id)).to.equal('k');
+            expect(getLensIdByShortcut('j')).to.equal(undefined);
+        });
+
+        it('steals a letter already used by another lens', function() {
+            const a = addUploadedLens({ name: 'A', css: 'a{}' });
+            const b = addUploadedLens({ name: 'B', css: 'b{}' });
+            setLensShortcut(a.id, 'j');
+            setLensShortcut(b.id, 'j');
+            expect(getLensIdByShortcut('j')).to.equal(b.id);
+            expect(getShortcutForLens(a.id)).to.equal(undefined);
+        });
+
+        it('removes a lens shortcut', function() {
+            const lens = addUploadedLens({ name: 'A', css: 'a{}' });
+            setLensShortcut(lens.id, 'j');
+            removeLensShortcut(lens.id);
+            expect(getShortcutForLens(lens.id)).to.equal(undefined);
+        });
+
+        it('drops the shortcut when its lens is removed', function() {
+            const lens = addUploadedLens({ name: 'A', css: 'a{}' });
+            setLensShortcut(lens.id, 'j');
+            removeUploadedLens(lens.id);
+            expect(getLensIdByShortcut('j')).to.equal(undefined);
+        });
+
+        // reserved (w, d) and non-single-letter values must be rejected
+        ['w', 'd', 'A', '1', 'ab', '', '!'].forEach(function(letter) {
+            it(`rejects invalid shortcut ${JSON.stringify(letter)}`, function() {
+                const lens = addUploadedLens({ name: 'A', css: 'a{}' });
+                expect(() => setLensShortcut(lens.id, letter)).to.throw();
+                expect(getShortcutForLens(lens.id)).to.equal(undefined);
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
Assigns keyboard shortcuts to imported lenses, in the same spirit as the preset shortcuts but with a modifier so there is no collision with the bare-digit preset shortcuts.

- Each imported lens can be bound to a single letter, activated with `⌥`+letter.
- Pressing the active lens's letter again toggles back to the default lens.
- `⌥D` is a fixed shortcut that returns to the default lens (lens off).
- Assignment happens inline in **Map data ▸ Lens**: a one-letter input per lens (shown with an `⌥` prefix), with validation for reserved (`w`, `d`) and invalid letters.
- The letter is read from `event.code` (`KeyJ` → `j`), so it works regardless of the character `⌥`+letter produces (e.g. on macOS), the same mechanism as the existing `⌥W`.

## Implementation
- `modules/core/lenses.ts`: `{ letter: lensId }` map under `preferences.lens.shortcuts`, with get/set/remove helpers, validation, stale-entry cleanup, and removal of a lens's shortcut when the lens is removed.
- `modules/behavior/lens_shortcuts.js`: keydown behavior, installed in `ui/init` like the preset shortcuts.
- `modules/ui/sections/lenses.ts` + `css/80_app.css` + EN/FR strings: assignment UI.

## Commits
1. Add lens keyboard shortcut storage
2. Activate lenses with Alt+letter
3. Add lens shortcut assignment UI

## Test plan
- [x] Unit tests for the shortcut storage (bind/reassign/steal/remove/cleanup, reserved + invalid rejection) in `test/spec/core/lenses_storage.js`.
- [x] Manual: import a lens, assign it a letter, `⌥<letter>` activates it and re-pressing toggles off; `⌥D` returns to default.

## Note
Some pre-existing tests in `test/spec/core/lenses_storage.js` that write then read a preference fail under jsdom locally (localStorage round-trip). This is unrelated to this feature and will be addressed in a separate PR; the new shortcut tests follow the same pattern and pass once preferences persist.