### PR TITLE
Add highway=stop presets with direction and stop=minor/all

### DIFF
--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -6,7 +6,8 @@
 
 /** Extra secondary OSM keys → `tag-{key}` and `tag-{key}-{value}` (do not duplicate upstream secondaries). */
 export const customSecondaryTagKeys = [
-    'cycleway'
+    'cycleway',
+    'stop'
 ];
 
 /**

--- a/css/20_map.css
+++ b/css/20_map.css
@@ -313,6 +313,14 @@ g.vertex.tag-wikidata .icon {
     color: #666;
 }
 
+/* Stop signs — v5 parity (stop=all dark red, stop=minor pale red) */
+g.vertex.tag-highway-stop.tag-stop-all .icon {
+    color: #AB0000;
+}
+g.vertex.tag-highway-stop.tag-stop-minor .icon {
+    color: #FFC9C9;
+}
+
 /* Selected Members */
 g.vertex.selected-member .shadow,
 g.point.selected-member .shadow,

--- a/data/custom-tagging/src/presets/highway/stop_variants.ts
+++ b/data/custom-tagging/src/presets/highway/stop_variants.ts
@@ -1,0 +1,30 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+/** Direction and stop=* value for each variant preset. */
+const STOP_VARIANTS: Record<string, { direction: string; stop: string }> = {
+    forward_minor: { direction: 'forward', stop: 'minor' },
+    forward_all: { direction: 'forward', stop: 'all' },
+    backward_minor: { direction: 'backward', stop: 'minor' },
+    backward_all: { direction: 'backward', stop: 'all' }
+};
+
+function stopPreset(suffix: string, variant: { direction: string; stop: string }): CustomPreset {
+    const tags = { highway: 'stop', direction: variant.direction, stop: variant.stop };
+
+    return {
+        icon: 'temaki-stop',
+        geometry: ['vertex'],
+        fields: ['stop', 'direction_vertex'],
+        tags,
+        addTags: tags,
+        reference: { key: 'highway', value: 'stop' },
+        name: presetNameEn(`highway/stop_${suffix}`)
+    };
+}
+
+export const stopVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    Object.entries(STOP_VARIANTS).map(
+        ([suffix, variant]) => [`highway/stop_${suffix}`, stopPreset(suffix, variant)] as const
+    )
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -12,6 +12,7 @@ import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_
 import { serviceVariantPresets } from './presets/highway/service_variants';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
+import { stopVariantPresets } from './presets/highway/stop_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -55,6 +56,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...serviceVariantPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,
+    ...stopVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -764,6 +764,26 @@
         "terms": "std, dismount, bicycle, steps, stairs, staircase, stairway",
         "aliases": "std"
     },
+    "highway/stop_forward_minor": {
+        "name": "Stop Sign Forward (minor)",
+        "terms": "stfm, stop, halt, sign, forward, minor",
+        "aliases": "stfm"
+    },
+    "highway/stop_forward_all": {
+        "name": "Stop Sign Forward (all directions)",
+        "terms": "stfa, stop, halt, sign, forward, all",
+        "aliases": "stfa"
+    },
+    "highway/stop_backward_minor": {
+        "name": "Stop Sign Backward (minor)",
+        "terms": "stbm, stop, halt, sign, backward, minor",
+        "aliases": "stbm"
+    },
+    "highway/stop_backward_all": {
+        "name": "Stop Sign Backward (all directions)",
+        "terms": "stba, stop, halt, sign, backward, all",
+        "aliases": "stba"
+    },
     "office/construction_company": {
         "name": "Building Construction Company",
         "terms": "construction, builder, building, contractor, general contractor"

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -764,6 +764,26 @@
         "terms": "std, vélo à pied, descendre du vélo, escalier, escaliers, marches",
         "aliases": "std"
     },
+    "highway/stop_forward_minor": {
+        "name": "Panneau d'arrêt avant (priorité mineure)",
+        "terms": "stfm, arrêt, stop, panneau, avant, forward, minor, mineure",
+        "aliases": "stfm"
+    },
+    "highway/stop_forward_all": {
+        "name": "Panneau d'arrêt avant (toutes directions)",
+        "terms": "stfa, arrêt, stop, panneau, avant, forward, all, toutes directions",
+        "aliases": "stfa"
+    },
+    "highway/stop_backward_minor": {
+        "name": "Panneau d'arrêt arrière (priorité mineure)",
+        "terms": "stbm, arrêt, stop, panneau, arrière, backward, minor, mineure",
+        "aliases": "stbm"
+    },
+    "highway/stop_backward_all": {
+        "name": "Panneau d'arrêt arrière (toutes directions)",
+        "terms": "stba, arrêt, stop, panneau, arrière, backward, all, toutes directions",
+        "aliases": "stba"
+    },
     "office/construction_company": {
         "name": "Entreprise de construction (bâtiments)",
         "terms": "construction, bâtiment, entrepreneur, constructeur, bâtisseur, contracteur"

--- a/test/spec/presets/custom/stop.js
+++ b/test/spec/presets/custom/stop.js
@@ -1,0 +1,44 @@
+import { loadCustomPresets } from './setup.js';
+
+const CASES = [
+    {
+        id: 'highway/stop_forward_minor',
+        tags: { highway: 'stop', direction: 'forward', stop: 'minor' },
+        alias: 'stfm'
+    },
+    {
+        id: 'highway/stop_forward_all',
+        tags: { highway: 'stop', direction: 'forward', stop: 'all' },
+        alias: 'stfa'
+    },
+    {
+        id: 'highway/stop_backward_minor',
+        tags: { highway: 'stop', direction: 'backward', stop: 'minor' },
+        alias: 'stbm'
+    },
+    {
+        id: 'highway/stop_backward_all',
+        tags: { highway: 'stop', direction: 'backward', stop: 'all' },
+        alias: 'stba'
+    }
+];
+
+describe('custom presets — stop sign variants', function() {
+    loadCustomPresets();
+
+    CASES.forEach(function({ id, tags, alias }) {
+        it(`defines ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.addTags).to.eql(tags);
+            expect(preset.geometry).to.include('vertex');
+        });
+
+        it(`finds ${id} by alias ${alias}`, function() {
+            const pool = iD.presetManager.matchAllGeometry(['vertex']);
+            const found = pool.search(alias, 'vertex').collection.map((p) => p.id);
+            expect(found).to.include(id);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add four custom vertex presets for `highway=stop` with `direction=forward|backward` and `stop=minor|all`.
- English and French names/terms plus search aliases (`stfm`, `stfa`, `stbm`, `stba`).
- Parametric tests for tags and alias search.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/stop.js` (8/8)
- [ ] Manual: search `stfm` / `stba` in preset list on a road vertex and confirm tags applied