### PR TITLE
Fix: Québec lens access/bridge styling and lens shortcuts

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -759,9 +759,10 @@ g.midpoint.tag-highway-bridleway .fill {
  *
  * Not in upstream iD. Depends on config/tag_classes_custom.js and
  * appendCustomTagClasses() in modules/svg/tag_classes.js.
+ * Duplicated in lenses/v5-quebec.css for lens-only users.
  * ----------------------------------------------------------------------------- */
 
-/* Motor roads: colored casing; exclude footways and paths */
+/* Motor roads: colored casing (mirrored in lenses/v5-quebec.css). */
 path.line.casing.tag-access-customers:not(.tag-highway-footway):not(.tag-highway-path),
 path.line.casing.tag-motor_vehicle-customers:not(.tag-highway-footway):not(.tag-highway-path) {
     stroke: rgb(255, 136, 0) !important;
@@ -796,7 +797,7 @@ path.line.casing.tag-highway-service.tag-custom-access-emphasis {
     stroke-width: 8 !important;
 }
 
-/* Footways / paths: colored dash only; white casing and selection halo (v5) */
+/* Footways / paths: colored dash only; white casing and selection halo (mirrored in lenses/v5-quebec.css) */
 path.line.stroke.tag-highway-footway.tag-access-private,
 path.line.stroke.tag-highway-footway.tag-foot-private,
 path.line.stroke.tag-highway-path.tag-access-private,
@@ -883,7 +884,7 @@ path.line.shadow.related.tag-highway-path.tag-foot-permissive {
     stroke-opacity: 0.45 !important;
 }
 
-/* footway=link / cycleway=link — continuous lines (v5) */
+/* footway=link / cycleway=link — continuous lines (mirrored in lenses/v5-quebec.css) */
 path.line.stroke.tag-highway-footway.tag-footway-link,
 path.line.stroke.tag-highway-footway.tag-footway-link.tag-unpaved {
     stroke: rgb(255, 241, 202);
@@ -909,7 +910,7 @@ path.line.casing.tag-highway-path.tag-cycleway-link {
     opacity: 0.5 !important;
 }
 
-/* placement=transition — wider road (+4px on shadow, casing, stroke) */
+/* placement=transition — wider road (+4px on shadow, casing, stroke; mirrored in lenses/v5-quebec.css) */
 path.line.shadow.tag-highway.tag-placement-transition {
     stroke-width: 24;
 }

--- a/lenses/maxspeed-colors.css
+++ b/lenses/maxspeed-colors.css
@@ -1,0 +1,494 @@
+/* ============================================================================
+ * Lens — Maxspeed colours
+ * ----------------------------------------------------------------------------
+ * Only saved highway ways are shown. Unsaved edits keep lens styling; selection
+ * restores core shadow/casing (advisory ring hidden while selected).
+ *   - maxspeed=* on highways → centre stroke colour (km/h buckets 10–100)
+ *   - maxspeed:advisory=* on highways → outer casing colour (same buckets)
+ *   - Both tags → 50/50 width split (casing = 2× stroke), slightly wider
+ * Import in Map data → Lens.
+ *
+ * 10 mauve · 20 bleu · 30 vert · 40 turquoise · 50 jaune · 60 orange
+ * 70 orange foncé · 80 rouge foncé · 90 magenta foncé · 100 rose
+ * Advisory (casing) : mêmes paliers, multiples de 5 km/h seulement (Québec).
+ * ============================================================================ */
+
+/* --- hide saved features except highway ways --- */
+/* Unsaved: .added .retagged .geometry-edited (ways/areas), .moved (nodes) */
+
+/* Polygons (buildings, landuse, etc.). */
+.layer-osm path.area.fill:not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member),
+.layer-osm path.area.stroke:not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member),
+.layer-osm path.area.shadow:not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member) {
+    display: none !important;
+}
+
+/* Junction / vertex nodes (incl. siblings of a selected way). */
+.layer-osm g.vertex:not(.added):not(.moved):not(.retagged):not(.selected):not(.selected-member):not(.sibling) {
+    display: none !important;
+}
+
+/* Standalone points without highway tag (stops, amenities, etc.). */
+.layer-osm g.point:not([class*="tag-highway"]):not(.added):not(.moved):not(.retagged):not(.selected):not(.selected-member) {
+    display: none !important;
+}
+
+/* Ways that are not highway=* (rail, waterway, power, barrier, …). */
+.layer-osm path.line.shadow:not([class*="tag-highway"]):not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member),
+.layer-osm path.line.casing:not([class*="tag-highway"]):not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member),
+.layer-osm path.line.stroke:not([class*="tag-highway"]):not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member),
+.layer-osm path.line.over-stroke:not([class*="tag-highway"]):not(.added):not(.retagged):not(.geometry-edited):not(.selected):not(.selected-member) {
+    display: none !important;
+}
+
+/* --- highway baseline: pale white stroke; casings hidden unless advisory --- */
+
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"]) {
+    stroke: rgb(255, 255, 255) !important;
+    fill: none !important;
+    opacity: 0.3 !important;
+    stroke-dasharray: none !important;
+}
+
+.layer-osm path.line.shadow[class*="tag-highway"],
+.layer-osm path.line.over-stroke[class*="tag-highway"],
+.layer-osm path.line.casing[class*="tag-highway"]:not([class*="tag-maxspeed_advisory-"]):not(.tag-has-maxspeed-advisory):not([class*="tag-xadv-"]) {
+    stroke: none !important;
+    opacity: 0 !important;
+}
+
+/* Neutralize fork access colours on highways (core 30_highways.css uses !important). */
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-access-"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-foot-private"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-foot-customers"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-foot-permissive"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-motor_vehicle-private"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-motor_vehicle-customers"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-motor_vehicle-permissive"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-service-private"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-service-customers"],
+.layer-osm path.line.stroke[class*="tag-highway"]:not([class*="tag-maxspeed-"])[class*="tag-service-permissive"] {
+    stroke: rgb(255, 255, 255) !important;
+    opacity: 0.3 !important;
+    stroke-dasharray: none !important;
+}
+
+.layer-osm path.line.casing[class*="tag-highway"]:not([class*="tag-maxspeed_advisory-"])[class*="tag-access-"],
+.layer-osm path.line.casing[class*="tag-highway"]:not([class*="tag-maxspeed_advisory-"])[class*="tag-motor_vehicle-"],
+.layer-osm path.line.casing[class*="tag-highway"]:not([class*="tag-maxspeed_advisory-"])[class*="tag-service-"],
+.layer-osm path.line.casing[class*="tag-highway"]:not([class*="tag-maxspeed_advisory-"]).tag-custom-access-emphasis {
+    stroke: none !important;
+    opacity: 0 !important;
+}
+
+/* --- maxspeed:advisory — 50/50 casing (outer) + stroke (centre), wider than default --- */
+
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory {
+    stroke-linecap: butt !important;
+    stroke-linejoin: miter !important;
+    fill: none !important;
+}
+
+/* Default: links and minor roads (casing 20, stroke 10 → 50/50 ring). */
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"] {
+    stroke-width: 20 !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-xadv-"] {
+    stroke-width: 10 !important;
+}
+
+/* Wide motor roads (not _link). */
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-motorway,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-trunk,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-primary,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-secondary,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-tertiary,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-motorway,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-trunk,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-primary,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-secondary,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-tertiary {
+    stroke-width: 22 !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-motorway,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-trunk,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-primary,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-secondary,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed_advisory-"].tag-highway-tertiary,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-motorway,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-trunk,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-primary,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-secondary,
+.layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory.tag-highway-tertiary {
+    stroke-width: 11 !important;
+}
+
+/* maxspeed (centre stroke) */
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-10 {
+    stroke: rgb(146, 106, 255) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-20 {
+    stroke: rgb(53, 188, 251) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-30 {
+    stroke: rgb(113, 179, 0) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-40 {
+    stroke: rgb(64, 224, 208) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-50 {
+    stroke: rgb(255, 230, 0) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-60 {
+    stroke: rgb(255, 136, 0) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-70 {
+    stroke: rgb(212, 67, 0) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-80 {
+    stroke: rgb(189, 0, 0) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-90 {
+    stroke: rgb(215, 10, 105) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+.layer-osm path.line.stroke[class*="tag-highway"].tag-maxspeed-100 {
+    stroke: rgb(255, 55, 188) !important;
+    fill: none !important;
+    opacity: 1 !important;
+    stroke-dasharray: none !important;
+}
+
+/* maxspeed:advisory (outer casing) — tag-xadv-* bucket colours, fully opaque */
+
+/* Fallback orange if bucket class missing; overridden below per tag-xadv-* */
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory {
+    stroke: rgb(255, 136, 0) !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10 { stroke: rgb(146, 106, 255) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20 { stroke: rgb(53, 188, 251) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30 { stroke: rgb(113, 179, 0) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40 { stroke: rgb(64, 224, 208) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50 { stroke: rgb(255, 230, 0) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60 { stroke: rgb(255, 136, 0) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70 { stroke: rgb(212, 67, 0) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80 { stroke: rgb(189, 0, 0) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90 { stroke: rgb(215, 10, 105) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+.layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100 { stroke: rgb(255, 55, 188) !important; stroke-opacity: 1 !important; opacity: 1 !important; }
+
+/* Neutralize core motorway/trunk casing brown on advisory ways */
+.layer-osm path.line.casing.tag-highway-motorway.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-motorway_link.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-trunk.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-trunk_link.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-primary.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-primary_link.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-secondary.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-secondary_link.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-tertiary.tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.tag-highway-tertiary_link.tag-has-maxspeed-advisory {
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+
+/* Bridge / tunnel / embankment / cutting — core 50_misc.css must not override advisory.
+ * Unlayered lens wins on stroke colour, but dasharray/opacity/width can leak from @layer ideditor. */
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-bridge,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-tunnel,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-embankment,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-cutting,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-location-underground,
+.layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory.tag-location-underwater,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-tunnel,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-embankment,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-cutting,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-location-underground,
+.layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-location-underwater {
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+
+/* Tunnels must not fade the maxspeed centre stroke. */
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed-"].tag-tunnel,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed-"].tag-location-underground,
+.layer-osm path.line.stroke[class*="tag-highway"][class*="tag-maxspeed-"].tag-location-underwater {
+    opacity: 1 !important;
+    stroke-opacity: 1 !important;
+}
+
+/* --- selection: core shadow + casing; maxspeed stroke colour kept --- */
+.layer-osm path.line.shadow.selected,
+.layer-osm path.line.shadow.selected-member,
+.layer-osm path.line.casing.selected,
+.layer-osm path.line.casing.selected-member,
+.layer-osm path.line.over-stroke.selected,
+.layer-osm path.line.over-stroke.selected-member,
+.layer-osm path.area.shadow.selected,
+.layer-osm path.area.shadow.selected-member,
+.layer-osm path.area.stroke.selected,
+.layer-osm path.area.stroke.selected-member,
+.layer-osm path.area.fill.selected,
+.layer-osm path.area.fill.selected-member {
+    display: revert-layer !important;
+    opacity: revert-layer !important;
+    stroke: revert-layer !important;
+    stroke-width: revert-layer !important;
+    stroke-opacity: revert-layer !important;
+    stroke-dasharray: revert-layer !important;
+    fill: revert-layer !important;
+    color: revert-layer !important;
+}
+
+/* No core shadow halo on advisory highways (except when selected above). */
+.layer-osm path.line.shadow[class*="tag-highway"][class*="tag-maxspeed_advisory-"]:not(.selected):not(.selected-member),
+.layer-osm path.line.shadow[class*="tag-highway"].tag-has-maxspeed-advisory:not(.selected):not(.selected-member),
+.layer-osm path.line.shadow[class*="tag-highway"][class*="tag-xadv-"]:not(.selected):not(.selected-member) {
+    stroke: none !important;
+    stroke-opacity: 0 !important;
+    opacity: 0 !important;
+}
+
+/* Keep advisory colours at full opacity in insert-waypoint mode */
+.ideditor.mode-insert-waypoint .layer-osm path.line.casing[class*="tag-highway"].tag-has-maxspeed-advisory,
+.ideditor.mode-insert-waypoint .layer-osm path.line.stroke[class*="tag-highway"].tag-has-maxspeed-advisory {
+    opacity: 1 !important;
+    stroke-opacity: 1 !important;
+}
+
+.layer-osm g.vertex.selected,
+.layer-osm g.vertex.selected-member,
+.layer-osm g.point.selected,
+.layer-osm g.point.selected-member {
+    display: revert-layer !important;
+}
+
+.layer-osm g.vertex.selected circle.shadow,
+.layer-osm g.vertex.selected circle.stroke,
+.layer-osm g.vertex.selected circle.fill,
+.layer-osm g.vertex.selected-member circle.shadow,
+.layer-osm g.vertex.selected-member circle.stroke,
+.layer-osm g.vertex.selected-member circle.fill,
+.layer-osm g.point.selected path.shadow,
+.layer-osm g.point.selected path.stroke,
+.layer-osm g.point.selected-member path.shadow,
+.layer-osm g.point.selected-member path.stroke {
+    opacity: revert-layer !important;
+    stroke: revert-layer !important;
+    fill: revert-layer !important;
+}
+
+/* --- structure tags: beat .ideditor path.line.casing.tag-bridge { stroke:#000 !important }
+ * Core rules use the .ideditor prefix; generic .layer-osm xadv selectors can lose on
+ * specificity even inside an unlayered lens. These come last and match .ideditor too. */
+
+.ideditor .layer-osm path.line.shadow[class*="tag-highway"].tag-bridge,
+.ideditor .layer-osm path.line.shadow[class*="tag-highway"].tag-embankment,
+.ideditor .layer-osm path.line.shadow[class*="tag-highway"].tag-cutting {
+    stroke: none !important;
+    stroke-opacity: 0 !important;
+    opacity: 0 !important;
+}
+
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-10.tag-location-underwater {
+    stroke: rgb(146, 106, 255) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-20.tag-location-underwater {
+    stroke: rgb(53, 188, 251) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-30.tag-location-underwater {
+    stroke: rgb(113, 179, 0) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-40.tag-location-underwater {
+    stroke: rgb(64, 224, 208) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-50.tag-location-underwater {
+    stroke: rgb(255, 230, 0) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-60.tag-location-underwater {
+    stroke: rgb(255, 136, 0) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-70.tag-location-underwater {
+    stroke: rgb(212, 67, 0) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-80.tag-location-underwater {
+    stroke: rgb(189, 0, 0) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-90.tag-location-underwater {
+    stroke: rgb(215, 10, 105) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-bridge,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-embankment,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-cutting,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-tunnel,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-location-underground,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"].tag-xadv-100.tag-location-underwater {
+    stroke: rgb(255, 55, 188) !important;
+    stroke-width: 20 !important;
+    stroke-dasharray: none !important;
+    stroke-linecap: butt !important;
+    stroke-opacity: 1 !important;
+    opacity: 1 !important;
+}
+
+/* Wide motor roads (not _link) with structure tags */
+.ideditor .layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge.tag-highway-motorway,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge.tag-highway-trunk,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge.tag-highway-primary,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge.tag-highway-secondary,
+.ideditor .layer-osm path.line.casing[class*="tag-highway"][class*="tag-xadv-"].tag-bridge.tag-highway-tertiary {
+    stroke-width: 22 !important;
+}
+
+/* Selected: hide advisory casing ring; core selection shadow/casing take over */
+.ideditor .layer-osm path.line.casing.selected[class*="tag-highway"].tag-has-maxspeed-advisory,
+.ideditor .layer-osm path.line.casing.selected[class*="tag-highway"][class*="tag-xadv-"],
+.ideditor .layer-osm path.line.casing.selected[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.ideditor .layer-osm path.line.casing.selected-member[class*="tag-highway"].tag-has-maxspeed-advisory,
+.ideditor .layer-osm path.line.casing.selected-member[class*="tag-highway"][class*="tag-xadv-"],
+.ideditor .layer-osm path.line.casing.selected-member[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.casing.selected[class*="tag-highway"].tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.selected[class*="tag-highway"][class*="tag-xadv-"],
+.layer-osm path.line.casing.selected[class*="tag-highway"][class*="tag-maxspeed_advisory-"],
+.layer-osm path.line.casing.selected-member[class*="tag-highway"].tag-has-maxspeed-advisory,
+.layer-osm path.line.casing.selected-member[class*="tag-highway"][class*="tag-xadv-"],
+.layer-osm path.line.casing.selected-member[class*="tag-highway"][class*="tag-maxspeed_advisory-"] {
+    display: revert-layer !important;
+    opacity: revert-layer !important;
+    stroke: revert-layer !important;
+    stroke-width: revert-layer !important;
+    stroke-opacity: revert-layer !important;
+    stroke-dasharray: revert-layer !important;
+    stroke-linecap: revert-layer !important;
+    stroke-linejoin: revert-layer !important;
+}

--- a/lenses/v5-quebec-surfaces.css
+++ b/lenses/v5-quebec-surfaces.css
@@ -6,6 +6,9 @@
  * missing/generic surface highlighted in blue. Over-stroke overlays for
  * cycleway lanes, bus lanes, etc. are omitted (as in v5 surface mode).
  *
+ * Fork rules from css/30_highways.css (access emphasis) and css/50_misc.css
+ * (bridges) are duplicated here so they are not overridden by this lens.
+ *
  * Import in Map data → Lens. Selectors use v6 paths
  * (`path.line.stroke`, `path.line.casing`, `path.line.over-stroke`).
  *
@@ -15,6 +18,7 @@
  *   sand #fff067, wood #a75e00, undefined #0080ff dashed stroke.
  *
  * Partial parity notes:
+ *   - Maxspeed colours: import lenses/maxspeed-colors.css (separate lens).
  *   - tag-surface-undefined is emitted by tag_classes_custom.js (v5 parity).
  *   - Building flat-count outlines (`tag-has-flats`, `tag-flats-N`) need
  *     `appendBuildingFlatsTagClasses` in config/tag_classes_custom.js.
@@ -31,85 +35,6 @@ g.vertex.tag-highway-stop.tag-stop-minor .icon {
     color: #FFC9C9;
 }
 
-
-/* ============================================================================
- * Lens — Maxspeed (dash length encodes the speed limit)
- * ----------------------------------------------------------------------------
- * Port of the v5 fork style: the faster the road, the longer the dash. Adapted
- * to v6 lenses — selectors use `path.line.stroke` (v5 used `path.stroke`) and no
- * `!important` is needed because lens CSS overrides core via the cascade layer.
- *
- * A way with `maxspeed=30` gets the class `tag-maxspeed-30` (lenses emit a class
- * per real tag value), so values must match exactly. Quebec uses round km/h
- * values, which line up with the buckets below.
- *
- * Not portable from v5: "missing maxspeed → red" and `tag-maxspeed-undefined`.
- * Lenses only emit classes for tags that EXIST, so the absence of a tag cannot
- * be styled (an open goal of openstreetmap/iD#11189).
- * ============================================================================ */
-
-path.line.stroke.tag-highway.tag-maxspeed-10 {
-    stroke-linecap: butt;
-    stroke-dasharray: 3, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-20 {
-    stroke-linecap: butt;
-    stroke-dasharray: 4, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-30 {
-    stroke-linecap: butt;
-    stroke-dasharray: 8, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-40 {
-    stroke-linecap: butt;
-    stroke-dasharray: 12, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-50 {
-    stroke-linecap: butt;
-    stroke-dasharray: 20, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-60 {
-    stroke-linecap: butt;
-    stroke-dasharray: 35, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-70 {
-    stroke-linecap: butt;
-    stroke-dasharray: 60, 0.5;
-}
-
-/* Extrapolated beyond v5's 70 cap, for Quebec highways at 80–100 km/h. */
-path.line.stroke.tag-highway.tag-maxspeed-80 {
-    stroke-linecap: butt;
-    stroke-dasharray: 80, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-90 {
-    stroke-linecap: butt;
-    stroke-dasharray: 105, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-100 {
-    stroke-linecap: butt;
-    stroke-dasharray: 130, 0.5;
-}
-
-/* Tertiary roads: slightly larger gap so the dashes stay legible (v5 parity). */
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-10,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-10 { stroke-dasharray: 3, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-20,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-20 { stroke-dasharray: 5, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-30,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-30 { stroke-dasharray: 10, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-40,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-40 { stroke-dasharray: 20, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-50,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-50 { stroke-dasharray: 30, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-60,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-60 { stroke-dasharray: 40, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-70,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-70 { stroke-dasharray: 60, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-80,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-80 { stroke-dasharray: 80, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-90,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-90 { stroke-dasharray: 100, 1; }
 
 /* --- v5 highway/crossing/sidewalk/cycleway/access rules --- */
 
@@ -394,20 +319,171 @@ path.line.stroke.tag-highway-steps {
   stroke-dasharray: 3, 3;
 }
 
-/* access: private, customers, delivery... */
-path.line.casing.tag-access-customers, path.line.casing.tag-motor_vehicle-customers {
-  stroke: rgb(255, 136, 0);
+/* access: motor roads (mirrors css/30_highways.css) */
+path.line.casing.tag-access-customers:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-customers:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(255, 136, 0) !important;
 }
-path.line.casing.tag-access-private, path.line.casing.tag-motor_vehicle-private {
-  stroke: rgb(189, 0, 0);
+path.line.casing.tag-access-private:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-private:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(205, 20, 20) !important;
 }
-path.line.casing.tag-access-delivery, path.line.casing.tag-motor_vehicle-delivery {
+path.line.casing.tag-access-permissive:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-permissive:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-service.tag-service-private,
+path.line.casing.tag-service-private {
+  stroke: rgb(205, 20, 20) !important;
+}
+path.line.casing.tag-highway-service.tag-service-customers,
+path.line.casing.tag-service-customers {
+  stroke: rgb(255, 136, 0) !important;
+}
+path.line.casing.tag-highway-service.tag-service-permissive,
+path.line.casing.tag-service-permissive {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-custom-access-emphasis {
+  stroke-width: 11 !important;
+}
+path.line.casing.tag-highway-service.tag-custom-access-emphasis {
+  stroke-width: 8 !important;
+}
+.low-zoom path.line.casing.tag-custom-access-emphasis {
+  stroke-width: 8 !important;
+}
+
+/* Footways / paths: colored dash only; white casing and selection halo (mirrors core) */
+path.line.stroke.tag-highway-footway.tag-access-private,
+path.line.stroke.tag-highway-footway.tag-foot-private,
+path.line.stroke.tag-highway-path.tag-access-private,
+path.line.stroke.tag-highway-path.tag-foot-private {
+  stroke: rgb(205, 20, 20) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-customers,
+path.line.stroke.tag-highway-footway.tag-foot-customers,
+path.line.stroke.tag-highway-path.tag-access-customers,
+path.line.stroke.tag-highway-path.tag-foot-customers {
+  stroke: rgb(255, 136, 0) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-permissive,
+path.line.stroke.tag-highway-footway.tag-foot-permissive,
+path.line.stroke.tag-highway-path.tag-access-permissive,
+path.line.stroke.tag-highway-path.tag-foot-permissive {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-footway.tag-access-private,
+path.line.casing.tag-highway-footway.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-foot-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-permissive,
+path.line.casing.tag-highway-path.tag-access-private,
+path.line.casing.tag-highway-path.tag-foot-private,
+path.line.casing.tag-highway-path.tag-access-customers,
+path.line.casing.tag-highway-path.tag-foot-customers,
+path.line.casing.tag-highway-path.tag-access-permissive,
+path.line.casing.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+}
+path.line.shadow.tag-highway-footway.tag-access-private,
+path.line.shadow.tag-highway-footway.tag-foot-private,
+path.line.shadow.tag-highway-footway.tag-access-customers,
+path.line.shadow.tag-highway-footway.tag-foot-customers,
+path.line.shadow.tag-highway-footway.tag-access-permissive,
+path.line.shadow.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.tag-highway-path.tag-access-private,
+path.line.shadow.tag-highway-path.tag-foot-private,
+path.line.shadow.tag-highway-path.tag-access-customers,
+path.line.shadow.tag-highway-path.tag-foot-customers,
+path.line.shadow.tag-highway-path.tag-access-permissive,
+path.line.shadow.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+}
+path.line.shadow.selected.tag-highway-footway.tag-access-private,
+path.line.shadow.selected.tag-highway-footway.tag-foot-private,
+path.line.shadow.selected.tag-highway-footway.tag-access-customers,
+path.line.shadow.selected.tag-highway-footway.tag-foot-customers,
+path.line.shadow.selected.tag-highway-footway.tag-access-permissive,
+path.line.shadow.selected.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.hover.tag-highway-footway.tag-access-private,
+path.line.shadow.hover.tag-highway-footway.tag-foot-private,
+path.line.shadow.hover.tag-highway-footway.tag-access-customers,
+path.line.shadow.hover.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-private,
+path.line.shadow.related.tag-highway-footway.tag-foot-private,
+path.line.shadow.related.tag-highway-footway.tag-access-customers,
+path.line.shadow.related.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-permissive,
+path.line.shadow.related.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.selected.tag-highway-path.tag-access-private,
+path.line.shadow.selected.tag-highway-path.tag-foot-private,
+path.line.shadow.selected.tag-highway-path.tag-access-customers,
+path.line.shadow.selected.tag-highway-path.tag-foot-customers,
+path.line.shadow.hover.tag-highway-path.tag-access-private,
+path.line.shadow.hover.tag-highway-path.tag-foot-private,
+path.line.shadow.hover.tag-highway-path.tag-access-customers,
+path.line.shadow.hover.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-private,
+path.line.shadow.related.tag-highway-path.tag-foot-private,
+path.line.shadow.related.tag-highway-path.tag-access-customers,
+path.line.shadow.related.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-permissive,
+path.line.shadow.related.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+  stroke-opacity: 0.45 !important;
+}
+
+/* footway=link / cycleway=link — continuous lines (mirrors core) */
+path.line.stroke.tag-highway-footway.tag-footway-link,
+path.line.stroke.tag-highway-footway.tag-footway-link.tag-unpaved {
+  stroke: rgb(255, 241, 202);
+  opacity: 0.5 !important;
+  stroke-linecap: butt;
+  stroke-dasharray: none !important;
+}
+path.line.casing.tag-highway-footway.tag-footway-link,
+path.line.casing.tag-highway-footway.tag-footway-link.tag-unpaved {
+  opacity: 0.5 !important;
+}
+path.line.stroke.tag-cycleway-link,
+path.line.stroke.tag-highway-cycleway.tag-cycleway-link,
+path.line.stroke.tag-highway-path.tag-cycleway-link {
+  opacity: 0.5 !important;
+  stroke: rgb(4, 0, 255) !important;
+  stroke-linecap: butt;
+  stroke-dasharray: none !important;
+}
+path.line.casing.tag-cycleway-link,
+path.line.casing.tag-highway-cycleway.tag-cycleway-link,
+path.line.casing.tag-highway-path.tag-cycleway-link {
+  opacity: 0.5 !important;
+}
+
+/* placement=transition — wider road (+4px on shadow, casing, stroke; mirrors core) */
+path.line.shadow.tag-highway.tag-placement-transition {
+  stroke-width: 24;
+}
+path.line.casing.tag-highway.tag-placement-transition {
+  stroke-width: 14 !important;
+}
+path.line.stroke.tag-highway.tag-placement-transition {
+  stroke-width: 12;
+}
+
+path.line.casing.tag-access-delivery:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-delivery:not(.tag-highway-footway):not(.tag-highway-path) {
   stroke: rgb(63, 214, 156);
 }
-path.line.casing.tag-access-permissive, path.line.casing.tag-motor_vehicle-permissive {
-  stroke: rgb(212, 67, 0);
-}
-path.line.casing.tag-access-destination, path.line.casing.tag-motor_vehicle-destination {
+path.line.casing.tag-access-destination:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-destination:not(.tag-highway-footway):not(.tag-highway-path) {
   stroke: rgb(255, 55, 188);
 }
 
@@ -443,7 +519,7 @@ path.line.casing.tag-highway-cycleway.tag-segregated-undefined.tag-foot-yes,
 path.line.casing.tag-highway.tag-sidewalk-undefined,
 path.line.casing.tag-highway.tag-sidewalk-invalid,
 path.line.casing.tag-highway.tag-maxspeed-undefined,
-path.line.casing.tag-highway.tag-surface-undefined,
+path.line.casing.tag-highway.tag-surface-undefined:not(.tag-bridge),
 path.line.casing.tag-highway.tag-lanes-undefined,
 path.line.casing.tag-highway.tag-lanes-error-count-lanes,
 path.line.casing.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
@@ -458,7 +534,7 @@ path.line.casing.tag-highway.tag-fixme {
 .high-zoom path.line.casing.tag-highway.tag-sidewalk-undefined,
 .high-zoom path.line.casing.tag-highway.tag-sidewalk-invalid,
 .high-zoom path.line.casing.tag-highway.tag-maxspeed-undefined,
-.high-zoom path.line.casing.tag-highway.tag-surface-undefined,
+.high-zoom path.line.casing.tag-highway.tag-surface-undefined:not(.tag-bridge),
 .high-zoom path.line.casing.tag-highway.tag-lanes-undefined,
 .high-zoom path.line.casing.tag-highway.tag-lanes-error-count-lanes,
 .high-zoom path.line.casing.tag-highway.tag-lanes-error-count-lanes-total-mismatch,
@@ -474,7 +550,7 @@ path.line.casing.tag-highway.tag-fixme {
 .high-zoom path.line.stroke.tag-highway.tag-sidewalk-invalid,
 .high-zoom path.line.stroke.tag-highway.tag-sidewalk-separate.tag-foot-not-use_sidepath:not(.tag-sidewalk-shared):not(.tag-sidewalk_left-shared):not(.tag-sidewalk_right-shared):not(.tag-sidewalk_both-shared),
 .high-zoom path.line.stroke.tag-highway.tag-maxspeed-undefined,
-.high-zoom path.line.stroke.tag-highway.tag-surface-undefined,
+.high-zoom path.line.stroke.tag-highway.tag-surface-undefined:not(.tag-bridge),
 .high-zoom path.line.stroke.tag-highway.tag-maxspeed-more_than_70.tag-highway-residential,
 .high-zoom path.line.stroke.tag-highway.tag-lanes-undefined,
 .high-zoom path.line.stroke.tag-highway.tag-lanes-error-count-lanes,
@@ -540,7 +616,7 @@ path.line.over-stroke.tag-cycleway_both-track {
   stroke-width: 1;
   stroke:  rgb(255, 0, 0);
 }*/
-path.line.stroke.tag-highway.tag-surface-undefined {
+path.line.stroke.tag-highway.tag-surface-undefined:not(.tag-bridge) {
   stroke: rgb(0, 128, 255);
   stroke-dasharray: 2, 2;
   stroke-linecap: butt;
@@ -576,6 +652,81 @@ path.line.over-stroke.tag-highway.tag-surface-sand {
 }
 path.line.over-stroke.tag-highway.tag-surface-wood {
   stroke: rgb(167, 94, 0);
+}
+
+
+/* bridges — duplicated from css/50_misc.css (lens overrides core @layer) */
+path.line.casing.tag-bridge {
+  stroke-opacity: 0.6;
+  stroke: #000 !important;
+  stroke-width: 16 !important;
+  stroke-linecap: butt;
+  stroke-dasharray: none;
+}
+path.line.shadow.tag-bridge {
+  stroke-width: 24 !important;
+}
+.low-zoom path.line.shadow.tag-bridge {
+  stroke-width: 16 !important;
+}
+.low-zoom path.line.casing.tag-bridge {
+  stroke-width: 10 !important;
+}
+path.line.shadow.tag-railway.tag-bridge,
+path.line.shadow.tag-highway-living_street.tag-bridge,
+path.line.shadow.tag-highway-path.tag-bridge,
+path.line.shadow.tag-highway-corridor.tag-bridge,
+path.line.shadow.tag-highway-pedestrian.tag-bridge,
+path.line.shadow.tag-highway-service.tag-bridge,
+path.line.shadow.tag-highway-track.tag-bridge,
+path.line.shadow.tag-highway-steps.tag-bridge,
+path.line.shadow.tag-highway-ladder.tag-bridge,
+path.line.shadow.tag-highway-footway.tag-bridge,
+path.line.shadow.tag-highway-cycleway.tag-bridge,
+path.line.shadow.tag-highway-bridleway.tag-bridge {
+  stroke-width: 18 !important;
+}
+path.line.casing.tag-railway.tag-bridge,
+path.line.casing.tag-highway-living_street.tag-bridge,
+path.line.casing.tag-highway-path.tag-bridge,
+path.line.casing.tag-highway-corridor.tag-bridge,
+path.line.casing.tag-highway-pedestrian.tag-bridge,
+path.line.casing.tag-highway-service.tag-bridge,
+path.line.casing.tag-highway-track.tag-bridge,
+path.line.casing.tag-highway-steps.tag-bridge,
+path.line.casing.tag-highway-ladder.tag-bridge,
+path.line.casing.tag-highway-footway.tag-bridge,
+path.line.casing.tag-highway-cycleway.tag-bridge,
+path.line.casing.tag-highway-bridleway.tag-bridge {
+  stroke-width: 10 !important;
+}
+.low-zoom path.line.shadow.tag-railway.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-living_street.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-path.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-corridor.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-pedestrian.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-service.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-track.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-steps.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-ladder.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-footway.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-cycleway.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-bridleway.tag-bridge {
+  stroke-width: 14 !important;
+}
+.low-zoom path.line.casing.tag-railway.tag-bridge,
+.low-zoom path.line.casing.tag-highway-living_street.tag-bridge,
+.low-zoom path.line.casing.tag-highway-path.tag-bridge,
+.low-zoom path.line.casing.tag-highway-corridor.tag-bridge,
+.low-zoom path.line.casing.tag-highway-pedestrian.tag-bridge,
+.low-zoom path.line.casing.tag-highway-service.tag-bridge,
+.low-zoom path.line.casing.tag-highway-track.tag-bridge,
+.low-zoom path.line.casing.tag-highway-steps.tag-bridge,
+.low-zoom path.line.casing.tag-highway-ladder.tag-bridge,
+.low-zoom path.line.casing.tag-highway-footway.tag-bridge,
+.low-zoom path.line.casing.tag-highway-cycleway.tag-bridge,
+.low-zoom path.line.casing.tag-highway-bridleway.tag-bridge {
+  stroke-width: 6 !important;
 }
 
 

--- a/lenses/v5-quebec.css
+++ b/lenses/v5-quebec.css
@@ -4,15 +4,11 @@
  * Import this file in Map data → Lens. Selectors use v6 map paths
  * (`path.line.stroke`, `path.line.casing`, `path.line.over-stroke`).
  *
- * Already in v6 core (no need to duplicate here):
- *   - access/private/customers/permissive motor-road casing emphasis
- *   - footway/path access dash colours + white casing/shadow
- *   - footway=link / cycleway=link continuous lines
- *   - placement=transition wider roads
- *   - stop=all (#AB0000) / stop=minor (#FFC9C9) vertex icon colours (20_map.css)
+ * Fork rules from css/30_highways.css (lines 757–921) are duplicated here so they work
+ * with the default lens and with this lens active. Stop signs are also in 20_map.css.
  *
  * Partial parity notes:
- *   - Maxspeed dash rules: see maxspeed section below (needs maxspeed=* tag).
+ *   - Maxspeed colours: import lenses/maxspeed-colors.css (separate lens).
  *   - Validation/error highlights (tag-maxspeed-undefined, tag-sidewalk-invalid,
  *     tag-lanes-error-*, tag-segregated-undefined, tag-surface-undefined, etc.)
  *     require v5 computed tag classes — rules are included but classes are NOT
@@ -32,85 +28,6 @@ g.vertex.tag-highway-stop.tag-stop-minor .icon {
     color: #FFC9C9;
 }
 
-
-/* ============================================================================
- * Lens — Maxspeed (dash length encodes the speed limit)
- * ----------------------------------------------------------------------------
- * Port of the v5 fork style: the faster the road, the longer the dash. Adapted
- * to v6 lenses — selectors use `path.line.stroke` (v5 used `path.stroke`) and no
- * `!important` is needed because lens CSS overrides core via the cascade layer.
- *
- * A way with `maxspeed=30` gets the class `tag-maxspeed-30` (lenses emit a class
- * per real tag value), so values must match exactly. Quebec uses round km/h
- * values, which line up with the buckets below.
- *
- * Not portable from v5: "missing maxspeed → red" and `tag-maxspeed-undefined`.
- * Lenses only emit classes for tags that EXIST, so the absence of a tag cannot
- * be styled (an open goal of openstreetmap/iD#11189).
- * ============================================================================ */
-
-path.line.stroke.tag-highway.tag-maxspeed-10 {
-    stroke-linecap: butt;
-    stroke-dasharray: 3, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-20 {
-    stroke-linecap: butt;
-    stroke-dasharray: 4, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-30 {
-    stroke-linecap: butt;
-    stroke-dasharray: 8, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-40 {
-    stroke-linecap: butt;
-    stroke-dasharray: 12, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-50 {
-    stroke-linecap: butt;
-    stroke-dasharray: 20, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-60 {
-    stroke-linecap: butt;
-    stroke-dasharray: 35, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-70 {
-    stroke-linecap: butt;
-    stroke-dasharray: 60, 0.5;
-}
-
-/* Extrapolated beyond v5's 70 cap, for Quebec highways at 80–100 km/h. */
-path.line.stroke.tag-highway.tag-maxspeed-80 {
-    stroke-linecap: butt;
-    stroke-dasharray: 80, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-90 {
-    stroke-linecap: butt;
-    stroke-dasharray: 105, 0.5;
-}
-path.line.stroke.tag-highway.tag-maxspeed-100 {
-    stroke-linecap: butt;
-    stroke-dasharray: 130, 0.5;
-}
-
-/* Tertiary roads: slightly larger gap so the dashes stay legible (v5 parity). */
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-10,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-10 { stroke-dasharray: 3, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-20,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-20 { stroke-dasharray: 5, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-30,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-30 { stroke-dasharray: 10, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-40,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-40 { stroke-dasharray: 20, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-50,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-50 { stroke-dasharray: 30, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-60,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-60 { stroke-dasharray: 40, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-70,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-70 { stroke-dasharray: 60, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-80,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-80 { stroke-dasharray: 80, 1; }
-path.line.stroke.tag-highway-tertiary.tag-maxspeed-90,
-path.line.stroke.tag-highway-tertiary_link.tag-maxspeed-90 { stroke-dasharray: 100, 1; }
 
 /* --- v5 highway/crossing/sidewalk/cycleway/access rules --- */
 
@@ -407,13 +324,165 @@ path.line.stroke.tag-highway-steps {
   stroke-dasharray: 3, 3;
 }
 
-/* access: private, customers, delivery... */
-path.line.casing.tag-access-customers, path.line.casing.tag-motor_vehicle-customers {
-  stroke: rgb(255, 136, 0);
+/* access: private, customers, delivery... (motor roads — mirrors css/30_highways.css) */
+path.line.casing.tag-access-customers:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-customers:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(255, 136, 0) !important;
 }
-path.line.casing.tag-access-private, path.line.casing.tag-motor_vehicle-private {
-  stroke: rgb(189, 0, 0);
+path.line.casing.tag-access-private:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-private:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(205, 20, 20) !important;
 }
+path.line.casing.tag-access-permissive:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-permissive:not(.tag-highway-footway):not(.tag-highway-path) {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-service.tag-service-private,
+path.line.casing.tag-service-private {
+  stroke: rgb(205, 20, 20) !important;
+}
+path.line.casing.tag-highway-service.tag-service-customers,
+path.line.casing.tag-service-customers {
+  stroke: rgb(255, 136, 0) !important;
+}
+path.line.casing.tag-highway-service.tag-service-permissive,
+path.line.casing.tag-service-permissive {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-custom-access-emphasis {
+  stroke-width: 11 !important;
+}
+path.line.casing.tag-highway-service.tag-custom-access-emphasis {
+  stroke-width: 8 !important;
+}
+.low-zoom path.line.casing.tag-custom-access-emphasis {
+  stroke-width: 8 !important;
+}
+
+/* Footways / paths: colored dash only; white casing and selection halo (mirrors core) */
+path.line.stroke.tag-highway-footway.tag-access-private,
+path.line.stroke.tag-highway-footway.tag-foot-private,
+path.line.stroke.tag-highway-path.tag-access-private,
+path.line.stroke.tag-highway-path.tag-foot-private {
+  stroke: rgb(205, 20, 20) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-customers,
+path.line.stroke.tag-highway-footway.tag-foot-customers,
+path.line.stroke.tag-highway-path.tag-access-customers,
+path.line.stroke.tag-highway-path.tag-foot-customers {
+  stroke: rgb(255, 136, 0) !important;
+}
+path.line.stroke.tag-highway-footway.tag-access-permissive,
+path.line.stroke.tag-highway-footway.tag-foot-permissive,
+path.line.stroke.tag-highway-path.tag-access-permissive,
+path.line.stroke.tag-highway-path.tag-foot-permissive {
+  stroke: rgb(255, 55, 0) !important;
+}
+path.line.casing.tag-highway-footway.tag-access-private,
+path.line.casing.tag-highway-footway.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-foot-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-private,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-customers,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-access-permissive,
+path.line.casing.tag-highway-footway.tag-footway-sidewalk.tag-foot-permissive,
+path.line.casing.tag-highway-path.tag-access-private,
+path.line.casing.tag-highway-path.tag-foot-private,
+path.line.casing.tag-highway-path.tag-access-customers,
+path.line.casing.tag-highway-path.tag-foot-customers,
+path.line.casing.tag-highway-path.tag-access-permissive,
+path.line.casing.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+}
+path.line.shadow.tag-highway-footway.tag-access-private,
+path.line.shadow.tag-highway-footway.tag-foot-private,
+path.line.shadow.tag-highway-footway.tag-access-customers,
+path.line.shadow.tag-highway-footway.tag-foot-customers,
+path.line.shadow.tag-highway-footway.tag-access-permissive,
+path.line.shadow.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.tag-highway-path.tag-access-private,
+path.line.shadow.tag-highway-path.tag-foot-private,
+path.line.shadow.tag-highway-path.tag-access-customers,
+path.line.shadow.tag-highway-path.tag-foot-customers,
+path.line.shadow.tag-highway-path.tag-access-permissive,
+path.line.shadow.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+}
+path.line.shadow.selected.tag-highway-footway.tag-access-private,
+path.line.shadow.selected.tag-highway-footway.tag-foot-private,
+path.line.shadow.selected.tag-highway-footway.tag-access-customers,
+path.line.shadow.selected.tag-highway-footway.tag-foot-customers,
+path.line.shadow.selected.tag-highway-footway.tag-access-permissive,
+path.line.shadow.selected.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.hover.tag-highway-footway.tag-access-private,
+path.line.shadow.hover.tag-highway-footway.tag-foot-private,
+path.line.shadow.hover.tag-highway-footway.tag-access-customers,
+path.line.shadow.hover.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-private,
+path.line.shadow.related.tag-highway-footway.tag-foot-private,
+path.line.shadow.related.tag-highway-footway.tag-access-customers,
+path.line.shadow.related.tag-highway-footway.tag-foot-customers,
+path.line.shadow.related.tag-highway-footway.tag-access-permissive,
+path.line.shadow.related.tag-highway-footway.tag-foot-permissive,
+path.line.shadow.selected.tag-highway-path.tag-access-private,
+path.line.shadow.selected.tag-highway-path.tag-foot-private,
+path.line.shadow.selected.tag-highway-path.tag-access-customers,
+path.line.shadow.selected.tag-highway-path.tag-foot-customers,
+path.line.shadow.hover.tag-highway-path.tag-access-private,
+path.line.shadow.hover.tag-highway-path.tag-foot-private,
+path.line.shadow.hover.tag-highway-path.tag-access-customers,
+path.line.shadow.hover.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-private,
+path.line.shadow.related.tag-highway-path.tag-foot-private,
+path.line.shadow.related.tag-highway-path.tag-access-customers,
+path.line.shadow.related.tag-highway-path.tag-foot-customers,
+path.line.shadow.related.tag-highway-path.tag-access-permissive,
+path.line.shadow.related.tag-highway-path.tag-foot-permissive {
+  stroke: #fff !important;
+  stroke-opacity: 0.45 !important;
+}
+
+/* footway=link / cycleway=link — continuous lines (mirrors core) */
+path.line.stroke.tag-highway-footway.tag-footway-link,
+path.line.stroke.tag-highway-footway.tag-footway-link.tag-unpaved {
+  stroke: rgb(255, 241, 202);
+  opacity: 0.5 !important;
+  stroke-linecap: butt;
+  stroke-dasharray: none !important;
+}
+path.line.casing.tag-highway-footway.tag-footway-link,
+path.line.casing.tag-highway-footway.tag-footway-link.tag-unpaved {
+  opacity: 0.5 !important;
+}
+path.line.stroke.tag-cycleway-link,
+path.line.stroke.tag-highway-cycleway.tag-cycleway-link,
+path.line.stroke.tag-highway-path.tag-cycleway-link {
+  opacity: 0.5 !important;
+  stroke: rgb(4, 0, 255) !important;
+  stroke-linecap: butt;
+  stroke-dasharray: none !important;
+}
+path.line.casing.tag-cycleway-link,
+path.line.casing.tag-highway-cycleway.tag-cycleway-link,
+path.line.casing.tag-highway-path.tag-cycleway-link {
+  opacity: 0.5 !important;
+}
+
+/* placement=transition — wider road (+4px on shadow, casing, stroke; mirrors core) */
+path.line.shadow.tag-highway.tag-placement-transition {
+  stroke-width: 24;
+}
+path.line.casing.tag-highway.tag-placement-transition {
+  stroke-width: 14 !important;
+}
+path.line.stroke.tag-highway.tag-placement-transition {
+  stroke-width: 12;
+}
+
 svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-access-private.tag-foot-yes, 
 svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-motor_vehicle-private.tag-foot-yes, 
 svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-access-customers.tag-foot-yes, 
@@ -425,13 +494,12 @@ svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-motor_vehicle-custome
   stroke: #aedf8e;
   stroke-width: 2;
 }
-path.line.casing.tag-access-delivery, path.line.casing.tag-motor_vehicle-delivery {
+path.line.casing.tag-access-delivery:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-delivery:not(.tag-highway-footway):not(.tag-highway-path) {
   stroke: rgb(63, 214, 156);
 }
-path.line.casing.tag-access-permissive, path.line.casing.tag-motor_vehicle-permissive {
-  stroke: rgb(212, 67, 0);
-}
-path.line.casing.tag-access-destination, path.line.casing.tag-motor_vehicle-destination {
+path.line.casing.tag-access-destination:not(.tag-highway-footway):not(.tag-highway-path),
+path.line.casing.tag-motor_vehicle-destination:not(.tag-highway-footway):not(.tag-highway-path) {
   stroke: rgb(255, 55, 188);
 }
 

--- a/modules/behavior/lens_shortcuts.js
+++ b/modules/behavior/lens_shortcuts.js
@@ -12,8 +12,8 @@ import {
  * Lens Shortcuts Behavior
  *
  * Activates an imported lens with `⌥`+letter. Letters are bound to lenses in the
- * Map data ▸ Lens section. Pressing the active lens's letter again toggles back
- * to the default lens. The letter is read from `event.code` (e.g. `KeyJ` → `j`)
+ * Map data ▸ Lens section. Pressing the same letter again keeps that lens active
+ * (no toggle off). Use `⌥D` to return to the default lens. The letter is read from `event.code` (e.g. `KeyJ` → `j`)
  * so it works regardless of the character `⌥`+letter produces (e.g. on macOS).
  *
  * @param {object} context - the iD application context
@@ -54,8 +54,12 @@ export function behaviorLensShortcuts(context) {
         } else {
             const lensId = getLensIdByShortcut(letter);
             if (!lensId) return;
-            // Toggle: pressing the active lens's letter returns to the default lens.
-            nextId = getSelectedLensId() === lensId ? DEFAULT_LENS_ID : lensId;
+            if (getSelectedLensId() === lensId) {
+                d3_event.preventDefault();
+                d3_event.stopPropagation();
+                return;
+            }
+            nextId = lensId;
         }
 
         d3_event.preventDefault();

--- a/modules/core/lenses.ts
+++ b/modules/core/lenses.ts
@@ -259,9 +259,42 @@ const SYNTHETIC_TAG_TOKENS = new Set([
 /** Lens-required secondary keys, in their CSS-class form (`:` written as `_`). */
 let lensSecondaryTagKeys = new Set<string>();
 
+/** When true, core highway emphasis classes are kept even if the lens styles maxspeed. */
+let lensPreservesCoreHighwayClasses = false;
+
 /** @param keys - secondary keys required by the active lens's CSS */
 export function setLensSecondaryTagKeys(keys: string[]): void {
     lensSecondaryTagKeys = new Set(Array.isArray(keys) ? keys : []);
+}
+
+/**
+ * Test hook: whether the active lens is a full highway-style lens (Quebec).
+ * @param preserve - keep structure/access emphasis classes when stripping
+ */
+export function setLensPreservesCoreHighwayClasses(preserve: boolean): void {
+    lensPreservesCoreHighwayClasses = preserve;
+}
+
+/** @deprecated use setLensPreservesCoreHighwayClasses */
+export function setLensPreservesMotorAccessClasses(preserve: boolean): void {
+    setLensPreservesCoreHighwayClasses(preserve);
+}
+
+/**
+ * Full highway lenses (Quebec) include maxspeed dash rules *and* rely on core
+ * structure/access styling. Do not strip those classes — only for maxspeed-only lenses.
+ * @param css - raw lens CSS
+ * @returns whether core emphasis classes should be preserved
+ */
+export function lensCssPreservesCoreHighwayClasses(css: string): boolean {
+    if (!css) return false;
+    return /tag-access-(?:private|customers|permissive)/.test(css)
+        && css.includes(':not(.tag-highway-footway)');
+}
+
+/** @deprecated use lensCssPreservesCoreHighwayClasses */
+export function lensCssPreservesMotorAccessClasses(css: string): boolean {
+    return lensCssPreservesCoreHighwayClasses(css);
 }
 
 /** @returns the lens-required secondary keys (CSS-class form) */
@@ -348,6 +381,19 @@ const MAXSPEED_LENS_ACCESS_CLASS_PREFIXES = [
 const MAXSPEED_LENS_ACCESS_VALUES = new Set(['private', 'customers', 'permissive']);
 
 function shouldStripClassForMaxspeedLens(klass: string): boolean {
+    if (lensPreservesCoreHighwayClasses) {
+        if (klass === 'tag-custom-access-emphasis') return false;
+        if (MAXSPEED_LENS_STRUCTURE_CLASS_PREFIXES.some(
+            (prefix) => klass === prefix || klass.startsWith(prefix + '-')
+        )) {
+            return false;
+        }
+        for (const prefix of MAXSPEED_LENS_ACCESS_CLASS_PREFIXES) {
+            if (!klass.startsWith(prefix + '-')) continue;
+            const value = klass.slice(prefix.length + 1);
+            if (MAXSPEED_LENS_ACCESS_VALUES.has(value)) return false;
+        }
+    }
     if (klass === 'tag-custom-access-emphasis') return true;
     if (MAXSPEED_LENS_STRUCTURE_CLASS_PREFIXES.some(
         (prefix) => klass === prefix || klass.startsWith(prefix + '-')
@@ -383,7 +429,9 @@ export function stripStructureClassesForMaxspeedLens(classes: string[]): void {
  * matching `tag-*` classes. Call on lens change and at startup.
  */
 export function refreshLensTagKeys(): void {
-    setLensSecondaryTagKeys(extractTagKeysFromCss(getActiveLensCss()));
+    const css = getActiveLensCss();
+    setLensSecondaryTagKeys(extractTagKeysFromCss(css));
+    lensPreservesCoreHighwayClasses = lensCssPreservesCoreHighwayClasses(css);
 }
 
 /** id of the <style> element holding the active lens's CSS. */

--- a/test/spec/core/lenses.js
+++ b/test/spec/core/lenses.js
@@ -2,7 +2,11 @@ import {
     appendLensTagClasses,
     extractTagKeysFromCss,
     getLensSecondaryTagKeys,
+    lensCssPreservesCoreHighwayClasses,
+    lensCssPreservesMotorAccessClasses,
     sanitizeLensCss,
+    setLensPreservesCoreHighwayClasses,
+    setLensPreservesMotorAccessClasses,
     setLensSecondaryTagKeys,
     stripStructureClassesForMaxspeedLens
 } from '../../../modules/core/lenses';
@@ -11,6 +15,7 @@ describe('lens tag classes', function() {
 
     afterEach(function() {
         setLensSecondaryTagKeys([]);
+        setLensPreservesCoreHighwayClasses(false);
     });
 
     describe('extractTagKeysFromCss', function() {
@@ -102,10 +107,32 @@ describe('lens tag classes', function() {
         cases.forEach(function([name, keys, input, expected]) {
             it(name, function() {
                 setLensSecondaryTagKeys(keys);
+                setLensPreservesCoreHighwayClasses(false);
                 const classes = input.slice();
                 stripStructureClassesForMaxspeedLens(classes);
                 expect(classes).to.eql(expected);
             });
+        });
+
+        it('keeps structure and access when quebec-style lens preserves them', function() {
+            setLensSecondaryTagKeys(['maxspeed']);
+            setLensPreservesCoreHighwayClasses(true);
+            const classes = [
+                'tag-highway-service', 'tag-access-customers', 'tag-custom-access-emphasis',
+                'tag-bridge', 'tag-bridge-yes', 'tag-tunnel', 'tag-maxspeed-30'
+            ];
+            stripStructureClassesForMaxspeedLens(classes);
+            expect(classes).to.eql([
+                'tag-highway-service', 'tag-access-customers', 'tag-custom-access-emphasis',
+                'tag-bridge', 'tag-bridge-yes', 'tag-tunnel', 'tag-maxspeed-30'
+            ]);
+        });
+
+        it('detects quebec core preservation from css', function() {
+            const snippet = 'path.line.casing.tag-access-customers:not(.tag-highway-footway)';
+            expect(lensCssPreservesCoreHighwayClasses(snippet)).to.be.true;
+            expect(lensCssPreservesMotorAccessClasses(snippet)).to.be.true;
+            expect(lensCssPreservesCoreHighwayClasses('.tag-maxspeed-30{}')).to.be.false;
         });
     });
 


### PR DESCRIPTION
## Summary
- Duplicate fork access emphasis rules into `v5-quebec.css` and complete the same block in `v5-quebec-surfaces.css` (footway/path, links, placement).
- Remove maxspeed dash rules from Québec lenses; add `lenses/maxspeed-colors.css` as the dedicated maxspeed visualization lens.
- Fix bridge rendering in `v5-quebec-surfaces.css` (duplicate `50_misc.css` bridge rules; exclude bridges from `tag-surface-undefined` casing).
- Preserve structure and access classes for full highway-style lenses when maxspeed lens stripping runs (`lenses.ts`).
- Lens shortcuts activate only (no toggle off on repeat); `⌥D` still returns to default.

## Test plan
- [x] `npx vitest run test/spec/core/lenses.js` (43 tests)
- [x] Re-import `v5-quebec.css` / `v5-quebec-surfaces.css` in Map data → Lens
- [x] Verify `access=customers` / `access=private` orange-red casing on motor roads
- [x] Verify bridge black wide casing (e.g. Rue des Ormeaux)
- [x] Verify `⌥+letter` activates lens without deactivating on repeat