### PR TITLE
Add flats field to all landuse presets

### DIFF
--- a/data/custom-tagging/src/fields/flats.ts
+++ b/data/custom-tagging/src/fields/flats.ts
@@ -1,0 +1,11 @@
+import type { CustomField } from '../types';
+
+/** Flat count on buildings and landuse areas (v5 fork). */
+export const flats: CustomField = {
+    key: 'flats',
+    type: 'number',
+    minValue: 0,
+    label: 'Number of flats',
+    placeholder: '1, 2, 3...',
+    geometry: ['area', 'point', 'vertex']
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -1,5 +1,6 @@
 import { accessRestricted } from './fields/access_restricted';
 import { capacityCharging } from './fields/capacity_charging';
+import { flats } from './fields/flats';
 import { parkingCondition } from './fields/parking_condition';
 import { routingEntrance } from './fields/routing_entrance';
 import { placement } from './fields/placement';
@@ -41,6 +42,7 @@ export const customFields: Record<string, CustomField> = {
     placement,
     access_restricted: accessRestricted,
     capacity_charging: capacityCharging,
+    flats,
     'parking/condition': parkingCondition,
     routing_entrance: routingEntrance,
     'roof/levels': roofLevels

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -12,6 +12,10 @@
                     "label": "Capacity for charging electric vehicles",
                     "placeholder": "1, 5, 10..."
                 },
+                "flats": {
+                    "label": "Number of flats",
+                    "placeholder": "1, 2, 3..."
+                },
                 "roof/levels": {
                     "label": "Roof Levels",
                     "placeholder": "0, 1, 2..."

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -31,6 +31,10 @@
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."
                 },
+                "flats": {
+                    "label": "Nombre de logements",
+                    "placeholder": "1, 2, 3..."
+                },
                 "roof/levels": {
                     "label": "Niveaux dans le toit",
                     "placeholder": "0, 1, 2..."

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -249,6 +249,7 @@ export function applyCustomFields(presetManager) {
     customizeAccess(presetManager);
     customizePostBox(presetManager);
     customizeCyclewaySidewalk(presetManager);
+    customizeLanduseFlats(presetManager);
     customizeBuildingLevels(presetManager);
     customizeBusStopBench(presetManager);
     setCycleFootPathDefaultSurface(presetManager);
@@ -496,13 +497,52 @@ function setCycleFootPathDefaultSurface(presetManager) {
     preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
 }
 
+const FLATS_FIELD = 'flats';
 const UNDERGROUND_LEVELS_FIELD = 'building/levels/underground';
 const ROOF_LEVELS_FIELD = 'roof/levels';
 const VISIBLE_BUILDING_LEVEL_FIELDS = [UNDERGROUND_LEVELS_FIELD, ROOF_LEVELS_FIELD];
 
+/**
+ * True when `preset` is a landuse preset (including subtypes under `landuse/`).
+ * @param {{ id: string, tags?: Record<string, string>, addTags?: Record<string, string> }} preset
+ * @returns {boolean}
+ */
+function isLandusePreset(preset) {
+    if (preset.id.startsWith('landuse/')) return true;
+    if (preset.tags?.landuse !== undefined) return true;
+    if (preset.addTags?.landuse !== undefined) return true;
+    return false;
+}
+
 /** @param {string} fieldID */
 function isPresetFieldReference(fieldID) {
     return fieldID.startsWith('{') && fieldID.endsWith('}');
+}
+
+/**
+ * Offer the `flats` field on every landuse preset (v5 fork). Inserted after
+ * `name` when present; otherwise appended to moreFields. Skips hidden presets
+ * that only inherit fields from a parent reference.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizeLanduseFlats(presetManager) {
+    presetManager.collection.forEach(preset => {
+        if (!isLandusePreset(preset)) return;
+
+        const fields = preset.originalFields;
+        const moreFields = preset.originalMoreFields;
+
+        if (fields.length && fields.every(isPresetFieldReference)) return;
+        if (fields.indexOf(FLATS_FIELD) !== -1 || moreFields.indexOf(FLATS_FIELD) !== -1) return;
+
+        const nameIndex = fields.indexOf('name');
+        if (nameIndex !== -1) {
+            fields.splice(nameIndex + 1, 0, FLATS_FIELD);
+        } else {
+            moreFields.push(FLATS_FIELD);
+        }
+    });
 }
 
 /**

--- a/test/spec/presets/custom/landuse_flats.js
+++ b/test/spec/presets/custom/landuse_flats.js
@@ -1,0 +1,100 @@
+import { loadCustomDistJson } from './setup.js';
+
+/** Minimal upstream landuse presets for flats attachment tests. */
+const UPSTREAM_LANDUSE_PRESETS = {
+    'landuse/residential': {
+        icon: 'maki-residential-community',
+        fields: ['name', 'residential'],
+        geometry: ['area'],
+        tags: { landuse: 'residential' },
+        name: 'Residential Area'
+    },
+    'landuse/commercial': {
+        icon: 'maki-suitcase',
+        fields: ['name'],
+        geometry: ['area'],
+        tags: { landuse: 'commercial' },
+        name: 'Commercial Area'
+    },
+    'landuse/industrial': {
+        icon: 'maki-industry',
+        fields: ['name', 'industrial'],
+        geometry: ['area'],
+        tags: { landuse: 'industrial' },
+        name: 'Industrial Area'
+    },
+    'landuse/retail': {
+        icon: 'maki-shop',
+        fields: ['name'],
+        geometry: ['area'],
+        tags: { landuse: 'retail' },
+        name: 'Retail Area'
+    },
+    'landuse/residential/apartments': {
+        icon: 'maki-residential-community',
+        fields: ['name', 'operator', 'address'],
+        geometry: ['point', 'area'],
+        tags: { residential: 'apartments' },
+        addTags: { landuse: 'residential', residential: 'apartments' },
+        name: 'Apartment Complex'
+    },
+    'landuse/industrial/_industrial_point': {
+        icon: 'maki-industry',
+        fields: ['{landuse/industrial}'],
+        moreFields: ['{landuse/industrial}'],
+        geometry: ['point'],
+        tags: { landuse: 'industrial' },
+        searchable: false,
+        name: '{landuse/industrial}'
+    },
+    'highway/residential': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway'],
+        geometry: ['line'],
+        tags: { highway: 'residential' },
+        name: 'Residential Road'
+    }
+};
+
+describe('landuse flats field (custom_fields)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_LANDUSE_PRESETS;
+        iD.fileFetcher.cache().preset_fields = { flats: customFields.flats };
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    const withFlatsAfterName = [
+        'landuse/residential',
+        'landuse/commercial',
+        'landuse/industrial',
+        'landuse/institutional',
+        'landuse/retail',
+        'landuse/residential/apartments'
+    ];
+
+    withFlatsAfterName.forEach(function(id) {
+        it(`${id} includes flats after name`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            const fields = preset.originalFields;
+            const nameIndex = fields.indexOf('name');
+            expect(nameIndex, `${id} fields`).to.be.at.least(0);
+            expect(fields[nameIndex + 1]).to.equal('flats');
+        });
+    });
+
+    it('does not add flats to non-landuse presets', function() {
+        const preset = iD.presetManager.item('highway/residential');
+        expect(preset.originalFields.indexOf('flats')).to.equal(-1);
+        expect(preset.originalMoreFields.indexOf('flats')).to.equal(-1);
+    });
+
+    it('skips landuse presets that only inherit fields from a parent', function() {
+        const preset = iD.presetManager.item('landuse/industrial/_industrial_point');
+        expect(preset.originalFields.indexOf('flats')).to.equal(-1);
+        expect(preset.originalMoreFields.indexOf('flats')).to.equal(-1);
+    });
+});

