### PR TITLE
Feat: digit-led alphanumeric preset shortcuts (8a, 42f)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -910,16 +910,16 @@ en:
     button_tooltip: Set keyboard shortcut
     button_tooltip_with_shortcut: "Keyboard shortcut: {shortcut}"
     preset_label: "Set shortcut for: {preset}"
-    instructions: "Enter a number between 8 and 999 (numbers 1-7 are reserved shortcuts)."
+    instructions: "Enter 8-999, or a digit-led code up to 3 characters (e.g. 8a). Numbers 1-7 are reserved."
     modal_title: Edit Keyboard Shortcut
-    modal_description: "Set a numeric keyboard shortcut (8-999) to quickly access this preset"
-    shortcut_label: "Shortcut Number"
-    shortcut_placeholder: "Enter 8-999"
+    modal_description: "Set a keyboard shortcut (8-999 or digit-led codes like 8a) to quickly access this preset"
+    shortcut_label: "Shortcut"
+    shortcut_placeholder: "e.g. 8, 42, 8a"
     save: Save
     remove: Remove Shortcut
     edit_tooltip: Edit shortcut
-    error_empty: "Please enter a shortcut number"
-    error_invalid_range: "Shortcut must be between 8 and 999"
+    error_empty: "Please enter a shortcut"
+    error_invalid_range: "Shortcut must be 8-999 or a digit-led code (e.g. 8a, 42f), up to 3 characters"
     error_conflict: "Shortcut {shortcut} is already used by {preset}"
     inline_label: "Keyboard shortcut"
     none_display: "none"

--- a/modules/behavior/preset_shortcuts.js
+++ b/modules/behavior/preset_shortcuts.js
@@ -2,6 +2,12 @@ import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { presetManager } from '../presets';
 import { presetShortcuts } from '../core/preset_shortcuts';
+import {
+    isPresetShortcutKey,
+    isValidPresetShortcut,
+    normalizePresetShortcut,
+    shouldCapturePresetShortcutBuffer
+} from '../core/preset_shortcut_format';
 import { modeAddPoint, modeAddLine, modeAddArea, modeBrowse } from '../modes';
 import { actionChangePreset } from '../actions';
 import { utilRebind } from '../util';
@@ -26,7 +32,7 @@ import { uiPresetIcon } from '../ui/preset_icon';
  *
  * Behavior:
  * - Numbers 1-3: Execute immediately (normal drawing modes) but can be cancelled by multi-digit shortcuts
- * - Numbers 8-999: User-defined preset shortcuts
+ * - Numbers 8-999 (or digit-led codes like `8a`): User-defined preset shortcuts
  * - Single-digit shortcuts: Execute after 150ms (can be cancelled by additional digits)
  * - Multi-digit shortcuts: Execute after 500ms, can override single-digit actions
  * - Cancellation: Multi-digit shortcuts cancel previous single-digit actions seamlessly
@@ -318,15 +324,11 @@ export function behaviorPresetShortcuts(context) {
             return true;
         }
 
-        const shortcut = _numberBuffer;
+        const shortcut = normalizePresetShortcut(_numberBuffer);
         clearNumberBuffer();
 
