### PR TITLE
Fix preset shortcuts for vertex/point geometry and repeat-draw

### DIFF
--- a/modules/behavior/preset_shortcuts.js
+++ b/modules/behavior/preset_shortcuts.js
@@ -6,6 +6,9 @@ import {
     isPresetShortcutKey,
     isValidPresetShortcut,
     normalizePresetShortcut,
+    presetShortcutDrawingGeometry,
+    presetShortcutMatchesEntity,
+    presetShortcutShouldRedraw,
     shouldCapturePresetShortcutBuffer
 } from '../core/preset_shortcut_format';
 import { modeAddPoint, modeAddLine, modeAddArea, modeBrowse } from '../modes';
@@ -144,6 +147,63 @@ export function behaviorPresetShortcuts(context) {
         sidebar.show(presetInfoPanel);
     }
 
+    function enterDrawingMode(preset, shortcut) {
+        const drawingGeometry = presetShortcutDrawingGeometry(preset);
+        let drawingMode;
+
+        if (drawingGeometry === 'point') {
+            drawingMode = modeAddPoint(context, {
+                title: t.append('modes.add_point.title'),
+                button: 'point',
+                description: t.append('modes.add_point.description'),
+                preset: preset,
+                key: shortcut
+            });
+        } else if (drawingGeometry === 'line') {
+            drawingMode = modeAddLine(context, {
+                title: t.append('modes.add_line.title'),
+                button: 'line',
+                description: t.append('modes.add_line.description'),
+                preset: preset,
+                key: shortcut
+            });
+        } else if (drawingGeometry === 'area') {
+            drawingMode = modeAddArea(context, {
+                title: t.append('modes.add_area.title'),
+                button: 'area',
+                description: t.append('modes.add_area.description'),
+                preset: preset,
+                key: shortcut
+            });
+        } else {
+            return false;
+        }
+
+        context.enter(drawingMode);
+        showPresetInSidebar(preset, shortcut, 'drawing');
+
+        setTimeout(() => {
+            try {
+                const presetName = preset.nameLabel();
+                context.ui().flash
+                    .duration(3000)
+                    .iconName('#iD-icon-apply')
+                    .iconClass('success')
+                    .label(function (selection) {
+                        selection.text('');
+                        selection.append('span').text('Drawing mode: ');
+                        presetName(selection.append('span').attr('class', 'preset-name'));
+                        selection.append('span').text(' (shortcut: ' + shortcut + ')');
+                    })();
+            } catch (error) {
+                console.error('Flash notification failed:', error);
+            }
+        }, 50);
+
+        dispatch.call('shortcutUsed', this, preset, shortcut, 'draw');
+        return true;
+    }
+
     function executeShortcut(shortcut) {
         const presetId = presetShortcuts.getPreset(shortcut);
         if (!presetId) {
@@ -155,75 +215,37 @@ export function behaviorPresetShortcuts(context) {
             return false;
         }
 
-        // If we're in browse mode and no entities are selected, enter drawing mode
         const mode = context.mode();
-        const selectedIDs = context.selectedIDs();
+        const entityIDs = context.selectedIDs();
 
-        // Handle both browse mode and drawing modes with no selection
-        if ((mode.id === 'browse' || /^add-/.test(mode.id)) && !selectedIDs.length) {
-            // Determine default geometry for this preset
-            const geometries = preset.geometry;
-            let drawingMode;
+        if (entityIDs.length > 0) {
+            const graph = context.graph();
+            const currentPresetIds = [];
+            const currentShortcuts = [];
+            const compatible = [];
 
-            if (geometries.includes('point')) {
-                drawingMode = modeAddPoint(context, {
-                    title: t.append('modes.add_point.title'),
-                    button: 'point',
-                    description: t.append('modes.add_point.description'),
-                    preset: preset,
-                    key: shortcut
-                });
-            } else if (geometries.includes('line')) {
-                drawingMode = modeAddLine(context, {
-                    title: t.append('modes.add_line.title'),
-                    button: 'line',
-                    description: t.append('modes.add_line.description'),
-                    preset: preset,
-                    key: shortcut
-                });
-            } else if (geometries.includes('area')) {
-                drawingMode = modeAddArea(context, {
-                    title: t.append('modes.add_area.title'),
-                    button: 'area',
-                    description: t.append('modes.add_area.description'),
-                    preset: preset,
-                    key: shortcut
-                });
-            } else {
-                return false; // No supported geometry
+            for (let i = 0; i < entityIDs.length; i++) {
+                const entity = graph.entity(entityIDs[i]);
+                const entityGeometry = entity.geometry(graph);
+                const currentPreset = presetManager.match(entity, graph);
+                const isCompatible = presetShortcutMatchesEntity(preset, entityGeometry);
+
+                currentPresetIds.push(currentPreset.id);
+                currentShortcuts.push(presetShortcuts.getShortcut(currentPreset.id));
+                compatible.push(isCompatible);
             }
 
-            context.enter(drawingMode);
+            if (presetShortcutShouldRedraw(shortcut, preset, currentPresetIds, currentShortcuts, compatible)) {
+                return enterDrawingMode(preset, shortcut);
+            }
+        }
 
-            // Show preset information in the sidebar when starting to draw
-            showPresetInSidebar(preset, shortcut, 'drawing');
-
-            // Show notification with preset name and shortcut
-            setTimeout(() => {
-                try {
-                    const presetName = preset.nameLabel();
-                    context.ui().flash
-                        .duration(3000)
-                        .iconName('#iD-icon-apply')
-                        .iconClass('success')
-                        .label(function (selection) {
-                            selection.text('');
-                            selection.append('span').text('Drawing mode: ');
-                            presetName(selection.append('span').attr('class', 'preset-name'));
-                            selection.append('span').text(' (shortcut: ' + shortcut + ')');
-                        })();
-                } catch (error) {
-                    console.error('Flash notification failed:', error);
-                }
-            }, 50);
-
-            dispatch.call('shortcutUsed', this, preset, shortcut, 'draw');
-            return true;
+        // If we're in browse mode and no entities are selected, enter drawing mode
+        if ((mode.id === 'browse' || /^add-/.test(mode.id)) && !entityIDs.length) {
+            return enterDrawingMode(preset, shortcut);
         }
 
         // If entities are selected, apply the preset to them
-        const entityIDs = context.selectedIDs();
-
         if (entityIDs.length > 0) {
             // Check if any entities are compatible with this preset
             const graph = context.graph();
@@ -233,7 +255,7 @@ export function behaviorPresetShortcuts(context) {
                 const entityID = entityIDs[i];
                 const entity = graph.entity(entityID);
                 const entityGeometry = entity.geometry(graph);
-                if (preset.geometry.includes(entityGeometry)) {
+                if (presetShortcutMatchesEntity(preset, entityGeometry)) {
                     compatibleEntities++;
                 }
             }
@@ -253,7 +275,7 @@ export function behaviorPresetShortcuts(context) {
 
                         // Check if preset is applicable to this geometry
                         const entityGeometry = entity.geometry(graph);
-                        if (preset.geometry.includes(entityGeometry)) {
+                        if (presetShortcutMatchesEntity(preset, entityGeometry)) {
                             graph = actionChangePreset(entityID, oldPreset, preset)(graph);
                         }
                     }

--- a/modules/core/preset_shortcut_format.js
+++ b/modules/core/preset_shortcut_format.js
@@ -58,3 +58,58 @@ export function shouldCapturePresetShortcutBuffer(buffer) {
     }
     return false;
 }
+
+/**
+ * Drawing mode kind for a preset shortcut, or `null` when unsupported.
+ * Vertex presets use point drawing mode (same as iD's add-point behavior).
+ * @param {{ geometry?: string[] }} preset
+ * @returns {'point' | 'line' | 'area' | null}
+ */
+export function presetShortcutDrawingGeometry(preset) {
+    const geometries = preset.geometry || [];
+    if (geometries.includes('line')) return 'line';
+    if (geometries.includes('area')) return 'area';
+    if (geometries.includes('point') || geometries.includes('vertex')) return 'point';
+    return null;
+}
+
+/**
+ * Whether a preset shortcut may be applied to a selected entity geometry.
+ * Vertex nodes may use point presets (e.g. tree on a way node); vertex-only
+ * presets (e.g. noexit) do not apply to standalone points.
+ * @param {{ matchGeometry: (geom: string) => boolean }} preset
+ * @param {string} entityGeometry - `point`, `vertex`, `line`, or `area`
+ * @returns {boolean}
+ */
+export function presetShortcutMatchesEntity(preset, entityGeometry) {
+    if (!preset || !entityGeometry) return false;
+    if (preset.matchGeometry(entityGeometry)) return true;
+    if (entityGeometry === 'vertex' && preset.matchGeometry('point')) return true;
+    return false;
+}
+
+/**
+ * True when the shortcut should start drawing a new feature instead of
+ * re-applying the preset to the current selection (same preset + same shortcut).
+ * @param {string} shortcut - normalized shortcut being pressed
+ * @param {{ id: string }} preset - preset bound to the shortcut
+ * @param {string[]} currentPresetIds - matched preset id per selected entity
+ * @param {(string|undefined)[]} currentShortcuts - shortcut key per entity's current preset
+ * @param {boolean[]} compatible - whether `preset` matches each entity geometry
+ * @returns {boolean}
+ */
+export function presetShortcutShouldRedraw(shortcut, preset, currentPresetIds, currentShortcuts, compatible) {
+    if (!presetShortcutDrawingGeometry(preset)) return false;
+    if (!currentPresetIds.length) return false;
+
+    const normalized = normalizePresetShortcut(shortcut);
+
+    for (let i = 0; i < currentPresetIds.length; i++) {
+        if (!compatible[i]) return false;
+        if (currentPresetIds[i] !== preset.id) return false;
+        const current = currentShortcuts[i];
+        if (!current || normalizePresetShortcut(current) !== normalized) return false;
+    }
+
+    return true;
+}

--- a/test/spec/core/preset_shortcut_format.js
+++ b/test/spec/core/preset_shortcut_format.js
@@ -2,8 +2,19 @@ import {
     isPresetShortcutKey,
     isValidPresetShortcut,
     normalizePresetShortcut,
+    presetShortcutDrawingGeometry,
+    presetShortcutMatchesEntity,
+    presetShortcutShouldRedraw,
     shouldCapturePresetShortcutBuffer
 } from '../../../modules/core/preset_shortcut_format';
+
+function mockPreset(geometries, id) {
+    return {
+        id: id || 'test/preset',
+        geometry: geometries,
+        matchGeometry: (geom) => geometries.indexOf(geom) >= 0
+    };
+}
 
 describe('core/preset_shortcut_format', function() {
 
@@ -70,6 +81,132 @@ describe('core/preset_shortcut_format', function() {
         cases.forEach(function([buffer, expected]) {
             it(`"${buffer}" → ${expected}`, function() {
                 expect(shouldCapturePresetShortcutBuffer(buffer)).to.equal(expected);
+            });
+        });
+    });
+
+    describe('presetShortcutDrawingGeometry', function() {
+        const cases = [
+            [['vertex'], 'point'],
+            [['point'], 'point'],
+            [['point', 'vertex'], 'point'],
+            [['line'], 'line'],
+            [['area'], 'area'],
+            [['vertex', 'line'], 'line'],
+            [[], null]
+        ];
+
+        cases.forEach(function([geometries, expected]) {
+            it(`${JSON.stringify(geometries)} → ${expected}`, function() {
+                expect(presetShortcutDrawingGeometry(mockPreset(geometries))).to.equal(expected);
+            });
+        });
+    });
+
+    describe('presetShortcutMatchesEntity', function() {
+        const tree = mockPreset(['point', 'vertex']);
+        const noexit = mockPreset(['vertex']);
+        const bench = mockPreset(['point']);
+        const residential = mockPreset(['line']);
+
+        const cases = [
+            [tree, 'point', true],
+            [tree, 'vertex', true],
+            [noexit, 'vertex', true],
+            [noexit, 'point', false],
+            [bench, 'point', true],
+            [bench, 'vertex', true],
+            [residential, 'line', true],
+            [residential, 'vertex', false]
+        ];
+
+        cases.forEach(function([preset, entityGeometry, expected]) {
+            it(`${JSON.stringify(preset.geometry)} + ${entityGeometry} → ${expected}`, function() {
+                expect(presetShortcutMatchesEntity(preset, entityGeometry)).to.equal(expected);
+            });
+        });
+    });
+
+    describe('presetShortcutShouldRedraw', function() {
+        const tree = mockPreset(['point', 'vertex'], 'natural/tree');
+        const bench = mockPreset(['point'], 'amenity/bench');
+        const residential = mockPreset(['line'], 'highway/residential');
+
+        const cases = [
+            {
+                label: 'same tree shortcut on selected tree → draw',
+                shortcut: '8t',
+                preset: tree,
+                currentPresetIds: ['natural/tree'],
+                currentShortcuts: ['8t'],
+                compatible: [true],
+                expected: true
+            },
+            {
+                label: 'different shortcut on selected tree → apply',
+                shortcut: '9b',
+                preset: bench,
+                currentPresetIds: ['natural/tree'],
+                currentShortcuts: ['8t'],
+                compatible: [true],
+                expected: false
+            },
+            {
+                label: 'same preset id but no shortcut assigned → apply',
+                shortcut: '8t',
+                preset: tree,
+                currentPresetIds: ['natural/tree'],
+                currentShortcuts: [undefined],
+                compatible: [true],
+                expected: false
+            },
+            {
+                label: 'multi-select same trees same shortcut → draw',
+                shortcut: '8t',
+                preset: tree,
+                currentPresetIds: ['natural/tree', 'natural/tree'],
+                currentShortcuts: ['8t', '8t'],
+                compatible: [true, true],
+                expected: true
+            },
+            {
+                label: 'mixed selection → apply',
+                shortcut: '8t',
+                preset: tree,
+                currentPresetIds: ['natural/tree', 'natural/tree'],
+                currentShortcuts: ['8t', '9b'],
+                compatible: [true, true],
+                expected: false
+            },
+            {
+                label: 'incompatible geometry → apply',
+                shortcut: '8t',
+                preset: tree,
+                currentPresetIds: ['highway/residential'],
+                currentShortcuts: ['22'],
+                compatible: [false],
+                expected: false
+            },
+            {
+                label: 'same residential shortcut on way → draw',
+                shortcut: '22',
+                preset: residential,
+                currentPresetIds: ['highway/residential'],
+                currentShortcuts: ['22'],
+                compatible: [true],
+                expected: true
+            }
+        ];
+
+        cases.forEach(function(c) {
+            it(c.label, function() {
+                expect(presetShortcutShouldRedraw(
+                    c.shortcut,
+                    c.preset,
+                    c.currentPresetIds,
+                    c.currentShortcuts,
+                    c.compatible
+                )).to.equal(c.expected);
             });
         });
     });


### PR DESCRIPTION
## Summary
- Support `vertex` geometry in preset shortcuts (e.g. No Exit): enter point drawing mode and apply on way nodes
- Match point presets to `vertex` entities (e.g. tree on a way node), but not vertex-only presets on standalone points
- Re-press the same shortcut on a selection that already uses that preset to start drawing another feature instead of re-applying tags

## Test plan
- [x] `npx vitest run test/spec/core/preset_shortcut_format.js` (46 tests)
- [x] Assign shortcut `5ne` to No Exit → works without selection (draw) and on a selected road-end vertex (apply)
- [x] Assign shortcut to Tree → works on isolated point; re-press shortcut on selected tree → draw mode for a second tree
- [x] Select tree, press a different preset shortcut → changes preset on selection
- [x] Way/area shortcuts unchanged (draw line/area; same-shortcut re-press starts new feature)