### PR TITLE
Add vertex preset for tactile_paving=yes

### DIFF
--- a/data/custom-tagging/src/presets/highway/crossing/tactile_paving_yes.ts
+++ b/data/custom-tagging/src/presets/highway/crossing/tactile_paving_yes.ts
@@ -1,0 +1,20 @@
+import type { CustomPreset } from '../../../types';
+import { presetNameEn } from '../../../preset_name_en';
+
+const ID = 'highway/crossing/tactile_paving_yes';
+const tags = { tactile_paving: 'yes' };
+
+/** Vertex-only preset to tag tactile paving on a crossing node (v5 parity). */
+export const tactilePavingYesPreset: CustomPreset = {
+    icon: 'temaki-rumble_strip',
+    geometry: ['vertex'],
+    fields: ['tactile_paving'],
+    tags,
+    addTags: tags,
+    reference: { key: 'tactile_paving', value: 'yes' },
+    name: presetNameEn(ID)
+};
+
+export const tactilePavingYesPresets: Record<string, CustomPreset> = {
+    [ID]: tactilePavingYesPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -14,6 +14,7 @@ import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_
 import { serviceVariantPresets } from './presets/highway/service_variants';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
+import { tactilePavingYesPresets } from './presets/highway/crossing/tactile_paving_yes';
 import { stopVariantPresets } from './presets/highway/stop_variants';
 import { trafficSignalsVariantPresets } from './presets/highway/traffic_signals_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
@@ -62,6 +63,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...serviceVariantPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,
+    ...tactilePavingYesPresets,
     ...stopVariantPresets,
     ...trafficSignalsVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -814,6 +814,11 @@
         "terms": "std, dismount, bicycle, steps, stairs, staircase, stairway",
         "aliases": "std"
     },
+    "highway/crossing/tactile_paving_yes": {
+        "name": "Tactile paving (yes)",
+        "terms": "tp, tactile paving, tactile_paving, yes, rumble strip",
+        "aliases": "tp"
+    },
     "highway/stop_forward_minor": {
         "name": "Stop Sign Forward (minor)",
         "terms": "stfm, stop, halt, sign, forward, minor",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -814,6 +814,11 @@
         "terms": "std, vélo à pied, descendre du vélo, escalier, escaliers, marches",
         "aliases": "std"
     },
+    "highway/crossing/tactile_paving_yes": {
+        "name": "Surface podotactile (oui)",
+        "terms": "tp, podotactile, tactile, oui, bande podotactile",
+        "aliases": "tp"
+    },
     "highway/stop_forward_minor": {
         "name": "Panneau d'arrêt avant (priorité mineure)",
         "terms": "stfm, arrêt, stop, panneau, avant, forward, minor, mineure",

--- a/test/spec/presets/custom/tactile_paving_yes.js
+++ b/test/spec/presets/custom/tactile_paving_yes.js
@@ -1,0 +1,24 @@
+import { loadCustomPresets } from './setup.js';
+
+const ID = 'highway/crossing/tactile_paving_yes';
+const TAGS = { tactile_paving: 'yes' };
+
+describe('custom presets — tactile paving (yes)', function() {
+    loadCustomPresets();
+
+    it(`defines ${ID}`, function() {
+        const preset = iD.presetManager.item(ID);
+        expect(preset, ID).to.exist;
+        expect(preset.tags).to.eql(TAGS);
+        expect(preset.addTags).to.eql(TAGS);
+        expect(preset.geometry).to.eql(['vertex']);
+        expect(preset.fields().map((f) => f.id)).to.include('tactile_paving');
+        expect(preset.icon).to.equal('temaki-rumble_strip');
+    });
+
+    it(`finds ${ID} by alias tp`, function() {
+        const pool = iD.presetManager.matchAllGeometry(['vertex']);
+        const found = pool.search('tp', 'vertex').collection.map((p) => p.id);
+        expect(found).to.include(ID);
+    });
+});


### PR DESCRIPTION
## Summary
- Add custom preset `highway/crossing/tactile_paving_yes` for vertex geometry only (`tactile_paving=yes`)
- v5 parity: icon `temaki-rumble_strip`, search alias `tp`, EN/FR locales
- No CSS changes — existing vertex styling applies

## Test plan
- [ ] `npx vitest run test/spec/presets/custom/tactile_paving_yes.js`
- [ ] On a crossing node, search `tp` and apply preset; verify `tactile_paving=yes` is set
- [ ] Confirm icon renders on the vertex (no style regression)