### PR TITLE
Fix: visual feedback when sidewalks/crossings/cycleways lack name

### DIFF
--- a/config/highway_validation_tag_classes.js
+++ b/config/highway_validation_tag_classes.js
@@ -57,6 +57,9 @@ export function appendHighwayValidationTagClasses(classes, t) {
     let widthLanesBackwardStartCount = null;
     let widthLanesBackwardEndCount = null;
 
+    let footway = null;
+    let hasCyclewayTag = false;
+    let hasName = false;
     let isOneWay = false;
     let hasLanes = false;
     let hasLanesForward = false;
@@ -69,6 +72,9 @@ export function appendHighwayValidationTagClasses(classes, t) {
         if (k === 'indoor') indoor = v;
         if (k === 'access') access = v;
         if (k === 'foot' || k === 'routing:foot') foot = v;
+        if (k === 'footway') footway = v;
+        if (k === 'cycleway') hasCyclewayTag = true;
+        if (k === 'name' && v) hasName = true;
         if (k === 'crossing') crossing = v;
         if (k === 'crossing:markings') crossingMarkings = v;
         if (k === 'segregated') segregated = v;
@@ -210,5 +216,13 @@ export function appendHighwayValidationTagClasses(classes, t) {
         if ((!surface || surface === 'paved') && indoor !== 'yes') {
             classes.push('tag-surface-undefined');
         }
+    }
+
+    // v5 parity: orange dashed over-stroke when name is missing (quebec lenses CSS)
+    const isSidewalk = footway !== null;
+    const isCrossing = crossing !== null;
+    const isStandaloneCycleway = highway === 'cycleway';
+    if (!hasName && (isSidewalk || isStandaloneCycleway || isCrossing || hasCyclewayTag)) {
+        classes.push('tag-name-no');
     }
 }

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -40,6 +40,18 @@ path.line.over-stroke {
     fill: none;
 }
 
+/* v5 fork: default over-stroke width on paths/cycleways (transparent until a rule sets colour). */
+path.line.over-stroke.tag-highway-track,
+path.line.over-stroke.tag-highway-path,
+path.line.over-stroke.tag-highway-footway,
+path.line.over-stroke.tag-highway-cycleway,
+path.line.over-stroke.tag-highway-bridleway,
+path.line.over-stroke.tag-highway-corridor,
+path.line.over-stroke.tag-highway-pedestrian,
+path.line.over-stroke.tag-highway-steps {
+    stroke-width: 2;
+}
+
 .preset-icon .icon.tag-highway-motorway,
 .preset-icon .icon.tag-highway-motorway_link {
     color: #CF2081;
@@ -919,4 +931,17 @@ path.line.casing.tag-highway.tag-placement-transition {
 }
 path.line.stroke.tag-highway.tag-placement-transition {
     stroke-width: 12;
+}
+
+/* sidewalk/crossing/cycleway no-name — orange dashed over-stroke (v5 parity) */
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-sidewalk.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-traffic_island.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-highway-cycleway.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-highway-cycleway.tag-name-no {
+    stroke-width: 1 !important;
+    stroke-dasharray: 6, 6 !important;
+    stroke: rgb(255, 81, 0) !important;
+    stroke-linecap: butt !important;
 }

--- a/lenses/v5-quebec-surfaces.css
+++ b/lenses/v5-quebec-surfaces.css
@@ -496,7 +496,6 @@ path.line.casing.tag-motor_vehicle-destination:not(.tag-highway-footway):not(.ta
 
 /* cycleway unmarked crossing */
 
-
 /* sidewalk separate */
 path.line.stroke.tag-sidewalk-separate {
   stroke-width: 8;
@@ -652,6 +651,19 @@ path.line.over-stroke.tag-highway.tag-surface-sand {
 }
 path.line.over-stroke.tag-highway.tag-surface-wood {
   stroke: rgb(167, 94, 0);
+}
+
+/* sidewalk/crossing/cycleway no-name — after surface over-stroke so it wins in cascade */
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-sidewalk.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-traffic_island.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-highway-cycleway.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-highway-cycleway.tag-name-no {
+  stroke-width: 1 !important;
+  stroke-dasharray: 6, 6 !important;
+  stroke: rgb(255, 81, 0) !important;
+  stroke-linecap: butt !important;
 }
 
 

--- a/lenses/v5-quebec.css
+++ b/lenses/v5-quebec.css
@@ -577,14 +577,17 @@ svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-sidewalk-shared-right
   stroke:  rgb(255, 124, 244);
 }
 
-/* sidewalk/crossings no-name */
+/* sidewalk/crossing/cycleway no-name */
 svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-sidewalk.tag-name-no,
 svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-traffic_island.tag-name-no,
-svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-name-no {
-  stroke-width: 1;
-  stroke-dasharray: 6, 6;
-  stroke:  rgb(255, 81, 0);
-  stroke-linecap: butt;
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-footway-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-highway-cycleway.tag-name-no,
+svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-highway-cycleway.tag-name-no {
+  stroke-width: 1 !important;
+  stroke-dasharray: 6, 6 !important;
+  stroke: rgb(255, 81, 0) !important;
+  stroke-linecap: butt !important;
 }
 
 /* cycleway separate (no biicycle access) */

--- a/modules/svg/layers.js
+++ b/modules/svg/layers.js
@@ -52,8 +52,10 @@ export function svgLayers(projection, context) {
 
         svg = svg.enter()
             .append('svg')
+            .attr('id', 'surface')
             .attr('class', 'surface')
-            .merge(svg);
+            .merge(svg)
+            .attr('id', 'surface');
 
         var defs = svg.selectAll('.surface-defs')
             .data([0]);

--- a/test/spec/svg/layers.js
+++ b/test/spec/svg/layers.js
@@ -14,6 +14,7 @@ describe('iD.svgLayers', function () {
     it('creates a surface', function () {
         container.call(iD.svgLayers(projection, context));
         expect(container.selectAll('svg').classed('surface')).to.be.true;
+        expect(container.select('svg#surface').empty()).to.be.false;
     });
 
     it('creates surface defs', function () {

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -378,6 +378,34 @@ describe('iD.svgTagClasses', function () {
         ['tag-fixme', { highway: 'residential', fixme: 'yes' }]
     ];
 
+    const nameNoCases = [
+        ['tag-name-no', { highway: 'footway', footway: 'sidewalk' }],
+        ['tag-name-no', { highway: 'footway', footway: 'traffic_island' }],
+        ['tag-name-no', { highway: 'footway', footway: 'crossing', crossing: 'unmarked' }],
+        ['tag-name-no', { highway: 'cycleway' }],
+        ['tag-name-no', { highway: 'cycleway', crossing: 'marked' }],
+        ['tag-name-no', { highway: 'residential', cycleway: 'lane' }]
+    ];
+
+    for (const [expectedClass, tags] of nameNoCases) {
+        it(`adds ${expectedClass} when name missing (${JSON.stringify(tags)})`, function() {
+            const sel = d3.select(document.createElement('div'));
+            sel
+                .datum(new iD.osmWay({ tags }))
+                .call(iD.svgTagClasses());
+            expect(sel.classed(expectedClass)).to.be.true;
+        });
+    }
+
+    it('does not add tag-name-no when name is set on sidewalk', function() {
+        selection
+            .datum(new iD.osmWay({
+                tags: { highway: 'footway', footway: 'sidewalk', name: 'Rue Example' }
+            }))
+            .call(iD.svgTagClasses());
+        expect(selection.classed('tag-name-no')).to.be.false;
+    });
+
     for (const [expectedClass, tags] of validationCases) {
         it(`adds ${expectedClass} (v5 validation)`, function() {
             const sel = d3.select(document.createElement('div'));


### PR DESCRIPTION
## Summary
- Emit `tag-name-no` when `name` is missing on sidewalks (`footway=*`), crossings (`crossing=*` / `footway=crossing`), standalone cycleways, and road `cycleway=*` tags (v5 parity).
- Restore `id="surface"` on the map SVG so `svg#surface` lens selectors apply (regression from upstream refactor).
- Add orange dashed over-stroke CSS in core `30_highways.css` and Québec lenses (`v5-quebec`, `v5-quebec-surfaces`).

## Test plan
- [x] `npx vitest run test/spec/svg/tag_classes.js test/spec/svg/layers.js` (64 tests)
- [ ] Hard refresh editor; select a `footway=sidewalk` without `name` → orange dashed over-stroke
- [ ] Re-import Québec lens CSS if using an older copy in localStorage