-        // Check if this is a preset shortcut (8-999)
-        const num = parseInt(shortcut, 10);
-        if (num >= 8 && num <= 999) {
-            if (executeShortcut(shortcut)) {
-                return true;
-            }
+        if (isValidPresetShortcut(shortcut) && executeShortcut(shortcut)) {
+            return true;
         }
 
         // If it's a single digit 1-3, handle as normal drawing mode
@@ -376,33 +378,19 @@ export function behaviorPresetShortcuts(context) {
         return false;
     }
 
-    function keydown(d3_event) {
-        // Only handle number keys
-        const key = d3_event.key;
-        if (!/^[0-9]$/.test(key)) {
-            return;
-        }
+    function handleShortcutKey(key, d3_event) {
+        const allShortcuts = presetShortcuts.getAllShortcuts();
+        const allShortcutKeys = Object.keys(allShortcuts);
 
-        // Don't interfere if user is typing in an input field
-        const target = d3_event.target || d3_event.srcElement;
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-            return;
-        }
-
-        // Don't interfere if modifier keys are pressed
-        if (d3_event.ctrlKey || d3_event.metaKey || d3_event.altKey) {
+        if (!isPresetShortcutKey(key, _numberBuffer, allShortcutKeys)) {
             return;
         }
 
         const digit = key;
-
-        // If this is not the first digit, we're building a multi-digit shortcut
         const wasEmpty = _numberBuffer === '';
 
-        // Add digit to buffer
-        _numberBuffer += digit;
+        _numberBuffer = normalizePresetShortcut(_numberBuffer + key);
 
-        // Clear any existing timeouts and reset execution flag for new sequence
         if (_numberTimeout) {
             clearTimeout(_numberTimeout);
         }
@@ -413,47 +401,30 @@ export function behaviorPresetShortcuts(context) {
             clearTimeout(_cleanupTimeout);
         }
 
-        // Always set cleanup timeout to clear buffer after 800ms (prevents infinite growth)
         _cleanupTimeout = setTimeout(() => {
             clearNumberBuffer();
         }, _cleanupDelay);
 
-        // If we're adding to an existing buffer, cancel any previous execution
         if (!wasEmpty) {
             _executed = false;
         }
 
-        const allShortcuts = presetShortcuts.getAllShortcuts();
-        const allShortcutKeys = Object.keys(allShortcuts);
-
-        // Check if there's an exact match for current buffer
         const hasExactMatch = allShortcutKeys.includes(_numberBuffer);
-
-        // Check if there are longer shortcuts starting with current buffer
         const hasLongerShortcuts = allShortcutKeys.some(shortcut =>
             shortcut.startsWith(_numberBuffer) && shortcut.length > _numberBuffer.length
         );
 
-
-
-        // For single digits 1-3, handle special logic for drawing modes
         if (_numberBuffer.length === 1 && digit >= '1' && digit <= '3') {
             if (!hasExactMatch && !hasLongerShortcuts) {
-                // No shortcuts use this digit, let normal handlers deal with it
                 clearNumberBuffer();
                 return;
             } else if (hasLongerShortcuts && !hasExactMatch) {
-                // There are longer shortcuts starting with this digit, but no exact match
-                // Wait to see if user is typing a multi-digit shortcut before executing drawing mode
-                // Don't let the normal action happen immediately - prevent it and wait
                 d3_event.preventDefault();
                 d3_event.stopImmediatePropagation();
             }
         }
 
-        // If we have an exact match, set up immediate execution
         if (hasExactMatch) {
-            // For digits 1-3 with exact matches, we need to prevent the default drawing mode
             if (_numberBuffer.length === 1 && digit >= '1' && digit <= '3') {
                 d3_event.preventDefault();
                 d3_event.stopImmediatePropagation();
@@ -469,7 +440,6 @@ export function behaviorPresetShortcuts(context) {
             }, _immediateDelay);
         }
 
-        // Always set the longer timeout for multi-digit shortcuts
         if (hasLongerShortcuts || hasExactMatch) {
             _numberTimeout = setTimeout(() => {
                 const handled = processNumberBuffer();
@@ -480,15 +450,10 @@ export function behaviorPresetShortcuts(context) {
             }, _waitDuration);
         }
 
-        // Handle multi-digit sequence detection and cancellation
         if (_numberBuffer.length > 1 && _singleDigitExecuted) {
-            // We're building a multi-digit shortcut after a single digit was executed
-
-            // Cancel the previous single-digit action by going back to browse mode
             context.enter(modeBrowse(context));
             _singleDigitExecuted = false;
 
-            // Show brief notification that we're switching
             try {
                 context.ui().flash
                     .duration(1500)
@@ -500,12 +465,28 @@ export function behaviorPresetShortcuts(context) {
             }
         }
 
-        // For potential multi-digit shortcuts (8+ or actual multi-digit sequences), prevent default
-        const bufferNum = parseInt(_numberBuffer, 10);
-        if (bufferNum >= 8 || (_numberBuffer.length > 1)) {
+        if (shouldCapturePresetShortcutBuffer(_numberBuffer)) {
             d3_event.preventDefault();
             d3_event.stopImmediatePropagation();
         }
+    }
+
+    function keydown(d3_event) {
+        const key = d3_event.key;
+        if (!/^[0-9a-z]$/i.test(key)) {
+            return;
+        }
+
+        const target = d3_event.target || d3_event.srcElement;
+        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+            return;
+        }
+
+        if (d3_event.ctrlKey || d3_event.metaKey || d3_event.altKey) {
+            return;
+        }
+
+        handleShortcutKey(key, d3_event);
     }
 
 

--- a/modules/core/preset_shortcut_format.js
+++ b/modules/core/preset_shortcut_format.js
@@ -1,0 +1,60 @@
+/** Max length for a preset shortcut (e.g. `8`, `88`, `8a`). */
+export const PRESET_SHORTCUT_MAX_LENGTH = 3;
+
+/**
+ * Normalize shortcut input for storage and lookup.
+ * @param {string} raw - user input
+ * @returns {string} trimmed lowercase shortcut
+ */
+export function normalizePresetShortcut(raw) {
+    return String(raw).trim().toLowerCase();
+}
+
+/**
+ * True when `shortcut` is a valid assigned preset shortcut:
+ *   - numeric `8`–`999`, or
+ *   - 2–3 chars starting with a digit, digits then optional letters (`8a`, `42f`).
+ * @param {string} shortcut - normalized shortcut
+ * @returns {boolean}
+ */
+export function isValidPresetShortcut(shortcut) {
+    if (!shortcut || shortcut.length > PRESET_SHORTCUT_MAX_LENGTH) return false;
+    if (!/^[0-9][0-9a-z]*$/.test(shortcut)) return false;
+    if (/^[0-9]+$/.test(shortcut)) {
+        const num = parseInt(shortcut, 10);
+        return num >= 8 && num <= 999;
+    }
+    return shortcut.length >= 2;
+}
+
+/**
+ * True when `key` may extend the in-progress shortcut buffer.
+ * Digits are always accepted; letters only when they continue an assigned shortcut.
+ * @param {string} key - single character from `event.key`
+ * @param {string} buffer - current in-progress buffer
+ * @param {string[]} assigned - shortcut keys already assigned
+ * @returns {boolean}
+ */
+export function isPresetShortcutKey(key, buffer, assigned) {
+    if (/^[0-9]$/.test(key)) return true;
+    if (!buffer || !/^[a-z]$/i.test(key)) return false;
+
+    const candidate = normalizePresetShortcut(buffer + key);
+    if (!/^[0-9][0-9a-z]{0,2}$/.test(candidate)) return false;
+
+    return assigned.some((shortcut) => shortcut === candidate || shortcut.startsWith(candidate));
+}
+
+/**
+ * True when the in-progress buffer should capture the key event (block other handlers).
+ * @param {string} buffer - current in-progress buffer
+ * @returns {boolean}
+ */
+export function shouldCapturePresetShortcutBuffer(buffer) {
+    if (!buffer) return false;
+    if (buffer.length > 1) return true;
+    if (/^[0-9]+$/.test(buffer)) {
+        return parseInt(buffer, 10) >= 8;
+    }
+    return false;
+}

--- a/modules/core/preset_shortcuts.js
+++ b/modules/core/preset_shortcuts.js
@@ -1,17 +1,20 @@
 import { prefs } from './preferences';
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { utilRebind } from '../util';
+import { isValidPresetShortcut, normalizePresetShortcut } from './preset_shortcut_format';
 
 /**
  * Core Preset Shortcuts Manager
  *
  * Manages user-defined keyboard shortcuts for presets. This module provides
  * functionality to store, retrieve, and manage preset shortcuts that allow
- * users to quickly activate presets using number keys 8-999.
+ * users to quickly activate presets using number keys 8-999, or digit-led codes
+ * such as `8a` (fork extension).
  *
  * Features:
  * - Store shortcuts in localStorage for persistence across sessions
  * - Support numeric shortcuts from 8-999 (1-7 reserved for drawing modes)
+ * - Support digit-led alphanumeric shortcuts up to 3 characters (e.g. `8a`, `42f`)
  * - Validate shortcuts to ensure they're within the allowed range
  * - Handle conflicts when multiple presets try to use the same shortcut
  * - Dispatch events when shortcuts are added, removed, or changed
@@ -78,10 +81,9 @@ export function corePresetShortcuts() {
         setShortcut: function(presetId, shortcut) {
             loadShortcuts();
 
-            // Validate shortcut format (8-999)
-            const num = parseInt(shortcut, 10);
-            if (isNaN(num) || num < 8 || num > 999) {
-                throw new Error('Shortcut must be a number between 8 and 999');
+            shortcut = normalizePresetShortcut(shortcut);
+            if (!isValidPresetShortcut(shortcut)) {
+                throw new Error('Invalid preset shortcut');
             }
 
             // Remove any existing shortcut for this preset

--- a/modules/ui/shortcut_editor.js
+++ b/modules/ui/shortcut_editor.js
@@ -1,5 +1,6 @@
 import { t } from '../core/localizer';
 import { presetShortcuts } from '../core/preset_shortcuts';
+import { isValidPresetShortcut, normalizePresetShortcut } from '../core/preset_shortcut_format';
 import { presetManager } from '../presets';
 import { svgIcon } from '../svg/icon';
 
@@ -99,7 +100,7 @@ export function uiShortcutEditor() {
 
         // Validation and save logic
         function handleSave() {
-            const value = shortcutInput.property('value').trim();
+            const value = normalizePresetShortcut(shortcutInput.property('value'));
 
             // Clear previous errors
             errorContainer.style('display', 'none');
@@ -110,9 +111,7 @@ export function uiShortcutEditor() {
                 return;
             }
 
-            // Validate range
-            const num = parseInt(value, 10);
-            if (isNaN(num) || num < 8 || num > 999) {
+            if (!isValidPresetShortcut(value)) {
                 showError(t('preset_shortcut.error_invalid_range'));
                 return;
             }

--- a/test/spec/core/preset_shortcut_format.js
+++ b/test/spec/core/preset_shortcut_format.js
@@ -1,0 +1,76 @@
+import {
+    isPresetShortcutKey,
+    isValidPresetShortcut,
+    normalizePresetShortcut,
+    shouldCapturePresetShortcutBuffer
+} from '../../../modules/core/preset_shortcut_format';
+
+describe('core/preset_shortcut_format', function() {
+
+    describe('normalizePresetShortcut', function() {
+        it('trims and lowercases', function() {
+            expect(normalizePresetShortcut(' 8A ')).to.equal('8a');
+        });
+    });
+
+    describe('isValidPresetShortcut', function() {
+        const cases = [
+            ['8', true],
+            ['999', true],
+            ['42', true],
+            ['8a', true],
+            ['42f', true],
+            ['10a', true],
+            ['8ab', true],
+            ['7', false],
+            ['1000', false],
+            ['a8', false],
+            ['', false]
+        ];
+
+        cases.forEach(function([shortcut, expected]) {
+            it(`${shortcut || '(empty)'} → ${expected}`, function() {
+                expect(isValidPresetShortcut(shortcut)).to.equal(expected);
+            });
+        });
+
+        it('accepts uppercase after normalization', function() {
+            expect(isValidPresetShortcut(normalizePresetShortcut('8A'))).to.be.true;
+        });
+    });
+
+    describe('isPresetShortcutKey', function() {
+        const assigned = ['8', '8a', '88', '42f'];
+
+        const cases = [
+            ['8', '', true],
+            ['a', '8', true],
+            ['a', '9', false],
+            ['b', '4', false],
+            ['f', '42', true],
+            ['x', '', false]
+        ];
+
+        cases.forEach(function([key, buffer, expected]) {
+            it(`key ${key} with buffer "${buffer}" → ${expected}`, function() {
+                expect(isPresetShortcutKey(key, buffer, assigned)).to.equal(expected);
+            });
+        });
+    });
+
+    describe('shouldCapturePresetShortcutBuffer', function() {
+        const cases = [
+            ['8', true],
+            ['88', true],
+            ['8a', true],
+            ['7', false],
+            ['', false]
+        ];
+
+        cases.forEach(function([buffer, expected]) {
+            it(`"${buffer}" → ${expected}`, function() {
+                expect(shouldCapturePresetShortcutBuffer(buffer)).to.equal(expected);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Allow preset shortcuts of up to 3 characters starting with a digit: numeric `8`–`999` or alphanumeric (`8a`, `42f`, `8ab`).
- New `preset_shortcut_format.js` module centralizes validation and key acceptance.
- Keyboard behavior captures letter keys only when they continue an assigned shortcut (same model as `8` + `88`).
- Updated shortcut editor UI strings in `data/core.yaml`.

Fork-only — not intended for upstream.

## Test plan
- [x] `npx vitest run test/spec/core/preset_shortcut_format.js --no-isolate`
- [ ] Assign `8a` to a preset, press `8` then `a` on the map — preset activates
- [ ] Numeric shortcuts `8`, `88`, `42` still work as before