### PR TITLE
Add maxspeed lens tag-class support

### DIFF
--- a/config/maxspeed_lens.js
+++ b/config/maxspeed_lens.js
@@ -1,0 +1,101 @@
+/**
+ * Maxspeed lens — parse OSM maxspeed values into decade colour buckets for CSS.
+ */
+
+/**
+ * @param {string|undefined} raw
+ * @returns {string|null}
+ */
+export function maxspeedClassValue(raw) {
+    if (!raw) return null;
+    const match = String(raw).match(/^([0-9][0-9.]*?)(?:[ ]?(?:km\/h|kmh|kph|mph|knots))?$/);
+    return match ? String(parseInt(match[1], 10)) : null;
+}
+
+/**
+ * Decade colour bucket (10–100) for maxspeed stroke styling.
+ *
+ * @param {string|undefined} raw
+ * @returns {string|null}
+ */
+export function maxspeedColorBucket(raw) {
+    const n = maxspeedClassValue(raw);
+    if (!n) return null;
+    const v = parseInt(n, 10);
+    return String(Math.min(100, Math.max(10, Math.floor(v / 10) * 10)));
+}
+
+/**
+ * Advisory colour bucket (10–100). Québec OSM uses multiples of 5 only (65, 75, …).
+ *
+ * @param {string|undefined} raw
+ * @returns {string|null}
+ */
+export function maxspeedAdvisoryColorBucket(raw) {
+    const n = maxspeedClassValue(raw);
+    if (!n) return null;
+    const v = parseInt(n, 10);
+    if (v % 5 !== 0) return null;
+    return String(Math.min(100, Math.max(10, Math.floor(v / 10) * 10)));
+}
+
+/**
+ * Effective maxspeed for styling (supports `maxspeed:forward` / `:backward`).
+ *
+ * @param {Record<string, string>} t
+ * @returns {string|undefined}
+ */
+export function pickMaxspeedRaw(t) {
+    const oneway = t.oneway;
+    if (oneway === '-1') {
+        return t['maxspeed:backward'] || t.maxspeed || t['maxspeed:forward'];
+    }
+    if (oneway === 'yes' || oneway === '1') {
+        return t['maxspeed:forward'] || t.maxspeed || t['maxspeed:backward'];
+    }
+    return t.maxspeed || t['maxspeed:forward'] || t['maxspeed:backward'];
+}
+
+/**
+ * Effective maxspeed:advisory for styling (supports directional subkeys).
+ *
+ * @param {Record<string, string>} t
+ * @returns {string|undefined}
+ */
+export function pickMaxspeedAdvisoryRaw(t) {
+    const oneway = t.oneway;
+    if (oneway === '-1') {
+        return t['maxspeed:advisory:backward'] || t['maxspeed:advisory'] ||
+            t['maxspeed:advisory:forward'];
+    }
+    if (oneway === 'yes' || oneway === '1') {
+        return t['maxspeed:advisory:forward'] || t['maxspeed:advisory'] ||
+            t['maxspeed:advisory:backward'];
+    }
+    return t['maxspeed:advisory'] || t['maxspeed:advisory:forward'] ||
+        t['maxspeed:advisory:backward'];
+}
+
+/**
+ * @param {string[]} classes
+ * @param {string} classKey
+ * @param {string|undefined} raw
+ * @param {(raw: string|undefined) => string|null} bucketFn
+ * @param {boolean} [advisoryExtras]
+ */
+export function appendMaxspeedLensClasses(classes, classKey, raw, bucketFn, advisoryExtras = false) {
+    if (!raw || raw === 'no') return;
+    const classValue = bucketFn(raw);
+    if (!classValue) return;
+    const keyClass = 'tag-' + classKey;
+    const valueClass = keyClass + '-' + classValue;
+    if (classes.indexOf(keyClass) === -1) classes.push(keyClass);
+    if (classes.indexOf(valueClass) === -1) classes.push(valueClass);
+    if (advisoryExtras) {
+        if (classes.indexOf('tag-has-maxspeed-advisory') === -1) {
+            classes.push('tag-has-maxspeed-advisory');
+        }
+        const xadvClass = 'tag-xadv-' + classValue;
+        if (classes.indexOf(xadvClass) === -1) classes.push(xadvClass);
+    }
+}

--- a/modules/core/lenses.ts
+++ b/modules/core/lenses.ts
@@ -1,4 +1,11 @@
 import { prefs } from './preferences';
+import {
+    appendMaxspeedLensClasses,
+    maxspeedAdvisoryColorBucket,
+    maxspeedColorBucket,
+    pickMaxspeedAdvisoryRaw,
+    pickMaxspeedRaw
+} from '../../config/maxspeed_lens.js';
 
 // UI lens support. A lens is a CSS file imported by the user and kept in
 // localStorage (a single stylesheet is well within the ~5 MB quota). The active
