### PR TITLE
Add v5 Québec validation lens (maxspeed/lanes/surface errors)

### DIFF
--- a/config/highway_validation_tag_classes.js
+++ b/config/highway_validation_tag_classes.js
@@ -1,0 +1,214 @@
+/**
+ * v5 fork highway validation tag classes (missing maxspeed/lanes/surface, sidewalk errors, etc.).
+ * Used by lenses/v5-quebec-validation.css.
+ */
+
+/** Highways excluded from sidewalk validation (v5 parity). */
+const IGNORE_SIDEWALK_HIGHWAYS = new Set([
+    'motorway', 'motorway_link', 'track', 'footway', 'cycleway', 'service',
+    'living_street', 'pedestrian', 'escape', 'raceway', 'bridleway', 'steps',
+    'path', 'corridor', 'construction', 'proposed'
+]);
+
+/** Highways excluded from maxspeed/lanes validation (v5 parity). */
+const IGNORE_MAXSPEED_HIGHWAYS = new Set([
+    'track', 'footway', 'cycleway', 'pedestrian', 'escape', 'raceway', 'bridleway',
+    'steps', 'path', 'corridor', 'construction', 'proposed'
+]);
+
+/** Private footways excluded from surface-undefined (v5 parity). */
+const PRIVATE_SURFACE_EXCLUDE_HIGHWAYS = new Set(['path', 'footway', 'steps']);
+
+/**
+ * Append v5 validation/error classes for highway ways.
+ * @param {string[]} classes
+ * @param {Record<string, string>} t entity tags
+ */
+export function appendHighwayValidationTagClasses(classes, t) {
+    const highway = t.highway;
+    if (!highway) return;
+
+    const ignoreSidewalk = IGNORE_SIDEWALK_HIGHWAYS.has(highway);
+    const ignoreMaxSpeed = IGNORE_MAXSPEED_HIGHWAYS.has(highway);
+
+    let sidewalk = null;
+    let sidewalkBoth = null;
+    let sidewalkLeft = null;
+    let sidewalkRight = null;
+    let indoor = null;
+    let crossing = null;
+    let crossingMarkings = null;
+    let segregated = null;
+    let foot = null;
+    let access = null;
+    let surface = null;
+    let maxSpeed = null;
+    let lanes = null;
+    let lanesForward = null;
+    let lanesBackward = null;
+    let lanesBothWays = null;
+    let widthLanesCount = null;
+    let widthLanesStartCount = null;
+    let widthLanesEndCount = null;
+    let widthLanesForwardCount = null;
+    let widthLanesForwardStartCount = null;
+    let widthLanesForwardEndCount = null;
+    let widthLanesBackwardCount = null;
+    let widthLanesBackwardStartCount = null;
+    let widthLanesBackwardEndCount = null;
+
+    let isOneWay = false;
+    let hasLanes = false;
+    let hasLanesForward = false;
+    let hasLanesBackward = false;
+    let hasLanesBothWays = false;
+
+    for (const k of Object.keys(t)) {
+        const v = t[k];
+
+        if (k === 'indoor') indoor = v;
+        if (k === 'access') access = v;
+        if (k === 'foot' || k === 'routing:foot') foot = v;
+        if (k === 'crossing') crossing = v;
+        if (k === 'crossing:markings') crossingMarkings = v;
+        if (k === 'segregated') segregated = v;
+        if (!ignoreSidewalk && k === 'sidewalk') sidewalk = v;
+        if (!ignoreSidewalk && k === 'sidewalk:both' && ['shared', 'separate', 'no'].includes(v)) {
+            sidewalkBoth = v;
+        }
+        if (!ignoreSidewalk && k === 'sidewalk:left') {
+            sidewalkLeft = v;
+            classes.push('tag-sidewalk_left-' + sidewalkLeft);
+        }
+        if (!ignoreSidewalk && k === 'sidewalk:right') {
+            sidewalkRight = v;
+            classes.push('tag-sidewalk_right-' + sidewalkRight);
+        }
+        if (!ignoreMaxSpeed && (k === 'maxspeed' || k === 'maxspeed:advisory') && v >= 10 && v <= 130) {
+            maxSpeed = Number(v);
+        }
+        if (k === 'surface' && v) surface = v;
+        if (k === 'oneway' && v === 'yes') isOneWay = true;
+        if (k === 'lanes' && v >= 1 && v <= 8) {
+            lanes = Number(v);
+            hasLanes = true;
+        }
+        if (k === 'lanes:forward' && v >= 1 && v <= 8) {
+            lanesForward = Number(v);
+            hasLanesForward = true;
+        }
+        if (k === 'lanes:backward' && v >= 1 && v <= 8) {
+            lanesBackward = Number(v);
+            hasLanesBackward = true;
+        }
+        if (k === 'lanes:both_ways' && v >= 1 && v <= 8) {
+            lanesBothWays = Number(v);
+            hasLanesBothWays = true;
+        }
+        if (k === 'width:lanes') widthLanesCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:start') widthLanesStartCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:end') widthLanesEndCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:forward') widthLanesForwardCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:forward:start') widthLanesForwardStartCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:forward:end') widthLanesForwardEndCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:backward') widthLanesBackwardCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:backward:start') widthLanesBackwardStartCount = (v.match(/\|/g) || []).length + 1;
+        if (k === 'width:lanes:backward:end') widthLanesBackwardEndCount = (v.match(/\|/g) || []).length + 1;
+    }
+
+    if (!ignoreSidewalk) {
+        if ((sidewalk !== 'no' && sidewalk !== null) ||
+            (sidewalk === 'no' && (sidewalkBoth !== null || sidewalkLeft !== null || sidewalkRight !== null))) {
+            classes.push('tag-sidewalk-invalid');
+        } else if ((sidewalk !== null || sidewalkBoth !== null) && (sidewalkLeft !== null || sidewalkRight !== null)) {
+            classes.push('tag-sidewalk-invalid');
+        } else if (
+            (sidewalk === null && sidewalkBoth === 'separate' && sidewalkLeft === null && sidewalkRight === null) ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'separate' && sidewalkRight === 'separate') ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'separate' && sidewalkRight === 'no') ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'no' && sidewalkRight === 'separate')
+        ) {
+            classes.push('tag-sidewalk-separate');
+            if (sidewalkLeft === 'no' && sidewalkRight === 'separate') {
+                classes.push('tag-sidewalk-separate-right');
+            } else if (sidewalkLeft === 'separate' && sidewalkRight === 'no') {
+                classes.push('tag-sidewalk-separate-left');
+            } else if (sidewalkBoth === 'separate') {
+                classes.push('tag-sidewalk-separate-both');
+            }
+        } else if (
+            (sidewalk === null && sidewalkBoth === 'shared' && sidewalkLeft === null && sidewalkRight === null) ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'shared' && sidewalkRight === 'shared') ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'shared' && sidewalkRight === 'no') ||
+            (sidewalk === null && sidewalkLeft === 'no' && sidewalkRight === 'shared')
+        ) {
+            classes.push('tag-sidewalk-shared');
+            if (sidewalkRight === 'shared' && sidewalkLeft === 'no') {
+                classes.push('tag-sidewalk-shared-right');
+            } else if (sidewalkLeft === 'shared' && sidewalkRight === 'no') {
+                classes.push('tag-sidewalk-shared-left');
+            } else if (sidewalkBoth === 'shared') {
+                classes.push('tag-sidewalk-shared-both');
+            }
+        } else if (
+            (sidewalk === 'no' && sidewalkBoth === null && sidewalkLeft === null && sidewalkRight === null) ||
+            (sidewalk === null && sidewalkBoth === null && sidewalkLeft === 'no' && sidewalkRight === 'no') ||
+            (sidewalk === null && sidewalkBoth === 'no' && sidewalkLeft === null && sidewalkRight === null)
+        ) {
+            classes.push('tag-sidewalk-no');
+        } else if (sidewalk === null && sidewalkBoth === null && sidewalkLeft === null && sidewalkRight === null) {
+            classes.push('tag-sidewalk-undefined');
+        } else {
+            classes.push('tag-sidewalk-invalid');
+        }
+        if (crossing === 'uncontrolled' && !crossingMarkings) {
+            classes.push('tag-crossing-uncontrolled-empty-crossing-markings');
+        }
+    }
+
+    if (!isOneWay && hasLanes && lanes > 2 && (!hasLanesForward || !hasLanesBackward)) {
+        classes.push('tag-lanes-error-count-lanes');
+    }
+    if (hasLanesForward && hasLanesBackward && lanes !== lanesForward + lanesBackward) {
+        if (hasLanesBothWays && lanes !== lanesForward + lanesBackward + lanesBothWays) {
+            classes.push('tag-lanes-error-count-lanes-total-mismatch');
+        }
+    }
+    if (
+        (widthLanesCount && widthLanesCount !== lanes) ||
+        (widthLanesStartCount && widthLanesStartCount !== lanes) ||
+        (widthLanesEndCount && widthLanesEndCount !== lanes) ||
+        (widthLanesForwardCount && widthLanesForwardCount !== lanesForward) ||
+        (widthLanesForwardStartCount && widthLanesForwardStartCount !== lanesForward) ||
+        (widthLanesForwardEndCount && widthLanesForwardEndCount !== lanesForward) ||
+        (widthLanesBackwardCount && widthLanesBackwardCount !== lanesBackward) ||
+        (widthLanesBackwardStartCount && widthLanesBackwardStartCount !== lanesBackward) ||
+        (widthLanesBackwardEndCount && widthLanesBackwardEndCount !== lanesBackward)
+    ) {
+        classes.push('tag-lanes-error-width-lanes');
+    }
+
+    if (highway === 'cycleway' && !segregated) {
+        classes.push('tag-segregated-undefined');
+    }
+
+    if (!ignoreMaxSpeed) {
+        if (maxSpeed) {
+            if (maxSpeed > 70) classes.push('tag-maxspeed-more_than_70');
+        } else if (highway !== 'service') {
+            classes.push('tag-maxspeed-undefined');
+        }
+        if (!hasLanes && highway !== 'service') {
+            classes.push('tag-lanes-undefined');
+        }
+        if (foot !== 'use_sidepath') {
+            classes.push('tag-foot-not-use_sidepath');
+        }
+    }
+
+    if (!(access === 'private' && PRIVATE_SURFACE_EXCLUDE_HIGHWAYS.has(highway))) {
+        if ((!surface || surface === 'paved') && indoor !== 'yes') {
+            classes.push('tag-surface-undefined');
+        }
+    }
+}

