### PR TITLE
Fix multiselect selection halo and lane field crashes

### DIFF
--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -21,6 +21,11 @@ function onewayArrowColour(tags) {
     return 'black';
 }
 
+/** @param {(entity: { id: string }) => boolean} f */
+function filterIsUniversal(f) {
+    return f({ id: '__none__' }) === true;
+}
+
 export function svgLines(projection, context) {
     var detected = utilDetect();
 
@@ -60,8 +65,11 @@ export function svgLines(projection, context) {
 
         // Targets allow hover and vertex snapping
         var targetData = data.targets.filter(getPath);
+        var joinFilter = (context.mode()?.id === 'select')
+            ? function() { return true; }
+            : function(d) { return filter(d.properties.entity); };
         var targets = selection.selectAll('.line.target-allowed')
-            .filter(function(d) { return filter(d.properties.entity); })
+            .filter(joinFilter)
             .data(targetData, function key(d) { return d.id; });
 
         // exit
@@ -94,7 +102,7 @@ export function svgLines(projection, context) {
         // NOPE
         var nopeData = data.nopes.filter(getPath);
         var nopes = selection.selectAll('.line.target-nope')
-            .filter(function(d) { return filter(d.properties.entity); })
+            .filter(joinFilter)
             .data(nopeData, function key(d) { return d.id; });
 
         // exit
@@ -135,9 +143,26 @@ export function svgLines(projection, context) {
             var isDrawing = mode && /^draw/.test(mode.id);
             var selectedClass = (!isDrawing && isSelected) ? 'selected ' : '';
 
+            // Partial redraw only joins entities in the change set; clean up stragglers.
+            if (isSelected) {
+                selection.selectAll('path')
+                    .filter(function(d) { return d && context.selectedIDs().indexOf(d.id) === -1; })
+                    .remove();
+            } else {
+                selection.selectAll('path')
+                    .filter(function(d) { return d && context.selectedIDs().indexOf(d.id) !== -1; })
+                    .remove();
+            }
+
+            // Highlighted groups must join all bound paths on select changes: a partial
+            // entity filter skips exit() for other selected ways (mixed tags/layers).
+            var joinFilter = (isSelected && context.mode()?.id === 'select')
+                ? function() { return true; }
+                : filter;
+
             var lines = selection
                 .selectAll('path')
-                .filter(filter)
+                .filter(joinFilter)
                 .data(getPathData(isSelected, wayFilter), osmIdManager.key);
 
             lines.exit()
@@ -188,6 +213,7 @@ export function svgLines(projection, context) {
                 .merge(lines)
                 .sort(waystack)
                 .attr('d', getPath)
+                .classed('selected', !isDrawing && isSelected)
                 .call(svgTagClasses().tags(svgRelationMemberTags(graph)));
 
             return selection;
@@ -260,6 +286,21 @@ export function svgLines(projection, context) {
             }
         }
 
+        // Partial redraw passes only the changed entity; highlighted groups still
+        // need every selected line (fork over-stroke, mixed tags/layers).
+        if (context.mode()?.id === 'select') {
+            context.selectedIDs().forEach(function(id) {
+                var selected = graph.hasEntity(id);
+                if (!selected || ways.indexOf(selected) !== -1) return;
+                if (selected.geometry(graph) !== 'line'
+                    && !(selected.geometry(graph) === 'area' && selected.sidednessIdentifier
+                        && selected.sidednessIdentifier() === 'coastline')) {
+                    return;
+                }
+                ways.push(selected);
+            });
+        }
+
         ways = ways.filter(getPath);
         const pathdata = utilArrayGroupBy(ways, (way) => Math.trunc(way.layer()));
 
@@ -306,7 +347,7 @@ export function svgLines(projection, context) {
 
             layergroup
                 .selectAll('g.linegroup')
-                .data(['shadow', 'casing', 'stroke', 'over-stroke', 'shadow-highlighted', 'casing-highlighted', 'stroke-highlighted'])
+                .data(['shadow', 'casing', 'stroke', 'over-stroke', 'shadow-highlighted', 'casing-highlighted', 'stroke-highlighted', 'over-stroke-highlighted'])
                 .enter()
                 .append('g')
                 .attr('class', function(d) { return 'linegroup line-' + d; });
@@ -329,6 +370,8 @@ export function svgLines(projection, context) {
                 .call(drawLineGroup, 'casing', true);
             layergroup.selectAll('g.line-stroke-highlighted')
                 .call(drawLineGroup, 'stroke', true);
+            layergroup.selectAll('g.line-over-stroke-highlighted')
+                .call(drawLineGroup, 'over-stroke', true, (d) => !!d.tags.highway);
 
             addMarkers(layergroup, 'oneway', 'onewaygroup', onewaydata, (d) => {
                 const category = onewayArrowColour(graph.entity(d.id).tags);
@@ -342,9 +385,12 @@ export function svgLines(projection, context) {
             );
         });
 
-        // Draw touch targets..
-        touchLayer
-            .call(drawTargets, graph, ways, filter);
+        // Partial line redraw in select mode updates highlighted geometry only.
+        // Partial touch-target joins drop hit areas (grab cursor) for other ways.
+        if (!(context.mode()?.id === 'select' && !filterIsUniversal(filter))) {
+            touchLayer
+                .call(drawTargets, graph, ways, filter);
+        }
     }
 
 

--- a/modules/ui/fields/lane_list.ts
+++ b/modules/ui/fields/lane_list.ts
@@ -5,7 +5,8 @@ import { uiCombobox } from '../combobox';
 import { t } from '../../core/localizer';
 import { utilNoAuto, utilRebind } from '../../util';
 import {
-    laneCountKey, laneKind, splitLaneValues, serializeLaneValues,
+    laneCountKey, laneKind, laneTagValue, laneTagConflict, laneCountFromTags,
+    splitLaneValues, serializeLaneValues,
     commonPatterns, matchPattern, cellOptions, cellDisplay, cellValue,
     changeBoundaries, boundariesToValue, laneCountMismatch
 } from './lane_patterns';
@@ -61,12 +62,29 @@ export function uiFieldLaneList(
     }
 
     function laneCount() {
-        return parseInt(_tags[countKey], 10);
+        return laneCountFromTags(_tags[countKey]) ?? NaN;
     }
 
     function render() {
         const count = laneCount();
-        const value = _tags[field.key] || '';
+        const value = laneTagValue(_tags[field.key]);
+        const conflict = laneTagConflict(_tags[countKey]) || laneTagConflict(_tags[field.key]);
+
+        wrap.selectAll('.lane-dropdown, .lane-grid').remove();
+
+        if (conflict) {
+            let notice = wrap.selectAll('.lane-multiselect-conflict').data([0]);
+            notice = notice.enter()
+                .append('div')
+                .attr('class', 'lane-multiselect-conflict field-warning')
+                .merge(notice);
+            notice.text(t('inspector.multiple_values'));
+            wrap.selectAll('.field-warning').not('.lane-multiselect-conflict').remove();
+            return;
+        }
+
+        wrap.selectAll('.lane-multiselect-conflict').remove();
+
         const patterns = commonPatterns(kind, count, arrow, widthEnd);
         const matched = matchPattern(kind, patterns, value);
         // hybrid: dropdown always; grid as soon as a value is set (or Custom…)

--- a/modules/ui/fields/lane_patterns.ts
+++ b/modules/ui/fields/lane_patterns.ts
@@ -22,8 +22,31 @@ export function laneKind(valueKey: string): LaneKind {
     return 'change';
 }
 
+/** True when a tag has conflicting values across a multiselection. */
+export function laneTagConflict(raw: string | string[] | undefined | null): boolean {
+    return Array.isArray(raw);
+}
+
+/** OSM tag value for a lane field; multiselect conflicts become empty (like combo fields). */
+export function laneTagValue(raw: string | string[] | undefined | null): string {
+    if (raw === undefined || raw === null) return '';
+    if (Array.isArray(raw)) return '';
+    return raw;
+}
+
+/** Lane count from a `lanes*` tag, or undefined when missing / multiselect conflict. */
+export function laneCountFromTags(raw: string | string[] | undefined | null): number | undefined {
+    if (laneTagConflict(raw)) return undefined;
+    const count = parseInt(laneTagValue(raw), 10);
+    return count >= 1 ? count : undefined;
+}
+
 /** Split a `a|b|c` value into exactly `count` cells (pad/truncate). */
-export function splitLaneValues(value: string, count: number): string[] {
+export function splitLaneValues(value: string | string[] | undefined | null, count: number): string[] {
+    if (Array.isArray(value)) {
+        const length = count > 0 ? count : 0;
+        return Array.from({ length }, () => '');
+    }
     const parts = value ? value.split('|') : [];
     const length = count > 0 ? count : parts.length;
     return Array.from({ length }, (_, i) => parts[i] || '');

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -261,4 +261,136 @@ describe('iD.svgLines', function () {
                 .to.eql('url(#ideditor-sided-marker-dual_carriageway)');
         });
     });
+
+    describe('highlighted groups (partial redraw)', function() {
+        var nodes, ways, graph;
+
+        beforeEach(function() {
+            nodes = [
+                new iD.osmNode({id: 'n1', loc: [0, 0]}),
+                new iD.osmNode({id: 'n2', loc: [0.001, 0]}),
+                new iD.osmNode({id: 'n3', loc: [0.002, 0]}),
+                new iD.osmNode({id: 'n4', loc: [0.003, 0]}),
+                new iD.osmNode({id: 'n5', loc: [0, 0.001]}),
+                new iD.osmNode({id: 'n6', loc: [0.001, 0.001]}),
+                new iD.osmNode({id: 'n7', loc: [0.002, 0.001]}),
+                new iD.osmNode({id: 'n8', loc: [0.003, 0.001]}),
+            ];
+            ways = [
+                new iD.osmWay({id: 'w1', tags: {highway: 'motorway'}, nodes: ['n1', 'n2']}),
+                new iD.osmWay({id: 'w2', tags: {highway: 'motorway'}, nodes: ['n3', 'n4']}),
+                new iD.osmWay({id: 'w3', tags: {highway: 'secondary'}, nodes: ['n5', 'n6']}),
+                new iD.osmWay({id: 'w4', tags: {highway: 'secondary'}, nodes: ['n7', 'n8']}),
+            ];
+            graph = new iD.coreGraph(nodes.concat(ways));
+            context.history().merge(nodes.concat(ways));
+            surface.call(iD.svgLines(projection, context), graph, ways, all);
+        });
+
+        function partialRedraw(ids) {
+            var selectedAndParents = {};
+            ids.forEach(function(id) { selectedAndParents[id] = graph.entity(id); });
+            var data = Object.values(selectedAndParents);
+            var filter = function(d) { return d.id in selectedAndParents; };
+            surface.call(iD.svgLines(projection, context), graph, data, filter);
+        }
+
+        function shadowGroup(isHighlighted) {
+            return surface.selectAll(
+                isHighlighted ? 'g.line-shadow-highlighted' : 'g.line-shadow'
+            );
+        }
+
+        function expectWaysHighlighted(ids) {
+            ids.forEach(function(id) {
+                var paths = shadowGroup(true).selectAll('path.' + id);
+                expect(paths.empty(), id + ' in shadow-highlighted').to.be.false;
+                paths.each(function() {
+                    expect(d3.select(this).classed('selected'), id + ' selected class').to.be.true;
+                });
+            });
+        }
+
+        function expectWaysNotInNormalShadow(ids) {
+            ids.forEach(function(id) {
+                expect(shadowGroup(false).selectAll('path.' + id).empty(), id + ' not in shadow')
+                    .to.be.true;
+            });
+        }
+
+        [1, 2, 3, 4].forEach(function(n) {
+            it('keeps ' + n + ' selected way(s) in highlighted shadow after partial redraw', function() {
+                var ids = ways.slice(0, n).map(function(w) { return w.id; });
+                context.enter(iD.modeSelect(context, ids));
+                partialRedraw(ids);
+                expectWaysHighlighted(ids);
+                expectWaysNotInNormalShadow(ids);
+            });
+        });
+
+        it('survives incremental partial redraws on the same surface (multi-shift+click)', function() {
+            var ids = [ways[0].id];
+            context.enter(iD.modeSelect(context, ids));
+            partialRedraw(ids);
+            expectWaysHighlighted(ids);
+
+            for (var n = 1; n < ways.length; n++) {
+                ids = ways.slice(0, n + 1).map(function(w) { return w.id; });
+                context.enter(iD.modeSelect(context, ids));
+                partialRedraw(ids);
+                expectWaysHighlighted(ids);
+                expectWaysNotInNormalShadow(ids);
+            }
+        });
+
+        it('drops deselected ways from highlighted shadow on partial redraw', function() {
+            var allIds = ways.map(function(w) { return w.id; });
+            context.enter(iD.modeSelect(context, allIds));
+            partialRedraw(allIds);
+            expectWaysHighlighted(allIds);
+
+            var fewer = allIds.slice(0, 3);
+            context.enter(iD.modeSelect(context, fewer));
+            partialRedraw(fewer);
+            expectWaysHighlighted(fewer);
+            expect(shadowGroup(true).selectAll('path.' + allIds[3]).empty()).to.be.true;
+        });
+
+        it('moves highway over-stroke into highlighted group when selected', function() {
+            var id = ways[0].id;
+            context.enter(iD.modeSelect(context, [id]));
+            partialRedraw([id]);
+            expect(surface.selectAll('g.line-over-stroke-highlighted path.' + id).empty()).to.be.false;
+            expect(surface.selectAll('g.line-over-stroke path.' + id).empty()).to.be.true;
+        });
+
+        [
+            ['w1', 'w3'],
+            ['w3', 'w1'],
+            ['w1', 'w2'],
+            ['w2', 'w1'],
+        ].forEach(function(pair) {
+            it('keeps both halos when incrementally selecting ' + pair.join(' then '), function() {
+                context.enter(iD.modeSelect(context, [pair[0]]));
+                partialRedraw([pair[0]]);
+                expectWaysHighlighted([pair[0]]);
+
+                context.enter(iD.modeSelect(context, pair));
+                partialRedraw([pair[1]]);
+                expectWaysHighlighted(pair);
+                expectWaysNotInNormalShadow(pair);
+            });
+        });
+
+        it('skips touch-target updates on partial redraw in select mode', function() {
+            context.enter(iD.modeSelect(context, ['w1', 'w3']));
+            surface.call(iD.svgLines(projection, context), graph, ways, all);
+            var touchLayer = surface.select('.layer-touch.lines');
+            var before = touchLayer.node().innerHTML;
+
+            partialRedraw(['w3']);
+
+            expect(touchLayer.node().innerHTML).to.eql(before);
+        });
+    });
 });

--- a/test/spec/ui/fields/lane_list.js
+++ b/test/spec/ui/fields/lane_list.js
@@ -34,6 +34,32 @@ describe('iD.uiFieldLaneList helpers', () => {
         });
     });
 
+    describe('laneTagValue', () => {
+        describe.each([
+            ['left|right', 'left|right'],
+            [['left', 'through'], ''],
+            [undefined, ''],
+            [null, ''],
+        ])('%j', (raw, expected) => {
+            it(`-> ${JSON.stringify(expected)}`, () => {
+                expect(iD.laneTagValue(raw)).toBe(expected);
+            });
+        });
+    });
+
+    describe('laneCountFromTags', () => {
+        describe.each([
+            ['3', 3],
+            [['2', '3'], undefined],
+            ['', undefined],
+            [undefined, undefined],
+        ])('%j', (raw, expected) => {
+            it(`-> ${expected}`, () => {
+                expect(iD.laneCountFromTags(raw)).toBe(expected);
+            });
+        });
+    });
+
     describe('splitLaneValues', () => {
         describe.each([
             // [value, count, expected]
@@ -42,7 +68,8 @@ describe('iD.uiFieldLaneList helpers', () => {
             ['3|3|2|2', 2, ['3', '3']],            // truncate to count
             ['', 3, ['', '', '']],                 // empty value, known count
             ['yes|no', 0, ['yes', 'no']],          // unknown count -> use the value's lanes
-            ['', 0, []]                            // unknown count, empty value
+            ['', 0, []],                           // unknown count, empty value
+            [['left', 'through'], 2, ['', '']],    // multiselect conflict
         ])('(%s, %i)', (value, count, expected) => {
             it(`-> ${JSON.stringify(expected)}`, () => {
                 expect(iD.splitLaneValues(value, count)).toEqual(expected);


### PR DESCRIPTION
## Summary
- Fix `laneList` crash when shift-selecting ways with conflicting `lanes*` / per-lane tags (`utilCombinedTags` returns arrays); show « multiple values » instead of calling `.split()` on a non-string.
- Harden fork `over-stroke` rendering on partial redraw: add `over-stroke-highlighted`, reconcile highlighted groups, preserve touch targets (fixes missing halo and grab cursor).

## Test plan
- [x] `npm run test:spec -- test/spec/ui/fields/lane_list.js test/spec/svg/lines.js` (136 tests)
- [ ] Shift+click two adjacent road segments with different `lanes` counts — no console error, inspector shows multiple values, halo and line cursor remain
- [ ] Shift+click multiple motorway segments with matching tags — selection feedback stays visible
- [ ] Pan not required to recover selection styling