### PR TITLE
Fix crossing_ways validation on long roads

### DIFF
--- a/modules/osm/way.ts
+++ b/modules/osm/way.ts
@@ -263,30 +263,30 @@ export class osmWay extends OsmAbstractEntity {
 
     // returns an array of objects representing the segments between the nodes in this way
     segments(graph: coreGraph) {
-        const segmentExtent = (graph: coreGraph) => {
-            var n1 = graph.hasEntity<osmNode>(this.nodes[0]);
-            var n2 = graph.hasEntity<osmNode>(this.nodes[1]);
-            return n1 && n2 && geoExtent([
-                [
-                    Math.min(n1.loc[0], n2.loc[0]),
-                    Math.min(n1.loc[1], n2.loc[1])
-                ],
-                [
-                    Math.max(n1.loc[0], n2.loc[0]),
-                    Math.max(n1.loc[1], n2.loc[1])
-                ]
-            ]);
-        };
-
         return graph.transient(this, 'segments', () => {
             var segments: Segment[] = [];
             for (var i = 0; i < this.nodes.length - 1; i++) {
+                const nodeA = this.nodes[i];
+                const nodeB = this.nodes[i + 1];
                 segments.push({
                     id: `${this.id}-${i}`,
                     wayId: this.id,
                     index: i,
-                    nodes: [this.nodes[i], this.nodes[i + 1]],
-                    extent: segmentExtent
+                    nodes: [nodeA, nodeB],
+                    extent: (g: coreGraph) => {
+                        var n1 = g.hasEntity<osmNode>(nodeA);
+                        var n2 = g.hasEntity<osmNode>(nodeB);
+                        return n1 && n2 && geoExtent([
+                            [
+                                Math.min(n1.loc[0], n2.loc[0]),
+                                Math.min(n1.loc[1], n2.loc[1])
+                            ],
+                            [
+                                Math.max(n1.loc[0], n2.loc[0]),
+                                Math.max(n1.loc[1], n2.loc[1])
+                            ]
+                        ]);
+                    }
                 });
             }
             return segments;

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -227,6 +227,94 @@ export function validationCrossingWays(context) {
     }
 
 
+    function isCrossingPathWay(way) {
+        var tags = way.tags;
+        if (tags.footway === 'crossing') return true;
+        return ['marked', 'unmarked', 'traffic_signals', 'uncontrolled'].indexOf(tags.crossing) !== -1;
+    }
+
+
+    function edgeAtNode(way, nodeId) {
+        var idx = way.nodes.indexOf(nodeId);
+        if (idx === -1) return null;
+        if (idx < way.nodes.length - 1) return [way.nodes[idx], way.nodes[idx + 1]];
+        if (idx > 0) return [way.nodes[idx - 1], way.nodes[idx]];
+        return null;
+    }
+
+
+    function findSharedVertexCrossings(way1, graph) {
+        var edgeCrossInfos = [];
+        if (way1.type !== 'way') return edgeCrossInfos;
+
+        var taggedFeature1 = getFeatureWithFeatureTypeTagsForWay(way1, graph);
+        var way1FeatureType = getFeatureType(taggedFeature1, graph);
+        if (way1FeatureType !== 'highway') return edgeCrossInfos;
+
+        var way1IsCrossingPath = isCrossingPathWay(way1);
+        var checkedPairs = {};
+
+        graph.childNodes(way1).forEach(function(node) {
+            if (node.isCrossing()) return;
+
+            graph.parentWays(node).forEach(function(way2) {
+                if (way2.id === way1.id) return;
+
+                var pairKey = way1.id < way2.id ? way1.id + '|' + way2.id : way2.id + '|' + way1.id;
+                if (checkedPairs[pairKey]) return;
+
+                var taggedFeature2 = getFeatureWithFeatureTypeTagsForWay(way2, graph);
+                var way2FeatureType = getFeatureType(taggedFeature2, graph);
+                if (way2FeatureType !== 'highway') return;
+
+                var pathWay = way1;
+                var roadWay = way2;
+                var pathFeature = taggedFeature1;
+                var roadFeature = taggedFeature2;
+                var pathFeatureType = way1FeatureType;
+                var roadFeatureType = way2FeatureType;
+
+                if (isCrossingPathWay(way2) && !way1IsCrossingPath) {
+                    pathWay = way2;
+                    roadWay = way1;
+                    pathFeature = taggedFeature2;
+                    roadFeature = taggedFeature1;
+                    pathFeatureType = way2FeatureType;
+                    roadFeatureType = way1FeatureType;
+                } else if (!way1IsCrossingPath) {
+                    return;
+                }
+
+                var entity1IsPath = osmPathHighwayTagValues[pathFeature.tags.highway];
+                var entity2IsPath = osmPathHighwayTagValues[roadFeature.tags.highway];
+                if (!entity1IsPath || entity2IsPath) return;
+
+                if (isLegitCrossing(pathFeature.tags, pathFeatureType, roadFeature.tags, roadFeatureType)) {
+                    return;
+                }
+
+                var connectionTags = tagsForConnectionNodeIfAllowed(pathFeature, roadFeature, graph);
+                if (!connectionTags) return;
+
+                var edge1 = edgeAtNode(pathWay, node.id);
+                var edge2 = edgeAtNode(roadWay, node.id);
+                if (!edge1 || !edge2) return;
+
+                checkedPairs[pairKey] = true;
+                edgeCrossInfos.push({
+                    wayInfos: [
+                        { way: pathWay, featureType: pathFeatureType, edge: edge1 },
+                        { way: roadWay, featureType: roadFeatureType, edge: edge2 }
+                    ],
+                    crossPoint: node.loc.slice()
+                });
+            });
+        });
+
+        return edgeCrossInfos;
+    }
+
+
     function findCrossingsByWay(way1, graph, tree) {
         var edgeCrossInfos = [];
         if (way1.type !== 'way') return edgeCrossInfos;
@@ -328,6 +416,17 @@ export function validationCrossingWays(context) {
                 }
             }
         }
+
+        var sharedVertexCrossings = findSharedVertexCrossings(way1, graph);
+        for (i = 0; i < sharedVertexCrossings.length; i++) {
+            var sharedCrossing = sharedVertexCrossings[i];
+            var duplicate = edgeCrossInfos.some(function(existing) {
+                return existing.crossPoint[0].toFixed(4) === sharedCrossing.crossPoint[0].toFixed(4) &&
+                    existing.crossPoint[1].toFixed(4) === sharedCrossing.crossPoint[1].toFixed(4);
+            });
+            if (!duplicate) edgeCrossInfos.push(sharedCrossing);
+        }
+
         return edgeCrossInfos;
     }
 

--- a/test/spec/osm/way.js
+++ b/test/spec/osm/way.js
@@ -1096,4 +1096,17 @@ describe('iD.osmWay', function() {
         });
     });
 
