### PR TITLE
Show building underground and roof level fields by default

### DIFF
--- a/data/custom-tagging/src/fields/roof_levels.ts
+++ b/data/custom-tagging/src/fields/roof_levels.ts
@@ -1,0 +1,11 @@
+import type { CustomField } from '../types';
+
+/** Number of levels contained in a building's roof (not in upstream schema yet). */
+export const roofLevels: CustomField = {
+    key: 'roof:levels',
+    type: 'number',
+    minValue: 0,
+    label: 'Roof Levels',
+    placeholder: '0, 1, 2...',
+    geometry: ['area']
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -3,6 +3,7 @@ import { capacityCharging } from './fields/capacity_charging';
 import { parkingCondition } from './fields/parking_condition';
 import { routingEntrance } from './fields/routing_entrance';
 import { placement } from './fields/placement';
+import { roofLevels } from './fields/roof_levels';
 import { bicycleDismountVariantPresets } from './presets/highway/footway/bicycle_dismount_variants';
 import { accessAisleVariantPresets } from './presets/highway/footway/access_aisle_variants';
 import { footwayLinkVariantPresets } from './presets/highway/footway/footway_link_variants';
@@ -40,7 +41,8 @@ export const customFields: Record<string, CustomField> = {
     access_restricted: accessRestricted,
     capacity_charging: capacityCharging,
     'parking/condition': parkingCondition,
-    routing_entrance: routingEntrance
+    routing_entrance: routingEntrance,
+    'roof/levels': roofLevels
 };
 
 /** Template name (filename without .json) → virtual preset under `presets/@templates/`. */

--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -12,6 +12,10 @@
                     "label": "Capacity for charging electric vehicles",
                     "placeholder": "1, 5, 10..."
                 },
+                "roof/levels": {
+                    "label": "Roof Levels",
+                    "placeholder": "0, 1, 2..."
+                },
                 "maxspeed_advisory": {
                     "label": "Advisory Speed Limit"
                 },

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -31,6 +31,10 @@
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."
                 },