--- a/test/spec/presets/custom_presets.js
+++ b/test/spec/presets/custom_presets.js
@@ -11,6 +11,11 @@ describe('custom presets (data/custom-tagging)', function() {
         expect(customFields.capacity_charging.key).to.equal('capacity:charging');
     });
 
+    it('loads flats field from built custom schema', function() {
+        expect(customFields.flats).to.exist;
+        expect(customFields.flats.key).to.equal('flats');
+    });
+
     it('resolves custom preset paths relative to assetPath (not dist/dist/...)', function() {
         iD.fileFetcher.assetPath('dist/');
         expect(iD.fileFetcher.asset('data/custom/presets.min.json')).to.equal(


### PR DESCRIPTION
## Summary
- Add `flats` number field to custom-tagging (v5 parity: `data/presets/fields/flats.json`)
- Attach `flats` additively to every `landuse/*` preset via `customizeLanduseFlats()` (after `name` when present)
- Enables `tag-has-flats` / `tag-flats-N` styling on landuse areas (yellow outline in Québec lenses)
- en/fr locale strings for the field label and placeholder

## Test plan
- [x] `npx vitest run test/spec/presets/custom/landuse_flats.js test/spec/presets/custom_presets.js`
- [ ] `npm run build:presets:custom` before deploy
- [ ] Inspector: `landuse=residential` polygon shows « Number of flats » / « Nombre de logements »
- [ ] Map with Québec lens: `landuse=residential` + `flats=4` → yellow border