### PR TITLE
Presets: v5 cycleway paths (no foot, segregated, mixed)

### DIFF
--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_path_variants.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_path_variants.ts
@@ -1,0 +1,60 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+
+const CYCLEWAY_REFERENCE = { key: 'highway', value: 'cycleway' } as const;
+
+const CYCLEWAY_PATH_ADD = {
+    lcn: 'yes',
+    surface: 'asphalt'
+} as const;
+
+interface CyclewayPathVariant {
+    id: string;
+    tags: Record<string, string>;
+    icon: string;
+}
+
+const CYCLEWAY_PATH_VARIANTS: CyclewayPathVariant[] = [
+    {
+        id: 'highway/cycleway',
+        tags: { highway: 'cycleway', foot: 'no' },
+        icon: 'fas-biking'
+    },
+    {
+        id: 'highway/cycleway/bicycle_foot',
+        tags: { highway: 'cycleway', foot: 'designated', segregated: 'no' },
+        icon: 'temaki-pedestrian_and_cyclist'
+    },
+    {
+        id: 'highway/cycleway/bicycle_foot_segregated',
+        tags: { highway: 'cycleway', foot: 'designated', segregated: 'yes' },
+        icon: 'temaki-pedestrian_and_cyclist'
+    }
+];
+
+/**
+ * v5 parity cycleway path presets. `bicycle=designated` is omitted from tags and
+ * addTags (implicit for `highway=cycleway`); removeTags clears it when switching.
+ *
+ * @param variant - preset id and discriminating tags
+ */
+function cyclewayPathPreset(variant: CyclewayPathVariant): CustomPreset {
+    const addTags = { ...variant.tags, ...CYCLEWAY_PATH_ADD };
+    return {
+        icon: variant.icon,
+        geometry: ['line'],
+        fields: ['{highway/cycleway}'],
+        moreFields: ['{highway/cycleway}'],
+        tags: variant.tags,
+        addTags,
+        removeTags: buildRemoveTags(addTags, { bicycle: ANY }),
+        matchScore: 2,
+        reference: CYCLEWAY_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+export const cyclewayPathVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    CYCLEWAY_PATH_VARIANTS.map((v) => [v.id, cyclewayPathPreset(v)] as const)
+);

--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_path_variants.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_path_variants.ts
@@ -5,7 +5,6 @@ import { presetNameEn } from '../../../preset_name_en';
 const CYCLEWAY_REFERENCE = { key: 'highway', value: 'cycleway' } as const;
 
 const CYCLEWAY_PATH_ADD = {
-    lcn: 'yes',
     surface: 'asphalt'
 } as const;
 
@@ -34,8 +33,8 @@ const CYCLEWAY_PATH_VARIANTS: CyclewayPathVariant[] = [
 ];
 
 /**
- * v5 parity cycleway path presets. `bicycle=designated` is omitted from tags and
- * addTags (implicit for `highway=cycleway`); removeTags clears it when switching.
+ * v5 parity cycleway path presets. `bicycle=designated` and `lcn=yes` are omitted
+ * from tags and addTags; removeTags clears them when switching presets.
  *
  * @param variant - preset id and discriminating tags
  */
@@ -48,7 +47,7 @@ function cyclewayPathPreset(variant: CyclewayPathVariant): CustomPreset {
         moreFields: ['{highway/cycleway}'],
         tags: variant.tags,
         addTags,
-        removeTags: buildRemoveTags(addTags, { bicycle: ANY }),
+        removeTags: buildRemoveTags(addTags, { bicycle: ANY, lcn: ANY }),
         matchScore: 2,
         reference: CYCLEWAY_REFERENCE,
         name: presetNameEn(variant.id)

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -20,6 +20,7 @@ import { stopVariantPresets } from './presets/highway/stop_variants';
 import { trafficSignalsVariantPresets } from './presets/highway/traffic_signals_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
 import { cyclewayLink } from './presets/highway/cycleway/cycleway_link';
+import { cyclewayPathVariantPresets } from './presets/highway/cycleway/cycleway_path_variants';
 import { parkingVariantPresets } from './presets/amenity/parking_variants';
 import { accessBarrierPresets } from './presets/barrier/access_barriers';
 import { constructionCompanyPresets } from './presets/office/construction_company';
@@ -68,6 +69,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...tactilePavingYesPresets,
     ...stopVariantPresets,
     ...trafficSignalsVariantPresets,
+    ...cyclewayPathVariantPresets,
     'highway/cycleway/cycleway_link': cyclewayLink,
     ...cyclewayCrossingVariantPresets,
     ...parkingVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -114,6 +114,21 @@
         "name": "Routing Entrance / Exit (yes)",
         "terms": "routing, entrance, yes"
     },
+    "highway/cycleway": {
+        "name": "Cycle Path (no foot)",
+        "terms": "cnf, bicycle path, bike path, cycling path, cycle path, no foot",
+        "aliases": "cnf"
+    },
+    "highway/cycleway/bicycle_foot": {
+        "name": "Cycle & Foot Path (not segregated)",
+        "terms": "cns, bicycle and foot path, bike and pedestrian path, greenway, mixed-use trail, multi-use trail, not segregated",
+        "aliases": "cns"
+    },
+    "highway/cycleway/bicycle_foot_segregated": {
+        "name": "Cycle & Foot Path (segregated)",
+        "terms": "cs, bicycle and foot path, bike and pedestrian path, greenway, mixed-use trail, multi-use trail, segregated",
+        "aliases": "cs"
+    },
     "highway/cycleway/crossing/traffic_signals-dashes_no_foot": {
         "name": "Traffic Signals Dashes Cycleway Crossing No Foot",
         "terms": "ctsdcnf, ctsd, cycleway crossing, traffic signals cycleway crossing, traffic signals crosswalk, traffic signals bicycle crossing, dashes crossing, dashes, no foot",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -114,6 +114,21 @@
         "name": "Entrée de routage / sortie (oui)",
         "terms": "routage, entrée, sortie, oui"
     },
+    "highway/cycleway": {
+        "name": "Piste cyclable (sans piétons)",
+        "terms": "cnf, piste cyclable, voie cyclable, sans piétons, piétons interdits",
+        "aliases": "cnf"
+    },
+    "highway/cycleway/bicycle_foot": {
+        "name": "Piste cyclable et piétons (non ségréguée)",
+        "terms": "cns, piste cyclable et piétons, voie mixte, sentier polyvalent, non ségréguée, mixte",
+        "aliases": "cns"
+    },
+    "highway/cycleway/bicycle_foot_segregated": {
+        "name": "Piste cyclable et piétons (ségréguée)",
+        "terms": "cs, piste cyclable et piétons, voie mixte, sentier polyvalent, ségréguée",
+        "aliases": "cs"
+    },
     "highway/cycleway/crossing/traffic_signals-dashes_no_foot": {
         "name": "Traversée cyclable — Feux, tirets, sans piétons",
         "terms": "ctsdcnf, tsdashnf, traversée cyclable, passage cyclable, passage pour vélo, traversée, feux, feux de circulation, signalisation, tirets, marquage en tirets, sans piétons, piétons interdits",

--- a/test/spec/presets/custom/cycleway.js
+++ b/test/spec/presets/custom/cycleway.js
@@ -1,11 +1,9 @@
 import { loadCustomPresets } from './setup.js';
 
-import { loadCustomPresets } from './setup.js';
-
 const CYCLEWAY_PATH_CASES = [
-    ['highway/cycleway', { highway: 'cycleway', foot: 'no' }, { lcn: 'yes', surface: 'asphalt' }],
-    ['highway/cycleway/bicycle_foot', { highway: 'cycleway', foot: 'designated', segregated: 'no' }, { lcn: 'yes', surface: 'asphalt' }],
-    ['highway/cycleway/bicycle_foot_segregated', { highway: 'cycleway', foot: 'designated', segregated: 'yes' }, { lcn: 'yes', surface: 'asphalt' }]
+    ['highway/cycleway', { highway: 'cycleway', foot: 'no' }, { surface: 'asphalt' }],
+    ['highway/cycleway/bicycle_foot', { highway: 'cycleway', foot: 'designated', segregated: 'no' }, { surface: 'asphalt' }],
+    ['highway/cycleway/bicycle_foot_segregated', { highway: 'cycleway', foot: 'designated', segregated: 'yes' }, { surface: 'asphalt' }]
 ];
 
 const CYCLEWAY_CROSSING_FOOT_MODES = [
@@ -18,14 +16,17 @@ describe('custom presets — cycleway', function() {
     loadCustomPresets();
 
     for (const [id, tags, addTags] of CYCLEWAY_PATH_CASES) {
-        it(`defines ${id} without required bicycle tag`, function() {
+        it(`defines ${id} without required bicycle or lcn tags`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
             expect(preset.tags).to.include(tags);
             expect(preset.tags).to.not.have.property('bicycle');
+            expect(preset.tags).to.not.have.property('lcn');
             expect(preset.addTags).to.include(addTags);
             expect(preset.addTags).to.not.have.property('bicycle');
+            expect(preset.addTags).to.not.have.property('lcn');
             expect(preset.removeTags).to.have.property('bicycle', '*');
+            expect(preset.removeTags).to.have.property('lcn', '*');
             expect(preset.addable()).to.be.true;
         });
     }

--- a/test/spec/presets/custom/cycleway.js
+++ b/test/spec/presets/custom/cycleway.js
@@ -1,7 +1,41 @@
 import { loadCustomPresets } from './setup.js';
 
+import { loadCustomPresets } from './setup.js';
+
+const CYCLEWAY_PATH_CASES = [
+    ['highway/cycleway', { highway: 'cycleway', foot: 'no' }, { lcn: 'yes', surface: 'asphalt' }],
+    ['highway/cycleway/bicycle_foot', { highway: 'cycleway', foot: 'designated', segregated: 'no' }, { lcn: 'yes', surface: 'asphalt' }],
+    ['highway/cycleway/bicycle_foot_segregated', { highway: 'cycleway', foot: 'designated', segregated: 'yes' }, { lcn: 'yes', surface: 'asphalt' }]
+];
+
+const CYCLEWAY_CROSSING_FOOT_MODES = [
+    ['no_foot', { foot: 'no' }],
+    ['not_segregated', { foot: 'designated', segregated: 'no' }],
+    ['segregated', { foot: 'designated', segregated: 'yes' }]
+];
+
 describe('custom presets — cycleway', function() {
     loadCustomPresets();
+
+    for (const [id, tags, addTags] of CYCLEWAY_PATH_CASES) {
+        it(`defines ${id} without required bicycle tag`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.include(tags);
+            expect(preset.tags).to.not.have.property('bicycle');
+            expect(preset.addTags).to.include(addTags);
+            expect(preset.addTags).to.not.have.property('bicycle');
+            expect(preset.removeTags).to.have.property('bicycle', '*');
+            expect(preset.addable()).to.be.true;
+        });
+    }
+
+    it('finds cycleway path presets via search aliases', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        expect(pool.search('cnf', 'line').collection.map((p) => p.id)).to.include('highway/cycleway');
+        expect(pool.search('cns', 'line').collection.map((p) => p.id)).to.include('highway/cycleway/bicycle_foot');
+        expect(pool.search('cs', 'line').collection.map((p) => p.id)).to.include('highway/cycleway/bicycle_foot_segregated');
+    });
 
     it('loads cycleway link preset with expected name', function() {
         const cycleway = iD.presetManager.item('highway/cycleway/cycleway_link');
@@ -67,4 +101,20 @@ describe('custom presets — cycleway', function() {
         expect(notSegregated.tags).to.not.have.property('bicycle');
         expect(segregated.removeTags).to.have.property('bicycle', '*');
     });
+
+    for (const [footMode, footTags] of CYCLEWAY_CROSSING_FOOT_MODES) {
+        it(`defines unmarked cycleway crossing for ${footMode}`, function() {
+            const preset = iD.presetManager.item(`highway/cycleway/crossing/unmarked_${footMode}`);
+            expect(preset, `unmarked_${footMode}`).to.exist;
+            expect(preset.tags).to.include({
+                highway: 'cycleway',
+                cycleway: 'crossing',
+                crossing: 'unmarked',
+                'crossing:markings': 'no',
+                ...footTags
+            });
+            expect(preset.tags).to.not.have.property('bicycle');
+            expect(preset.addTags).to.not.have.property('bicycle');
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- Add three v5 cycleway path presets: `highway/cycleway` (foot=no), `bicycle_foot` (not segregated), `bicycle_foot_segregated`.
- Default `surface=asphalt` on create.
- `bicycle=designated` and `lcn=yes` omitted from tags/addTags (legacy/implicit); cleared via `removeTags` when switching presets.
- Crossings already had `no_foot`, `not_segregated` and `segregated` variants without required `bicycle` — tests confirm.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/cycleway.js` (15 tests)
- [ ] Inspector: draw each path preset, verify foot/segregated tags and no default `bicycle` or `lcn`
- [ ] Search aliases `cnf`, `cns`, `cs` find the three path presets