### PR TITLE
Fix: smooth/curverize osmNode requires new after ES6 migration

### DIFF
--- a/modules/actions/curverize.ts
+++ b/modules/actions/curverize.ts
@@ -164,7 +164,7 @@ export function actionCurverize(selectedIds: EntityID[], projection: iD.Projecti
                 const latLonPoint = projection.invert(arcPoint);
                 if (geoSphericalDistance(latLonPoint, segmentNodeEnd.loc) >= ARC_NODE_THRESHOLD_METERS &&
                     geoSphericalDistance(latLonPoint, segmentNodeStart.loc) >= ARC_NODE_THRESHOLD_METERS) {
-                    radiusNodes.push(osmNode({ loc: latLonPoint }));
+                    radiusNodes.push(new osmNode({ loc: latLonPoint }));
                 }
             }
 

--- a/modules/actions/smooth.ts
+++ b/modules/actions/smooth.ts
@@ -546,7 +546,7 @@ function smoothSingleWay(graph: iD.Graph, way: iD.OsmWay, node1: iD.OsmNode, nod
                 return graph.entity<iD.OsmNode>(intersectionNodeIds[m]);
             }
         }
-        return osmNode({ loc: coord });
+        return new osmNode({ loc: coord });
     });
 
     const smoothedNodesIds = smoothedNodes.map((node) => node.id);
@@ -817,7 +817,7 @@ function smoothAcrossWays(graph: iD.Graph, node1: iD.OsmNode, node2: iD.OsmNode,
             }
 
             if (!tooCloseToPrevious) {
-                const newNode = osmNode({ loc: coord });
+                const newNode = new osmNode({ loc: coord });
                 smoothedNodes.push(newNode);
                 lastCoord = coord;
             }
@@ -1129,7 +1129,7 @@ function smoothEntireWay(graph: iD.Graph, way: iD.OsmWay): iD.Graph {
                 lastCoord = coord;
             }
         } else if (!tooCloseToPrevious) {
-            const newNode = osmNode({ loc: coord });
+            const newNode = new osmNode({ loc: coord });
             smoothedNodes.push(newNode);
             lastCoord = coord;
         }


### PR DESCRIPTION
## Summary
- Add missing `new` before `osmNode()` in `smooth.ts` (3 call sites) and `curverize.ts` (1 call site).
- Fixes `TypeError: class constructors must be invoked with 'new'` when running Smooth on a way.

## Test plan
- [ ] Manual: select a highway way, run Smooth — should complete without console error
- [ ] Manual: run Curverize on a curved segment — should complete without console error