### PR TITLE
Add zebra footway crossing presets for customers and private access

### DIFF
--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
@@ -24,6 +24,14 @@ export const FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS = [
     'access_restricted'
 ] as const;
 
+/** Uncontrolled zebra crossings with fixed `access` (use `access_restricted` field). */
+export const FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS = [
+    'crossing',
+    '{@templates/crossing/markings_yes}',
+    'surface',
+    'access_restricted'
+] as const;
+
 export const FOOTWAY_CROSSING_MORE_FIELDS = [
     '{@templates/crossing/defaults}',
     '{@templates/crossing/geometry_way_more}',

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
@@ -8,7 +8,8 @@ import {
     FOOTWAY_CROSSING_TRAFFIC_SIGNALS_MORE_FIELDS,
     FOOTWAY_CROSSING_UNCONTROLLED_FIELDS,
     FOOTWAY_CROSSING_UNMARKED_FIELDS,
-    FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS
+    FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS,
+    FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS
 } from './footway_crossing_fields';
 import { type CrossingType, type MarkingSlug, MARKING_TAG } from '../crossing_shared';
 
@@ -95,6 +96,22 @@ const UNMARKED_EXTRA_VARIANTS: UnmarkedExtraVariant[] = [
     }
 ];
 
+/** v5 zebra footway crossings with restricted access. */
+const ZEBRA_ACCESS_VARIANTS: UnmarkedExtraVariant[] = [
+    {
+        id: 'highway/footway/crossing/uncontrolled-zebra_customers',
+        extraTags: { access: 'customers' },
+        fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    },
+    {
+        id: 'highway/footway/crossing/uncontrolled-zebra_private',
+        extraTags: { access: 'private' },
+        fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    }
+];
+
 const FOOTWAY_CROSSING_REMOVE_WILDCARDS = { bicycle: ANY, foot: ANY, segregated: ANY } as const;
 
 function unmarkedExtraPreset(variant: UnmarkedExtraVariant): CustomPreset {
@@ -114,6 +131,33 @@ function unmarkedExtraPreset(variant: UnmarkedExtraVariant): CustomPreset {
         tags,
         addTags: { ...tags },
         removeTags: buildRemoveTags({ ...tags }, variant.removeWildcards ?? FOOTWAY_CROSSING_REMOVE_WILDCARDS),
+        matchScore: 2,
+        reference: FOOTWAY_CROSSING_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+function zebraAccessPreset(variant: UnmarkedExtraVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'footway',
+        footway: 'crossing',
+        crossing: 'uncontrolled',
+        'crossing:markings': 'zebra',
+        ...variant.extraTags
+    };
+    const addTags: Record<string, string> = {
+        ...tags,
+        surface: 'asphalt'
+    };
+
+    return {
+        icon: 'temaki-pedestrian_crosswalk',
+        geometry: ['line'],
+        fields: [...variant.fields],
+        moreFields: [...FOOTWAY_CROSSING_MORE_FIELDS],
+        tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, variant.removeWildcards ?? FOOTWAY_CROSSING_REMOVE_WILDCARDS),
         matchScore: 2,
         reference: FOOTWAY_CROSSING_REFERENCE,
         name: presetNameEn(variant.id)
@@ -169,5 +213,6 @@ function footwayCrossingPreset(variant: FootwayCrossingVariant): CustomPreset {
 
 export const footwayCrossingVariantPresets: Record<string, CustomPreset> = {
     ...Object.fromEntries(buildVariantList().map((v) => [v.id, footwayCrossingPreset(v)] as const)),
-    ...Object.fromEntries(UNMARKED_EXTRA_VARIANTS.map((v) => [v.id, unmarkedExtraPreset(v)] as const))
+    ...Object.fromEntries(UNMARKED_EXTRA_VARIANTS.map((v) => [v.id, unmarkedExtraPreset(v)] as const)),
+    ...Object.fromEntries(ZEBRA_ACCESS_VARIANTS.map((v) => [v.id, zebraAccessPreset(v)] as const))
 };

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -364,6 +364,16 @@
         "terms": "uzns, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra",
         "aliases": "uzns"
     },
+    "highway/footway/crossing/uncontrolled-zebra_customers": {
+        "name": "Uncontrolled Zebra Footway Crossing (Customers)",
+        "terms": "uzcn, uzc, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, customers",
+        "aliases": "uzcn"
+    },
+    "highway/footway/crossing/uncontrolled-zebra_private": {
+        "name": "Uncontrolled Zebra Footway Crossing (Private)",
+        "terms": "uznp, uzp, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, private",
+        "aliases": "uznp"
+    },
     "highway/footway/crossing/unmarked": {
         "name": "Unmarked Footway Crossing",
         "terms": "uns, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -364,6 +364,16 @@
         "terms": "uzns, uzns, uz, zns, zuns, uczns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, zébrée, passage zébré, bandes zébrées",
         "aliases": "uzns"
     },
+    "highway/footway/crossing/uncontrolled-zebra_customers": {
+        "name": "Traversée piétonne — Zébrée (clients)",
+        "terms": "uzcn, uzc, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, clients",
+        "aliases": "uzcn"
+    },
+    "highway/footway/crossing/uncontrolled-zebra_private": {
+        "name": "Traversée piétonne — Zébrée (privé)",
+        "terms": "uznp, uzp, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, privé",
+        "aliases": "uznp"
+    },
     "highway/footway/crossing/unmarked": {
         "name": "Traversée piétonne — Non marqué",
         "terms": "uns, uns, un, traversée piétonne, passage piéton, passage piéton, traversée, non marqué, sans marquage",

--- a/test/spec/presets/custom/footway_crossing.js
+++ b/test/spec/presets/custom/footway_crossing.js
@@ -62,4 +62,39 @@ describe('custom presets — footway crossing', function() {
             access: 'customers'
         });
     });
+
+    const zebraAccessCases = [
+        {
+            id: 'highway/footway/crossing/uncontrolled-zebra_customers',
+            access: 'customers',
+            name: 'Uncontrolled Zebra Footway Crossing (Customers)'
+        },
+        {
+            id: 'highway/footway/crossing/uncontrolled-zebra_private',
+            access: 'private',
+            name: 'Uncontrolled Zebra Footway Crossing (Private)'
+        }
+    ];
+
+    zebraAccessCases.forEach(function({ id, access, name }) {
+        it(`${id} sets zebra crossing tags, default asphalt, and ${access} access`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.name()).to.equal(name);
+            expect(preset.tags).to.include({
+                highway: 'footway',
+                footway: 'crossing',
+                crossing: 'uncontrolled',
+                'crossing:markings': 'zebra',
+                access
+            });
+            expect(preset.tags).to.not.have.property('surface');
+            expect(preset.addTags).to.include({
+                surface: 'asphalt',
+                access
+            });
+            expect(preset.originalFields).to.include('surface');
+            expect(preset.originalFields).to.include('access_restricted');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Add `highway/footway/crossing/uncontrolled-zebra_customers` and `uncontrolled-zebra_private` custom presets (v5 parity).
- Default `surface=asphalt` on creation; `surface` and `access_restricted` remain editable like other crossing variants.
- Locales en/fr with search aliases `uzcn` / `uznp`.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/footway_crossing.js` (8 tests)
- [ ] Draw a zebra customers crossing → `access=customers`, `crossing:markings=zebra`, default asphalt
- [ ] Change surface to concrete in the inspector
- [ ] Same for private variant