### PR TITLE
Feat: dual carriageway map markers (gray dots both sides)

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -13,6 +13,7 @@
 .layer-osm path.sided-marker-coastline-path { fill: #77dede; }
 .layer-osm path.sided-marker-barrier-path   { fill: #ddd; }
 .layer-osm path.sided-marker-man_made-path  { fill: #fff; }
+.layer-osm circle.sided-marker-dual_carriageway-path { fill: rgb(170, 170, 170); }
 
 /* IE/Edge rule for <use> marker style */
 .layer-osm path.viewfield-marker-path {

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -74,6 +74,35 @@ export function svgDefs(context) {
                 .attr('stroke-width', options.strokeColor ? 0.1 : 0)
                 .attr('fill', options.color);
         }
+        /** Gray dots on both sides of divided-road carriageways (`dual_carriageway=yes`). */
+        function addBothSidedCircleMarker(name, options) {
+            const offset = options.offset;
+            const radius = options.radius || 0.7;
+            const marker = _defsSelection
+                .append('marker')
+                .attr('id', 'ideditor-sided-marker-' + name)
+                .attr('viewBox', `0,-${offset + radius}, 2,${2 * (offset + radius)}`)
+                .attr('refX', 1)
+                .attr('refY', 0)
+                .attr('markerWidth', 1)
+                .attr('markerHeight', 1 * (2 + offset))
+                .attr('markerUnits', 'strokeWidth')
+                .attr('orient', 'auto');
+            marker.append('circle')
+                .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
+                .attr('cx', 1)
+                .attr('cy', -offset)
+                .attr('r', radius)
+                .attr('stroke', 'none')
+                .attr('fill', options.color);
+            marker.append('circle')
+                .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
+                .attr('cx', 1)
+                .attr('cy', offset)
+                .attr('r', radius)
+                .attr('stroke', 'none')
+                .attr('fill', options.color);
+        }
         addSidedMarker('natural', { color: 'rgb(170, 170, 170)', offset: 0 });
         // for a coastline, the arrows are (somewhat unintuitively) on
         // the water side, so let's color them blue (with a gap) to
@@ -87,6 +116,7 @@ export function svgDefs(context) {
         // marker on opposite side, circles instead of triangles
         addSidedMarker('guard_rail', { color: '#ddd', offset: -1.5, style: 'circle' });
         addSidedMarker('man_made', { color: '#fff', offset: 0 });
+        addBothSidedCircleMarker('dual_carriageway', { color: 'rgb(170, 170, 170)', offset: 2, radius: 0.7 });
         function addBothSidedMarker(name, options) {
             let mirror = false;
             if (options.offset < 0) {

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -273,11 +273,18 @@ export function svgLines(projection, context) {
             );
             onewaydata[k] = utilArrayFlatten(onewayArr.map(onewaySegments));
 
-            var sidedArr = v.filter(function(d) { return d.isSided(); });
+            var sidedArr = v.filter(function(d) {
+                return d.isSided() && d.tags.dual_carriageway !== 'yes';
+            });
             var sidedSegments = svgMarkerSegments(
                 projection, graph, 30
             );
             sideddata[k] = utilArrayFlatten(sidedArr.map(sidedSegments));
+
+            // Dual carriageways: tighter dot spacing, marker on both sides of the way
+            var dualCarriagewayArr = v.filter(function(d) { return d.tags.dual_carriageway === 'yes'; });
+            var dualCarriagewaySegments = svgMarkerSegments(projection, graph, 6);
+            sideddata[k] = sideddata[k].concat(utilArrayFlatten(dualCarriagewayArr.map(dualCarriagewaySegments)));
         });
 
 

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -241,5 +241,24 @@ describe('iD.svgLines', function () {
             var selection = surface.selectAll('g.sidedgroup > path');
             expect(selection.empty()).to.be.true;
         });
+
+        it('has dual carriageway marker on both sides of the way', function() {
+            var a = new iD.osmNode({id: 'a', loc: [0, 0]});
+            var b = new iD.osmNode({id: 'b', loc: [1e-2, 0]});
+
+            var way = new iD.osmWay({
+                id: 'dual-carriageway',
+                tags: { highway: 'primary', dual_carriageway: 'yes' },
+                nodes: [a.id, b.id]
+            });
+
+            var graph = new iD.coreGraph([a, b, way]);
+
+            surface.call(iD.svgLines(projection, context), graph, [way], all);
+            var selection = surface.selectAll('g.sidedgroup > path');
+            expect(selection.size()).to.eql(1);
+            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue)
+                .to.eql('url(#ideditor-sided-marker-dual_carriageway)');
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Restore v5-style map markers for ways tagged `dual_carriageway=yes`
- Gray dots appear on **both sides** of the way (improvement over v5, which showed them on one side only)
- Tighter marker spacing (6px) matching v5 behaviour

## Test plan
- [x] `npm run test:spec -- test/spec/svg/lines.js` passes
- [x] Select a one-way highway with `dual_carriageway=yes` — gray dots visible on both sides of the line
- [x] Ways without the tag are unchanged