--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -4,10 +4,13 @@
  * Listed here so fork-specific OSM keys and access rules stay out of modules/svg/tag_classes.js.
  */
 
+import { appendHighwayValidationTagClasses } from './highway_validation_tag_classes.js';
+
 /** Extra secondary OSM keys → `tag-{key}` and `tag-{key}-{value}` (do not duplicate upstream secondaries). */
 export const customSecondaryTagKeys = [
     'cycleway',
-    'stop'
+    'stop',
+    'fixme'
 ];
 
 /**
@@ -96,6 +99,7 @@ export function appendCustomTagClasses(classes, t) {
     }
 
     appendBuildingFlatsTagClasses(classes, t);
+    appendHighwayValidationTagClasses(classes, t);
 
     const highway = t.highway;
     if (!highway || excludeHighways.has(highway)) return;

--- a/lenses/v5-quebec-validation.css
+++ b/lenses/v5-quebec-validation.css
@@ -1,0 +1,125 @@
+/* ============================================================================
+ * Lens — v5 Québec validation / error highlights
+ * ----------------------------------------------------------------------------
+ * Port of v5 fork validation strokes (missing maxspeed, lanes, surface, sidewalk
+ * errors, lane count mismatches, segregated undefined, fixme).
+ *
+ * Import in Map data → Lens. Requires computed classes from
+ * config/highway_validation_tag_classes.js (wired via tag_classes_custom.js).
+ *
+ * Stroke colours (centre line):
+ *   fixme #FF7B7B · lanes error #A900A6 · segregated undefined #F00
+ *   sidewalk undefined/invalid #FF6600 (#65B30C when no other error)
+ *   lanes undefined #FFE600 · maxspeed undefined / >70 residential #F00
+ *   surface undefined #0080FF · sidewalk separate + foot #FF4800
+ * ============================================================================ */
+
+
+/* --- casing emphasis on errors (high zoom) --- */
+path.line.casing.tag-highway-cycleway.tag-segregated-undefined.tag-foot-designated,
+path.line.casing.tag-highway-cycleway.tag-segregated-undefined.tag-foot-yes,
+path.line.casing.tag-highway.tag-sidewalk-undefined,
+path.line.casing.tag-highway.tag-sidewalk-invalid,
+path.line.casing.tag-highway.tag-maxspeed-undefined,
+path.line.casing.tag-highway.tag-surface-undefined,
+path.line.casing.tag-highway.tag-lanes-undefined,
+path.line.casing.tag-highway.tag-lanes-error-count-lanes,
+path.line.casing.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
+path.line.casing.tag-highway.tag-lanes-error-width-lanes,
+path.line.casing.tag-highway.tag-fixme {
+    stroke: rgb(0, 0, 0);
+    stroke-dasharray: none;
+}
+
+.high-zoom path.line.casing.tag-highway-cycleway.tag-segregated-undefined.tag-foot-designated,
+.high-zoom path.line.casing.tag-highway-cycleway.tag-segregated-undefined.tag-foot-yes,
+.high-zoom path.line.casing.tag-highway.tag-sidewalk-undefined,
+.high-zoom path.line.casing.tag-highway.tag-sidewalk-invalid,
+.high-zoom path.line.casing.tag-highway.tag-maxspeed-undefined,
+.high-zoom path.line.casing.tag-highway.tag-surface-undefined,
+.high-zoom path.line.casing.tag-highway.tag-lanes-undefined,
+.high-zoom path.line.casing.tag-highway.tag-lanes-error-count-lanes,
+.high-zoom path.line.casing.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
+.high-zoom path.line.casing.tag-highway.tag-lanes-error-width-lanes,
+.high-zoom path.line.casing.tag-highway.tag-fixme {
+    stroke-width: 3;
+    opacity: 0.5;
+}
+
+.high-zoom path.line.stroke.tag-highway-cycleway.tag-segregated-undefined.tag-foot-designated,
+.high-zoom path.line.stroke.tag-highway-cycleway.tag-segregated-undefined.tag-foot-yes,
+.high-zoom path.line.stroke.tag-highway.tag-sidewalk-undefined,
+.high-zoom path.line.stroke.tag-highway.tag-sidewalk-invalid,
+.high-zoom path.line.stroke.tag-highway.tag-sidewalk-separate.tag-foot-not-use_sidepath:not(.tag-sidewalk-shared):not(.tag-sidewalk_left-shared):not(.tag-sidewalk_right-shared):not(.tag-sidewalk_both-shared),
+.high-zoom path.line.stroke.tag-highway.tag-maxspeed-undefined,
+.high-zoom path.line.stroke.tag-highway.tag-surface-undefined,
+.high-zoom path.line.stroke.tag-highway.tag-maxspeed-more_than_70.tag-highway-residential,
+.high-zoom path.line.stroke.tag-highway.tag-lanes-undefined,
+.high-zoom path.line.stroke.tag-highway.tag-lanes-error-count-lanes,
+.high-zoom path.line.stroke.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
+.high-zoom path.line.stroke.tag-highway.tag-lanes-error-width-lanes,
+.high-zoom path.line.stroke.tag-highway.tag-fixme {
+    stroke-width: 2;
+    opacity: 0.5;
+}
+
+/* --- stroke colours --- */
+path.line.stroke.tag-highway.tag-fixme {
+    stroke: rgb(255, 123, 123);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-lanes-error-count-lanes,
+path.line.stroke.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
+path.line.stroke.tag-highway.tag-lanes-error-width-lanes {
+    stroke: rgb(169, 0, 166);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway-cycleway.tag-segregated-undefined.tag-foot-designated,
+path.line.stroke.tag-highway-cycleway.tag-segregated-undefined.tag-foot-yes {
+    stroke: rgb(255, 0, 0);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-sidewalk-undefined,
+path.line.stroke.tag-highway.tag-sidewalk-invalid {
+    stroke: rgb(255, 102, 0);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-sidewalk-undefined:not(.tag-maxspeed-undefined):not(.tag-lanes-undefined):not(.tag-surface-undefined),
+path.line.stroke.tag-highway.tag-sidewalk-invalid:not(.tag-maxspeed-undefined):not(.tag-lanes-undefined):not(.tag-surface-undefined) {
+    stroke: rgb(101, 179, 12);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-lanes-undefined {
+    stroke: rgb(255, 230, 0);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-sidewalk-separate.tag-foot-not-use_sidepath:not(.tag-sidewalk-shared):not(.tag-sidewalk_left-shared):not(.tag-sidewalk_right-shared):not(.tag-sidewalk_both-shared) {
+    stroke: rgb(255, 72, 0);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-maxspeed-undefined,
+path.line.stroke.tag-highway.tag-maxspeed-more_than_70.tag-highway-residential {
+    stroke: rgb(255, 0, 0);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}
+
+path.line.stroke.tag-highway.tag-surface-undefined {
+    stroke: rgb(0, 128, 255);
+    stroke-dasharray: 2, 2;
+    stroke-linecap: butt;
+}

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -310,11 +310,12 @@ describe('iD.svgTagClasses', function () {
 
     for (const [key, value, expectedClass] of flatsCases) {
         it(`adds ${expectedClass} for building with ${key}=${value}`, function() {
-            selection
+            const sel = d3.select(document.createElement('div'));
+            sel
                 .datum(new iD.osmWay({ tags: { building: 'apartments', [key]: value } }))
                 .call(iD.svgTagClasses());
-            expect(selection.classed('tag-has-flats')).to.be.true;
-            expect(selection.classed(expectedClass)).to.be.true;
+            expect(sel.classed('tag-has-flats')).to.be.true;
+            expect(sel.classed(expectedClass)).to.be.true;
         });
     }
 
@@ -324,6 +325,35 @@ describe('iD.svgTagClasses', function () {
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-has-flats')).to.be.true;
         expect(selection.classed('tag-flats-4')).to.be.true;
+    });
+
+    const validationCases = [
+        ['tag-maxspeed-undefined', { highway: 'residential' }],
+        ['tag-lanes-undefined', { highway: 'primary' }],
+        ['tag-surface-undefined', { highway: 'secondary', surface: 'paved' }],
+        ['tag-surface-undefined', { highway: 'tertiary' }],
+        ['tag-sidewalk-undefined', { highway: 'residential' }],
+        ['tag-maxspeed-more_than_70', { highway: 'motorway', maxspeed: '90' }],
+        ['tag-lanes-error-count-lanes', { highway: 'primary', lanes: '4' }],
+        ['tag-segregated-undefined', { highway: 'cycleway', foot: 'designated' }],
+        ['tag-fixme', { highway: 'residential', fixme: 'yes' }]
+    ];
+
+    for (const [expectedClass, tags] of validationCases) {
+        it(`adds ${expectedClass} (v5 validation)`, function() {
+            const sel = d3.select(document.createElement('div'));
+            sel
+                .datum(new iD.osmWay({ tags }))
+                .call(iD.svgTagClasses());
+            expect(sel.classed(expectedClass)).to.be.true;
+        });
+    }
+
+    it('does not add tag-surface-undefined on private footway', function() {
+        selection
+            .datum(new iD.osmWay({ tags: { highway: 'footway', access: 'private' } }))
+            .call(iD.svgTagClasses());
+        expect(selection.classed('tag-surface-undefined')).to.be.false;
     });
 
     it('maxspeed lens omits bridge structure classes', function() {


### PR DESCRIPTION
## Summary
- Add `config/highway_validation_tag_classes.js`: port v5 validation classes (`tag-maxspeed-undefined`, `tag-lanes-undefined`, `tag-surface-undefined`, sidewalk errors, lane mismatches, etc.).
- Wire via `tag_classes_custom.js`; add `fixme` to custom secondaries for `tag-fixme`.
- Add `lenses/v5-quebec-validation.css`: dashed error strokes (always on, no debug-surfaces toggle).
- Parametric tests for validation tag classes.

## Test plan
- [x] `npx vitest run test/spec/svg/tag_classes.js -t validation`
- [ ] Import `lenses/v5-quebec-validation.css` in Map data → Lens
- [ ] Residential road without `maxspeed` → red dashed stroke
- [ ] Primary without `lanes` → yellow dashed stroke
- [ ] Road with `surface=paved` or no surface → blue dashed stroke
- [ ] `fixme=yes` → pink dashed stroke