+                "roof/levels": {
+                    "label": "Niveaux dans le toit",
+                    "placeholder": "0, 1, 2..."
+                },
                 "parking/condition": {
                     "label": "Condition de stationnement",
                     "options": {

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -249,6 +249,7 @@ export function applyCustomFields(presetManager) {
     customizeAccess(presetManager);
     customizePostBox(presetManager);
     customizeCyclewaySidewalk(presetManager);
+    customizeBuildingLevels(presetManager);
     setCycleFootPathDefaultSurface(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
@@ -492,5 +493,91 @@ function setCycleFootPathDefaultSurface(presetManager) {
     const preset = presetManager.item('highway/cycleway/bicycle_foot');
     if (!preset) return;
     preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
+}
+
+const UNDERGROUND_LEVELS_FIELD = 'building/levels/underground';
+const ROOF_LEVELS_FIELD = 'roof/levels';
+const VISIBLE_BUILDING_LEVEL_FIELDS = [UNDERGROUND_LEVELS_FIELD, ROOF_LEVELS_FIELD];
+
+/** @param {string} fieldID */
+function isPresetFieldReference(fieldID) {
+    return fieldID.startsWith('{') && fieldID.endsWith('}');
+}
+
+/**
+ * True when `preset` is a building preset (including subtypes under `building/`).
+ * @param {{ id: string, tags?: Record<string, string>, addTags?: Record<string, string> }} preset
+ * @returns {boolean}
+ */
+function isBuildingPreset(preset) {
+    if (preset.id === 'building' || preset.id.startsWith('building/')) return true;
+    if (preset.tags?.building !== undefined) return true;
+    if (preset.addTags?.building !== undefined) return true;
+    return false;
+}
+
+/**
+ * True when default fields inherit from a parent building preset via `{building…}`.
+ * @param {{ originalFields: string[] }} preset
+ * @returns {boolean}
+ */
+function inheritsBuildingDefaults(preset) {
+    return preset.originalFields.some(fieldID => {
+        if (!isPresetFieldReference(fieldID)) return false;
+        const parentID = fieldID.slice(1, -1);
+        return parentID === 'building' || parentID.startsWith('building/');
+    });
+}
+
+/**
+ * Move underground/roof level fields into default fields (after `building/levels`
+ * when present, else after `height` or `building`, else at the end). Removes them
+ * from moreFields so they are always visible, not hidden behind "+ add field".
+ *
+ * @param {string[]} fields
+ * @param {string[]} moreFields
+ */
+function promoteBuildingLevelFields(fields, moreFields) {
+    VISIBLE_BUILDING_LEVEL_FIELDS.forEach(id => {
+        removeField(fields, id);
+        removeField(moreFields, id);
+    });
+
+    const anchors = ['building/levels', 'height', 'building'];
+    let anchorIndex = -1;
+    for (const anchor of anchors) {
+        anchorIndex = fields.indexOf(anchor);
+        if (anchorIndex !== -1) break;
+    }
+    if (anchorIndex === -1) {
+        for (const anchor of anchors) {
+            anchorIndex = moreFields.indexOf(anchor);
+            if (anchorIndex !== -1) break;
+        }
+    }
+
+    const insertAt = anchorIndex === -1 ? fields.length : anchorIndex + 1;
+    fields.splice(insertAt, 0, ...VISIBLE_BUILDING_LEVEL_FIELDS);
+}
+
+/**
+ * Show `building:levels:underground` and `roof:levels` on building presets.
+ * Upstream keeps underground levels in moreFields; roof levels is a custom field.
+ * Presets that inherit default fields from `{building}` pick up the base preset.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizeBuildingLevels(presetManager) {
+    presetManager.collection.forEach(preset => {
+        if (!isBuildingPreset(preset)) return;
+
+        const fields = preset.originalFields;
+        const moreFields = preset.originalMoreFields;
+
+        if (fields.length && fields.every(isPresetFieldReference)) return;
+        if (preset.id !== 'building' && inheritsBuildingDefaults(preset)) return;
+
+        promoteBuildingLevelFields(fields, moreFields);
+    });
 }
 

--- a/test/spec/presets/custom/building_levels.js
+++ b/test/spec/presets/custom/building_levels.js
@@ -1,0 +1,164 @@
+import { loadCustomDistJson } from './setup.js';
+
+/** Minimal upstream building presets for level-field promotion tests. */
+const UPSTREAM_BUILDING_PRESETS = {
+    building: {
+        icon: 'maki-home',
+        fields: ['name', 'building', 'building/levels', 'height', 'address'],
+        moreFields: [
+            'architect',
+            'building/colour',
+            'building/levels/underground',
+            'building/material',
+            'roof/height'
+        ],
+        geometry: ['area'],
+        tags: { building: '*' },
+        name: 'Building'
+    },
+    'building/residential': {
+        icon: 'maki-residential-community',
+        fields: ['{building}'],
+        moreFields: ['{building}'],
+        geometry: ['area'],
+        tags: { building: 'residential' },
+        name: 'Residential Building'
+    },
+    'building/apartments': {
+        icon: 'maki-building',
+        fields: ['{building}', 'building/flats'],
+        moreFields: ['{building}'],
+        geometry: ['area'],
+        tags: { building: 'apartments' },
+        name: 'Apartment Building'
+    },
+    'building/roof': {
+        icon: 'maki-shelter',
+        fields: ['building', 'height', 'layer_1'],
+        moreFields: [
+            'address',
+            'building/levels',
+            'building/levels/underground',
+            'roof/height'
+        ],
+        geometry: ['area'],
+        tags: { building: 'roof' },
+        name: 'Roof'
+    },
+    'building/hangar': {
+        icon: 'temaki-hangar',
+        fields: ['name'],
+        moreFields: ['{building}'],
+        geometry: ['area'],
+        tags: { building: 'hangar' },
+        name: 'Hangar Building'
+    },
+    'building/garages': {
+        icon: 'fas-warehouse',
+        fields: ['capacity'],
+        moreFields: ['building', 'building/levels', 'height', '{building}'],
+        geometry: ['area'],
+        tags: { building: 'garages' },
+        name: 'Garages'
+    },
+    'building/garage': {
+        icon: 'fas-warehouse',
+        fields: ['{building/garages}'],
+        moreFields: ['{building/garages}'],
+        geometry: ['area'],
+        tags: { building: 'garage' },
+        searchable: false,
+        name: '{building/garages}'
+    },
+    'highway/residential': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway'],
+        geometry: ['line'],
+        tags: { highway: 'residential' },
+        name: 'Residential Road'
+    }
+};
+
+/** Upstream field defs needed by the tests (underground is in the schema). */
+const UPSTREAM_BUILDING_FIELDS = {
+    'building/levels': {
+        key: 'building:levels',
+        type: 'number',
+        minValue: 0,
+        label: 'Levels'
+    },
+    'building/levels/underground': {
+        key: 'building:levels:underground',
+        type: 'number',
+        minValue: 0,
+        label: 'Underground Levels'
+    }
+};
+
+describe('building level fields (custom_fields)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_BUILDING_PRESETS;
+        iD.fileFetcher.cache().preset_fields = {
+            ...UPSTREAM_BUILDING_FIELDS,
+            'roof/levels': customFields['roof/levels']
+        };
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    const expectLevelFieldsAfter = (id, anchor) => {
+        it(`${id} shows underground and roof levels after ${anchor}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            const fields = preset.originalFields;
+            const anchorIndex = fields.indexOf(anchor);
+            expect(anchorIndex, `${id} fields`).to.be.at.least(0);
+            expect(fields[anchorIndex + 1]).to.equal('building/levels/underground');
+            expect(fields[anchorIndex + 2]).to.equal('roof/levels');
+            expect(preset.originalMoreFields.indexOf('building/levels/underground')).to.equal(-1);
+            expect(preset.originalMoreFields.indexOf('roof/levels')).to.equal(-1);
+        });
+    };
+
+    expectLevelFieldsAfter('building', 'building/levels');
+    expectLevelFieldsAfter('building/roof', 'height');
+    expectLevelFieldsAfter('building/garages', 'capacity');
+
+    it('building/hangar appends level fields to default fields', function() {
+        const preset = iD.presetManager.item('building/hangar');
+        const fields = preset.originalFields;
+        expect(fields[fields.length - 2]).to.equal('building/levels/underground');
+        expect(fields[fields.length - 1]).to.equal('roof/levels');
+    });
+
+    const inheritsFromBuilding = [
+        'building/residential',
+        'building/apartments'
+    ];
+
+    inheritsFromBuilding.forEach(function(id) {
+        it(`${id} inherits level fields from {building}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
+            expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+            const resolved = preset.fields();
+            const keys = resolved.map(f => f.key);
+            expect(keys.indexOf('building:levels:underground')).to.be.at.least(0);
+            expect(keys.indexOf('roof:levels')).to.be.at.least(0);
+        });
+    });
+
+    it('does not add level fields to non-building presets', function() {
+        const preset = iD.presetManager.item('highway/residential');
+        expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
+        expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+    });
+
+    it('skips building presets that only inherit fields from a parent', function() {
+        const preset = iD.presetManager.item('building/garage');
+        expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
+        expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+    });
+});

--- a/test/spec/presets/custom/setup.js
+++ b/test/spec/presets/custom/setup.js
@@ -18,7 +18,7 @@ function assertCustomDistBuilt() {
 }
 
 /** @returns {Promise<{ customFields: object, customPresets: object }>} */
-async function loadCustomDistJson() {
+export async function loadCustomDistJson() {
     assertCustomDistBuilt();
     const [{ default: customFields }, { default: customPresets }] = await Promise.all([
         import(pathToFileURL(CUSTOM_FIELDS_PATH).href),


### PR DESCRIPTION
## Summary
- Promote `building:levels:underground` from moreFields to default fields on building presets (upstream keeps it hidden behind "+ add field").
- Add custom `roof:levels` field and show it by default alongside underground levels.
- Presets inheriting `{building}` pick up the base preset; special cases (`building/roof`, `building/garages`, `building/hangar`, etc.) are handled explicitly.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/building_levels.js` (8 tests)
- [x] Select a generic building → underground levels and roof levels visible after "Levels"
- [x] Select `building=roof` or `building=garages` → same fields visible without opening more fields
- [x] Select a road preset → fields not shown