### PR TITLE
Add traffic signals forward/backward vertex presets

### DIFF
--- a/data/custom-tagging/src/presets/highway/traffic_signals_variants.ts
+++ b/data/custom-tagging/src/presets/highway/traffic_signals_variants.ts
@@ -1,0 +1,29 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+/** `traffic_signals:direction` value for each variant preset. */
+const TRAFFIC_SIGNALS_VARIANTS: Record<string, string> = {
+    forward: 'forward',
+    backward: 'backward'
+};
+
+function trafficSignalsPreset(suffix: string, direction: string): CustomPreset {
+    const tags = { highway: 'traffic_signals', 'traffic_signals:direction': direction };
+
+    return {
+        icon: 'temaki-traffic_signals',
+        geometry: ['vertex'],
+        fields: ['traffic_signals', 'traffic_signals/direction'],
+        tags,
+        addTags: tags,
+        reference: { key: 'highway', value: 'traffic_signals' },
+        name: presetNameEn(`highway/traffic_signals_${suffix}`)
+    };
+}
+
+export const trafficSignalsVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    Object.entries(TRAFFIC_SIGNALS_VARIANTS).map(
+        ([suffix, direction]) =>
+            [`highway/traffic_signals_${suffix}`, trafficSignalsPreset(suffix, direction)] as const
+    )
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -13,6 +13,7 @@ import { serviceVariantPresets } from './presets/highway/service_variants';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { stopVariantPresets } from './presets/highway/stop_variants';
+import { trafficSignalsVariantPresets } from './presets/highway/traffic_signals_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
@@ -57,6 +58,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...trackPrivatePresets,
     ...stepsVariantPresets,
     ...stopVariantPresets,
+    ...trafficSignalsVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -784,6 +784,16 @@
         "terms": "stba, stop, halt, sign, backward, all",
         "aliases": "stba"
     },
+    "highway/traffic_signals_forward": {
+        "name": "Traffic Signals Forward",
+        "terms": "tsfw, light, stoplight, traffic light, signals, forward",
+        "aliases": "tsfw"
+    },
+    "highway/traffic_signals_backward": {
+        "name": "Traffic Signals Backward",
+        "terms": "tsbw, light, stoplight, traffic light, signals, backward",
+        "aliases": "tsbw"
+    },
     "office/construction_company": {
         "name": "Building Construction Company",
         "terms": "construction, builder, building, contractor, general contractor"

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -784,6 +784,16 @@
         "terms": "stba, arrêt, stop, panneau, arrière, backward, all, toutes directions",
         "aliases": "stba"
     },
+    "highway/traffic_signals_forward": {
+        "name": "Feux de circulation avant",
+        "terms": "tsfw, feux, lumière, traffic light, signals, avant, forward",
+        "aliases": "tsfw"
+    },
+    "highway/traffic_signals_backward": {
+        "name": "Feux de circulation arrière",
+        "terms": "tsbw, feux, lumière, traffic light, signals, arrière, backward",
+        "aliases": "tsbw"
+    },
     "office/construction_company": {
         "name": "Entreprise de construction (bâtiments)",
         "terms": "construction, bâtiment, entrepreneur, constructeur, bâtisseur, contracteur"

--- a/test/spec/presets/custom/traffic_signals.js
+++ b/test/spec/presets/custom/traffic_signals.js
@@ -1,0 +1,34 @@
+import { loadCustomPresets } from './setup.js';
+
+const CASES = [
+    {
+        id: 'highway/traffic_signals_forward',
+        tags: { highway: 'traffic_signals', 'traffic_signals:direction': 'forward' },
+        alias: 'tsfw'
+    },
+    {
+        id: 'highway/traffic_signals_backward',
+        tags: { highway: 'traffic_signals', 'traffic_signals:direction': 'backward' },
+        alias: 'tsbw'
+    }
+];
+
+describe('custom presets — traffic signals variants', function() {
+    loadCustomPresets();
+
+    CASES.forEach(function({ id, tags, alias }) {
+        it(`defines ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql(tags);
+            expect(preset.addTags).to.eql(tags);
+            expect(preset.geometry).to.include('vertex');
+        });
+
+        it(`finds ${id} by alias ${alias}`, function() {
+            const pool = iD.presetManager.matchAllGeometry(['vertex']);
+            const found = pool.search(alias, 'vertex').collection.map((p) => p.id);
+            expect(found).to.include(id);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add two custom vertex presets: `highway/traffic_signals_forward` and `highway/traffic_signals_backward`.
- Tags: `highway=traffic_signals` + `traffic_signals:direction=forward|backward` (same as v5).
- English/French names and search aliases (`tsfw`, `tsbw`).
- Parametric tests for tags and alias search.

## OSM wiki check
Verified against [Tag:highway=traffic_signals](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtraffic_signals):
- `traffic_signals:direction=forward|backward` is the documented way to indicate which travel direction the signals apply to on bidirectional ways.
- Distinct from `direction=*` used on `highway=stop` nodes — our stop presets already use the correct key.
- Upstream id-tagging-schema already ships the `traffic_signals/direction` field (forward, backward, both); no schema or wiki update needed for this PR.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/traffic_signals.js` (4/4)
- [x] Manual: on a bidirectional road vertex, search `tsfw` / `tsbw` and confirm tags