### PR TITLE
Fix: save dialog blocked by invalid feature on changeset.update

### DIFF
--- a/modules/osm/changeset.ts
+++ b/modules/osm/changeset.ts
@@ -18,6 +18,11 @@ export class osmChangeset extends OsmAbstractEntity {
         super({ type: 'changeset' }, ...args);
     }
 
+    /** Inherited {@link OsmAbstractEntity.update} routes through createEntity, which rejects changesets. */
+    update(attrs: Partial<OsmEntityProps>) {
+        return new osmChangeset(this, { ...attrs, v: 1 + (this.v || 0) });
+    }
+
     copy(): never {
         throw new Error('not allowed');
     }

--- a/test/spec/osm/changeset.js
+++ b/test/spec/osm/changeset.js
@@ -12,6 +12,13 @@ describe('iD.osmChangeset', function () {
         expect(new iD.osmChangeset({tags: {foo: 'bar'}}).tags).to.eql({foo: 'bar'});
     });
 
+    it('updates tags via update()', function () {
+        var c = new iD.osmChangeset({ tags: { comment: 'hello' } });
+        var updated = c.update({ tags: { comment: 'hello', source: 'survey' } });
+        expect(updated).to.be.an.instanceOf(iD.osmChangeset);
+        expect(updated.tags).to.eql({ comment: 'hello', source: 'survey' });
+    });
+
 
     describe('#asJXON', function () {
         it('converts a node to jxon', function() {


### PR DESCRIPTION
## Summary
- Override `osmChangeset.update()` so it no longer routes through `createEntity`, which rejects `type === 'changeset'`.
- Fixes the `Uncaught Error: invalid feature` when opening the save/commit dialog after the ES6 migration.

## Test plan
- [x] `npx vitest run test/spec/osm/changeset.js --no-isolate`
- [ ] Manual: edit map, click Save — commit dialog should appear