+    it('gives each segment its own spatial extent', function() {
+        var n1 = new iD.osmNode({ id: 'n1', loc: [0, 0] });
+        var n2 = new iD.osmNode({ id: 'n2', loc: [1, 0] });
+        var n3 = new iD.osmNode({ id: 'n3', loc: [5, 0] });
+        var way = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'] });
+        var graph = new iD.coreGraph([n1, n2, n3, way]);
+
+        var segments = way.segments(graph);
+        expect(segments).to.have.lengthOf(2);
+        expect(segments[0].extent(graph).bbox()).to.eql({ minX: 0, minY: 0, maxX: 1, maxY: 0 });
+        expect(segments[1].extent(graph).bbox()).to.eql({ minX: 1, minY: 0, maxX: 5, maxY: 0 });
+    });
+
 });

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -280,6 +280,43 @@ describe('iD.validations.crossing_ways', function () {
         verifySingleCrossingIssue(validate(), {});
     });
 
+    it('flags footway crossing a long road away from its first segment', function() {
+        var n1 = new iD.osmNode({ id: 'n-1', loc: [1, 1] });
+        var n2 = new iD.osmNode({ id: 'n-2', loc: [3, 1] });
+        var n3 = new iD.osmNode({ id: 'n-3', loc: [6, 1] });
+        var n4 = new iD.osmNode({ id: 'n-4', loc: [10, 1] });
+        var wRoad = new iD.osmWay({
+            id: 'w-road',
+            nodes: ['n-1', 'n-2', 'n-3', 'n-4'],
+            tags: { highway: 'residential' }
+        });
+
+        var n5 = new iD.osmNode({ id: 'n-5', loc: [7, 0] });
+        var n6 = new iD.osmNode({ id: 'n-6', loc: [7, 2] });
+        var wCross = new iD.osmWay({
+            id: 'w-cross',
+            nodes: ['n-5', 'n-6'],
+            tags: { highway: 'footway', footway: 'crossing', crossing: 'uncontrolled' }
+        });
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(n4),
+            iD.actionAddEntity(n5),
+            iD.actionAddEntity(n6),
+            iD.actionAddEntity(wRoad),
+            iD.actionAddEntity(wCross)
+        );
+
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+        expect(issues[0].type).to.eql('crossing_ways');
+        expect(issues[0].loc).to.eql([7, 1]);
+        expect(issues[0].data.connectionTags).to.eql({ highway: 'crossing', crossing: 'uncontrolled' });
+    });
+
     it('flags road crossing footway', function() {
         createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway' });
         verifySingleCrossingIssue(validate(), { highway: 'crossing' });
@@ -456,6 +493,53 @@ describe('iD.validations.crossing_ways', function () {
     it('flags corridor crossing corridor on the same level', function() {
         createWaysWithOneCrossingPoint({ highway: 'corridor', level: '0' }, { highway: 'corridor', level: '0' });
         verifySingleCrossingIssue(validate(), {});
+    });
+
+    function createCrosswalkConnectedToRoadAtNode(crosswalkTags) {
+        var n1 = new iD.osmNode({ id: 'n-1', loc: [1, 1] });
+        var nMid = new iD.osmNode({ id: 'n-mid', loc: [1.5, 1] });
+        var n2 = new iD.osmNode({ id: 'n-2', loc: [3, 1] });
+        var wRoad = new iD.osmWay({ id: 'w-road', nodes: ['n-1', 'n-mid', 'n-2'], tags: { highway: 'residential' } });
+
+        var n3 = new iD.osmNode({ id: 'n-3', loc: [1.5, 0.5] });
+        var n4 = new iD.osmNode({ id: 'n-4', loc: [1.5, 1.5] });
+        var wCross = new iD.osmWay({
+            id: 'w-cross',
+            nodes: ['n-3', 'n-mid', 'n-4'],
+            tags: crosswalkTags
+        });
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(nMid),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(n4),
+            iD.actionAddEntity(wRoad),
+            iD.actionAddEntity(wCross)
+        );
+    }
+
+    it('flags crossing path connected to road at shared node without crossing tags', function() {
+        createCrosswalkConnectedToRoadAtNode({
+            highway: 'footway',
+            footway: 'crossing',
+            crossing: 'uncontrolled'
+        });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+        expect(issues[0].id).to.eql(issues[1].id);
+        expect(issues[0].type).to.eql('crossing_ways');
+        expect(issues[0].loc).to.eql([1.5, 1]);
+        expect(issues[0].data.connectionTags).to.eql({ highway: 'crossing', crossing: 'uncontrolled' });
+    });
+
+    it('ignores footway sidewalk connected to road at shared node', function() {
+        createCrosswalkConnectedToRoadAtNode({
+            highway: 'footway',
+            footway: 'sidewalk'
+        });
+        expect(validate()).to.have.lengthOf(0);
     });
 
     it('flags road crossing road twice', function() {


### PR DESCRIPTION
## Summary
- Fix v6 regression in `way.segments()`: each segment now gets its own spatial extent (arrow function had bound all segment bboxes to the way's first edge)
- Restores reliable `crossing_ways` warnings when a crosswalk intersects a road away from its first segment
- Also flag tagged crossing paths (`footway=crossing`, etc.) that share a road vertex without `highway=crossing` on the node

## Root cause
Upstream JS uses `function segmentExtent(graph)` so `this` is the segment object. The v6 TypeScript port used an arrow function inside `segments()`, capturing the way as `this` — the segment R-tree only indexed the first edge of each way.

## Test plan
- [ ] `npx vitest run test/spec/osm/way.js -t "segment its own"`
- [ ] `npx vitest run test/spec/validations/crossing_ways.js`
- [ ] Draw a crosswalk across the middle of a long `highway=residential` way → warning appears after finish/select
- [ ] Confirm fix on a short 2-node road still works