@@ -246,7 +253,7 @@ export function removeLensShortcut(id: string): void {
  *   - `custom`     → from `tag-custom-access-emphasis` (fork access-emphasis styling)
  */
 const SYNTHETIC_TAG_TOKENS = new Set([
-    'status', 'wikidata', 'paved', 'unpaved', 'semipaved', 'custom'
+    'status', 'wikidata', 'paved', 'unpaved', 'semipaved', 'custom', 'has', 'xadv'
 ]);
 
 /** Lens-required secondary keys, in their CSS-class form (`:` written as `_`). */
@@ -279,6 +286,10 @@ export function extractTagKeysFromCss(css: string): string[] {
         const key = match[1];
         if (!SYNTHETIC_TAG_TOKENS.has(key)) keys.add(key);
     }
+    // Attribute selectors (e.g. [class*="tag-maxspeed_advisory-"]) are not matched above.
+    if (/tag-maxspeed_advisory|tag-has-maxspeed-advisory|tag-xadv-/.test(css)) {
+        keys.add('maxspeed_advisory');
+    }
     return [...keys];
 }
 
@@ -294,7 +305,19 @@ export function extractTagKeysFromCss(css: string): string[] {
  */
 export function appendLensTagClasses(classes: string[], t: Record<string, string>): void {
     if (lensSecondaryTagKeys.size === 0) return;
+
+    if (lensSecondaryTagKeys.has('maxspeed')) {
+        appendMaxspeedLensClasses(classes, 'maxspeed', pickMaxspeedRaw(t), maxspeedColorBucket);
+    }
+    if (lensSecondaryTagKeys.has('maxspeed_advisory')) {
+        appendMaxspeedLensClasses(
+            classes, 'maxspeed_advisory', pickMaxspeedAdvisoryRaw(t),
+            maxspeedAdvisoryColorBucket, true
+        );
+    }
+
     for (const realKey in t) {
+        if (realKey === 'maxspeed' || realKey.startsWith('maxspeed:')) continue;
         const classKey = realKey.replace(/:/g, '_');
         if (!lensSecondaryTagKeys.has(classKey)) continue;
         const value = t[realKey];
@@ -302,6 +325,56 @@ export function appendLensTagClasses(classes: string[], t: Record<string, string
         if (classes.indexOf('tag-' + classKey) === -1) classes.push('tag-' + classKey);
         const valueClass = 'tag-' + classKey + '-' + value;
         if (classes.indexOf(valueClass) === -1) classes.push(valueClass);
+    }
+}
+
+/** Core structure classes that override maxspeed lens advisory casing (50_misc.css). */
+const MAXSPEED_LENS_STRUCTURE_CLASS_PREFIXES = [
+    'tag-bridge',
+    'tag-tunnel',
+    'tag-embankment',
+    'tag-cutting',
+    'tag-location-underground',
+    'tag-location-underwater'
+];
+
+/** Fork access classes that recolour footways/paths and motor roads (30_highways.css). */
+const MAXSPEED_LENS_ACCESS_CLASS_PREFIXES = [
+    'tag-access',
+    'tag-foot',
+    'tag-motor_vehicle',
+    'tag-service'
+];
+const MAXSPEED_LENS_ACCESS_VALUES = new Set(['private', 'customers', 'permissive']);
+
+function shouldStripClassForMaxspeedLens(klass: string): boolean {
+    if (klass === 'tag-custom-access-emphasis') return true;
+    if (MAXSPEED_LENS_STRUCTURE_CLASS_PREFIXES.some(
+        (prefix) => klass === prefix || klass.startsWith(prefix + '-')
+    )) {
+        return true;
+    }
+    for (const prefix of MAXSPEED_LENS_ACCESS_CLASS_PREFIXES) {
+        if (!klass.startsWith(prefix + '-')) continue;
+        const value = klass.slice(prefix.length + 1);
+        if (MAXSPEED_LENS_ACCESS_VALUES.has(value)) return true;
+    }
+    return false;
+}
+
+/**
+ * Drop classes that conflict with maxspeed lens styling (structures, access colours).
+ *
+ * @param classes - class list being built (mutated)
+ */
+export function stripStructureClassesForMaxspeedLens(classes: string[]): void {
+    if (!lensSecondaryTagKeys.has('maxspeed') && !lensSecondaryTagKeys.has('maxspeed_advisory')) {
+        return;
+    }
+    for (let i = classes.length - 1; i >= 0; i--) {
+        if (shouldStripClassForMaxspeedLens(classes[i])) {
+            classes.splice(i, 1);
+        }
     }
 }
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -3,7 +3,7 @@ import {
     appendCustomTagClasses,
     customSecondaryTagKeys
 } from '../../config/tag_classes_custom.js';
-import { appendLensTagClasses } from '../core/lenses';
+import { appendLensTagClasses, stripStructureClassesForMaxspeedLens } from '../core/lenses';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
 
 
@@ -157,6 +157,7 @@ export function svgTagClasses() {
 
         appendCustomTagClasses(classes, t);
         appendLensTagClasses(classes, t);
+        stripStructureClassesForMaxspeedLens(classes);
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)

--- a/test/spec/core/lenses.js
+++ b/test/spec/core/lenses.js
@@ -3,7 +3,8 @@ import {
     extractTagKeysFromCss,
     getLensSecondaryTagKeys,
     sanitizeLensCss,
-    setLensSecondaryTagKeys
+    setLensSecondaryTagKeys,
+    stripStructureClassesForMaxspeedLens
 } from '../../../modules/core/lenses';
 
 describe('lens tag classes', function() {
@@ -25,7 +26,9 @@ describe('lens tag classes', function() {
             ['several rules', '.tag-cuisine-pizza{}\n.tag-amenity-cafe{}\n.tag-cuisine{}', ['amenity', 'cuisine']],
             ['synthetic tokens skipped', '.tag-status-abandoned{} .tag-wikidata{} .tag-paved{} .tag-custom-access-emphasis{}', []],
             ['non-string', null, []],
-            ['no tag classes', '.foo .bar { color: red; }', []]
+            ['no tag classes', '.foo .bar { color: red; }', []],
+            ['maxspeed_advisory via attribute selector', '[class*="tag-maxspeed_advisory-"]{}', ['maxspeed_advisory']],
+            ['maxspeed_advisory via xadv class', '.tag-xadv-60 { stroke: orange; }', ['maxspeed_advisory']]
         ];
 
         cases.forEach(function([name, css, expected]) {
@@ -44,7 +47,20 @@ describe('lens tag classes', function() {
             ['mixed : and _', ['piste_type_for_x'], { 'piste:type_for_x': 'a' }, ['tag-piste_type_for_x', 'tag-piste_type_for_x-a']],
             ['value no is skipped', ['tunnel'], { tunnel: 'no' }, []],
             ['key absent', ['cuisine'], { amenity: 'cafe' }, []],
-            ['no lens keys', [], { cuisine: 'pizza' }, []]
+            ['no lens keys', [], { cuisine: 'pizza' }, []],
+            ['maxspeed bucketed to decade', ['maxspeed'], { maxspeed: '65' }, ['tag-maxspeed', 'tag-maxspeed-60']],
+            ['maxspeed with units', ['maxspeed'], { maxspeed: '100 km/h' }, ['tag-maxspeed', 'tag-maxspeed-100']],
+            ['maxspeed:advisory bucketed', ['maxspeed_advisory'], { 'maxspeed:advisory': '65' },
+                ['tag-maxspeed_advisory', 'tag-maxspeed_advisory-60', 'tag-has-maxspeed-advisory', 'tag-xadv-60']],
+            ['maxspeed + advisory', ['maxspeed', 'maxspeed_advisory'],
+                { maxspeed: '100', 'maxspeed:advisory': '65' },
+                ['tag-maxspeed', 'tag-maxspeed-100', 'tag-maxspeed_advisory', 'tag-maxspeed_advisory-60',
+                    'tag-has-maxspeed-advisory', 'tag-xadv-60']],
+            ['maxspeed:advisory:forward on oneway link', ['maxspeed', 'maxspeed_advisory'],
+                { highway: 'motorway_link', oneway: 'yes', maxspeed: '70', 'maxspeed:advisory:forward': '35' },
+                ['tag-maxspeed', 'tag-maxspeed-70', 'tag-maxspeed_advisory', 'tag-maxspeed_advisory-30',
+                    'tag-has-maxspeed-advisory', 'tag-xadv-30']],
+            ['maxspeed:advisory non-multiple-of-5 skipped', ['maxspeed_advisory'], { 'maxspeed:advisory': '62' }, []]
         ];
 
         cases.forEach(function([name, keys, tags, expected]) {
@@ -61,6 +77,35 @@ describe('lens tag classes', function() {
             const classes = ['tag-cuisine'];
             appendLensTagClasses(classes, { cuisine: 'pizza' });
             expect(classes).to.eql(['tag-cuisine', 'tag-cuisine-pizza']);
+        });
+    });
+
+    describe('stripStructureClassesForMaxspeedLens', function() {
+        // [name, lens keys, classes in, classes out]
+        const cases = [
+            ['no-op when lens off', [], ['tag-bridge', 'tag-highway-motorway'], ['tag-bridge', 'tag-highway-motorway']],
+            ['strips bridge for maxspeed lens', ['maxspeed', 'maxspeed_advisory'],
+                ['tag-highway-motorway_link', 'tag-bridge', 'tag-bridge-yes', 'tag-xadv-30'],
+                ['tag-highway-motorway_link', 'tag-xadv-30']],
+            ['strips tunnel embankment cutting location', ['maxspeed_advisory'],
+                ['tag-tunnel', 'tag-tunnel-yes', 'tag-embankment', 'tag-cutting',
+                    'tag-location-underground', 'tag-location-underwater'],
+                []],
+            ['strips footway/path access colours', ['maxspeed'],
+                ['tag-highway-path', 'tag-access-private', 'tag-foot-customers',
+                    'tag-custom-access-emphasis', 'tag-maxspeed-30'],
+                ['tag-highway-path', 'tag-maxspeed-30']],
+            ['keeps non-emphasis access values', ['maxspeed'],
+                ['tag-highway-residential', 'tag-access-destination'], ['tag-highway-residential', 'tag-access-destination']]
+        ];
+
+        cases.forEach(function([name, keys, input, expected]) {
+            it(name, function() {
+                setLensSecondaryTagKeys(keys);
+                const classes = input.slice();
+                stripStructureClassesForMaxspeedLens(classes);
+                expect(classes).to.eql(expected);
+            });
         });
     });
 

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -1,8 +1,14 @@
+import { setLensSecondaryTagKeys } from '../../../modules/core/lenses';
+
 describe('iD.svgTagClasses', function () {
     var selection;
 
     beforeEach(function () {
         selection = d3.select(document.createElement('div'));
+    });
+
+    afterEach(function () {
+        setLensSecondaryTagKeys([]);
     });
 
     it('adds no classes to elements whose datum has no tags', function() {
@@ -294,5 +300,29 @@ describe('iD.svgTagClasses', function () {
             .datum(new iD.osmWay({tags: {'piste:type': 'nordic'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-piste_type tag-piste_type-nordic');
+    });
+
+    it('maxspeed lens omits bridge structure classes', function() {
+        setLensSecondaryTagKeys(['maxspeed', 'maxspeed_advisory']);
+        const classes = iD.svgTagClasses().getClassesString({
+            highway: 'motorway_link',
+            bridge: 'yes',
+            maxspeed: '70',
+            'maxspeed:advisory': '35'
+        }, 'way line casing');
+        expect(classes).to.include('tag-xadv-30');
+        expect(classes).to.not.match(/\btag-bridge\b/);
+        expect(classes).to.not.match(/\btag-bridge-yes\b/);
+    });
+
+    it('maxspeed lens omits footway access colour classes', function() {
+        setLensSecondaryTagKeys(['maxspeed', 'maxspeed_advisory']);
+        const classes = iD.svgTagClasses().getClassesString({
+            highway: 'path',
+            access: 'private',
+            foot: 'private'
+        }, 'way line stroke');
+        expect(classes).to.not.match(/\btag-access-private\b/);
+        expect(classes).to.not.match(/\btag-foot-private\b/);
     });
 });


### PR DESCRIPTION
## Summary
- Add `config/maxspeed_lens.js` to bucket `maxspeed` / `maxspeed:advisory` into decade CSS classes (including directional subkeys and Québec advisory multiples-of-5 rule).
- Extend `appendLensTagClasses` to emit `tag-maxspeed-*`, `tag-xadv-*`, and `tag-has-maxspeed-advisory` for imported CSS lenses.
- Strip conflicting `bridge` / `tunnel` / `embankment` / `cutting` and fork access classes (`private`, `customers`, `permissive`) while the maxspeed lens is active, so core highway styles do not override lens colours.
- Parametric tests for bucketing, class stripping, and SVG integration.

Companion lens stylesheet (`lenses/maxspeed-colors.css`) is kept out of this PR — import it locally via Map data → Lens.

## Not in this PR (left on working tree)
- `config/tag_classes_custom.js` — `tag-surface-undefined` for the v5 surface lens
- `lenses/*.css` — lens CSS files
- No `entrance` / `routing:entrance` changes in this diff

## Test plan
- [ ] `npx vitest run test/spec/core/lenses.js`
- [ ] `npx vitest run test/spec/svg/tag_classes.js` (maxspeed lens cases)
- [ ] Import `lenses/maxspeed-colors.css`, activate lens, verify maxspeed + advisory colours on highways
- [ ] Select a way: nodes visible, core selection shadow/casing, advisory ring hidden
- [ ] Bridge / private footway segments use lens colours, not core black/red/orange