### PR TITLE
Restore crossing:markings dash styles (footway + cycleway)

### DIFF
--- a/config/tag_classes_custom.js
+++ b/config/tag_classes_custom.js
@@ -79,6 +79,26 @@ export function appendBuildingFlatsTagClasses(classes, t) {
  * @param {string[]} classes
  * @param {Record<string, string>} t entity tags
  */
+export function appendCrossingStyleTagClasses(classes, t) {
+    const markings = t['crossing:markings'];
+    if (markings) {
+        classes.push('tag-crossing-markings-' + markings.replace(/:/g, '_'));
+    }
+    if (t.segregated) {
+        classes.push('tag-segregated-' + t.segregated);
+    }
+    const foot = t.foot || t['routing:foot'];
+    if (foot === 'no') {
+        classes.push('tag-foot-no');
+    }
+}
+
+/**
+ * Append fork-specific tag classes for custom map styling.
+ *
+ * @param {string[]} classes
+ * @param {Record<string, string>} t entity tags
+ */
 export function appendCustomTagClasses(classes, t) {
     const emphasisValues = new Set(customAccessEmphasisValues);
     const excludeHighways = new Set(customAccessEmphasisExcludeHighways);
@@ -100,6 +120,7 @@ export function appendCustomTagClasses(classes, t) {
     }
 
     appendBuildingFlatsTagClasses(classes, t);
+    appendCrossingStyleTagClasses(classes, t);
     appendHighwayValidationTagClasses(classes, t);
 
     if (!highway || excludeHighways.has(highway)) return;

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -945,3 +945,46 @@ svg#surface:not(.debug-surfaces) path.line.over-stroke.tag-crossing.tag-highway-
     stroke: rgb(255, 81, 0) !important;
     stroke-linecap: butt !important;
 }
+
+/* crossing:markings — footway + cycleway crossings (v5 parity) */
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines {
+    stroke-dasharray: none !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots {
+    stroke-dasharray: 2, 5 !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes {
+    stroke-dasharray: 14, 8 !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+    stroke-dasharray: 6, 4 !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra {
+    stroke-width: 6;
+    stroke-dasharray: 3, 3 !important;
+    stroke-linecap: butt;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface.tag-foot-no {
+    stroke-dasharray: none !important;
+}
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+    stroke: none !important;
+    opacity: 0 !important;
+}

--- a/lenses/v5-quebec-surfaces.css
+++ b/lenses/v5-quebec-surfaces.css
@@ -195,46 +195,47 @@ path.line.stroke.tag-crossing.tag-cycleway-link {
 path.line.casing.tag-crossing-unmarked {
   opacity: 0.4;
 }
+/* crossing:markings — footway + cycleway crossings (v5 parity) */
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines,
 path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines {
-  stroke-dasharray: 16, 6;
+  stroke-dasharray: none !important;
 }
-path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines.tag-foot-no {
-  stroke-dasharray: none;
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots {
+  stroke-dasharray: 2, 5 !important;
 }
-
-
-path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-lines {
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes {
+  stroke-dasharray: 14, 8 !important;
 }
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+  stroke-dasharray: 6, 4 !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
 path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra {
   stroke-width: 6;
-  stroke-dasharray: 3, 3;
+  stroke-dasharray: 3, 3 !important;
+  stroke-linecap: butt;
 }
-path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra.tag-foot-no {
-  stroke-dasharray: none;
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface.tag-foot-no {
+  stroke-dasharray: none !important;
 }
-path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-zebra {
-}
-
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-no {
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-no {
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines {
-  stroke-dasharray: 16, 6;
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines.tag-foot-no {
-  stroke-dasharray: none;
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-lines {
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra {
-  stroke-width: 6;
-  stroke-dasharray: 3, 3;
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra.tag-foot-no {
-  stroke-dasharray: none;
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-zebra {
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+  stroke: none !important;
+  opacity: 0 !important;
 }
 
 

--- a/lenses/v5-quebec.css
+++ b/lenses/v5-quebec.css
@@ -14,7 +14,8 @@
  *     require v5 computed tag classes — rules are included but classes are NOT
  *     emitted unless tag_classes_custom.js is extended (openstreetmap/iD#11189).
  *   - Surface colours: use lenses/v5-quebec-surfaces.css (v5 touche S, always on).
- *   - Compound classes like tag-crossing-markings-* need v5 tag_classes logic.
+ *   - Compound classes tag-crossing-markings-*, tag-segregated-*, tag-foot-no
+ *     are emitted in config/tag_classes_custom.js.
  *   - Building flat-count outlines (`tag-has-flats`, `tag-flats-N`) need
  *     `appendBuildingFlatsTagClasses` in config/tag_classes_custom.js.
  * ============================================================================ */
@@ -200,46 +201,47 @@ path.line.stroke.tag-crossing.tag-cycleway-link {
 path.line.casing.tag-crossing-unmarked {
   opacity: 0.4;
 }
+/* crossing:markings — footway + cycleway crossings (v5 parity) */
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines,
 path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines {
-  stroke-dasharray: 16, 6;
+  stroke-dasharray: none !important;
 }
-path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines.tag-foot-no {
-  stroke-dasharray: none;
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots {
+  stroke-dasharray: 2, 5 !important;
 }
-
-
-path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-lines {
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes {
+  stroke-dasharray: 14, 8 !important;
 }
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+  stroke-dasharray: 6, 4 !important;
+}
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
 path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra {
   stroke-width: 6;
-  stroke-dasharray: 3, 3;
+  stroke-dasharray: 3, 3 !important;
+  stroke-linecap: butt;
 }
-path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra.tag-foot-no {
-  stroke-dasharray: none;
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-lines.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dots.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-dashes.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-zebra.tag-foot-no,
+path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-surface.tag-foot-no,
+path.line.stroke.tag-crossing-uncontrolled.tag-crossing-markings-surface.tag-foot-no {
+  stroke-dasharray: none !important;
 }
-path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-zebra {
-}
-
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-no {
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-no {
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines {
-  stroke-dasharray: 16, 6;
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-lines.tag-foot-no {
-  stroke-dasharray: none;
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-lines {
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra {
-  stroke-width: 6;
-  stroke-dasharray: 3, 3;
-}
-path.line.stroke.tag-crossing-traffic_signals.tag-crossing-markings-zebra.tag-foot-no {
-  stroke-dasharray: none;
-}
-path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-zebra {
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-zebra,
+path.line.casing.tag-crossing-traffic_signals.tag-crossing-markings-surface,
+path.line.casing.tag-crossing-uncontrolled.tag-crossing-markings-surface {
+  stroke: none !important;
+  opacity: 0 !important;
 }
 
 

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -387,6 +387,30 @@ describe('iD.svgTagClasses', function () {
         ['tag-name-no', { highway: 'residential', cycleway: 'lane' }]
     ];
 
+    const crossingStyleCases = [
+        ['tag-crossing-markings-zebra', { highway: 'cycleway', crossing: 'traffic_signals', 'crossing:markings': 'zebra' }],
+        ['tag-crossing-markings-lines', { highway: 'cycleway', crossing: 'uncontrolled', 'crossing:markings': 'lines' }],
+        ['tag-crossing-markings-surface', { highway: 'cycleway', crossing: 'traffic_signals', 'crossing:markings': 'surface' }],
+        ['tag-crossing-markings-dots', { highway: 'cycleway', crossing: 'traffic_signals', 'crossing:markings': 'dots' }],
+        ['tag-crossing-markings-dashes', { highway: 'cycleway', crossing: 'uncontrolled', 'crossing:markings': 'dashes' }],
+        ['tag-crossing-markings-dots', { highway: 'footway', footway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'dots' }],
+        ['tag-crossing-markings-zebra', { highway: 'footway', footway: 'crossing', crossing: 'uncontrolled', 'crossing:markings': 'zebra' }],
+        ['tag-crossing-markings-lines', { highway: 'footway', footway: 'crossing', crossing: 'uncontrolled', 'crossing:markings': 'lines' }],
+        ['tag-segregated-yes', { highway: 'cycleway', crossing: 'unmarked', foot: 'designated', segregated: 'yes' }],
+        ['tag-segregated-no', { highway: 'cycleway', crossing: 'unmarked', foot: 'designated', segregated: 'no' }],
+        ['tag-foot-no', { highway: 'cycleway', crossing: 'unmarked', foot: 'no' }]
+    ];
+
+    for (const [expectedClass, tags] of crossingStyleCases) {
+        it(`adds ${expectedClass} for crossing styling (${tags.highway})`, function() {
+            const sel = d3.select(document.createElement('div'));
+            sel
+                .datum(new iD.osmWay({ tags }))
+                .call(iD.svgTagClasses());
+            expect(sel.classed(expectedClass)).to.be.true;
+        });
+    }
+
     for (const [expectedClass, tags] of nameNoCases) {
         it(`adds ${expectedClass} when name missing (${JSON.stringify(tags)})`, function() {
             const sel = d3.select(document.createElement('div'));


### PR DESCRIPTION
## Summary
- Emit `tag-crossing-markings-*`, `tag-segregated-*`, and `tag-foot-no` classes from `config/tag_classes_custom.js` so lens/CSS can target `crossing:markings` on map ways.
- Restore v5 compound selectors (`tag-crossing-{type}` + `tag-crossing-markings-{value}`) in core `css/30_highways.css` and both Québec lenses — works for footway and cycleway crossings.
- Per-marking dash lengths: lines (solid), dots `2,5`, dashes `14,8`, surface `6,4`, zebra `3,3` at stroke-width 6 with casing hidden for zebra/surface.

## Test plan
- [ ] Hard refresh; re-import `lenses/v5-quebec.css` if using the uploaded lens
- [ ] Draw footway crossings (dots, lines, dashes, zebra, surface) — each marking shows a distinct dash pattern
- [ ] Draw cycleway crossings with the same markings — same visual distinction
- [ ] Zebra: thick bar pattern on stroke, no casing
- [ ] `foot=no` cycleway crossings: solid stroke on all markings
- [ ] `npx vitest run test/spec/svg/tag_classes.js`