### PR TITLE
Add highway=crossing vertex presets (markings variants)

### DIFF
--- a/data/custom-tagging/src/presets/highway/crossing/crossing_node_fields.ts
+++ b/data/custom-tagging/src/presets/highway/crossing/crossing_node_fields.ts
@@ -1,0 +1,31 @@
+/** Field lists for `highway=crossing` vertex presets (≤10 expanded fields). */
+export const CROSSING_NODE_TRAFFIC_SIGNALS_FIELDS = [
+    'crossing',
+    '{@templates/crossing/traffic_signal}',
+    '{@templates/crossing/markings}',
+    'tactile_paving'
+] as const;
+
+export const CROSSING_NODE_UNCONTROLLED_FIELDS = [
+    'crossing',
+    '{@templates/crossing/markings_yes}',
+    'tactile_paving'
+] as const;
+
+export const CROSSING_NODE_UNMARKED_FIELDS = [
+    'crossing',
+    'tactile_paving'
+] as const;
+
+export const CROSSING_NODE_MORE_FIELDS = [
+    '{@templates/crossing/defaults}',
+    'kerb',
+    'flashing_lights'
+] as const;
+
+export const CROSSING_NODE_TRAFFIC_SIGNALS_MORE_FIELDS = [
+    '{@templates/crossing/traffic_signal_more}',
+    ...CROSSING_NODE_MORE_FIELDS
+] as const;
+
+export const CROSSING_NODE_REFERENCE = { key: 'highway', value: 'crossing' } as const;

--- a/data/custom-tagging/src/presets/highway/crossing/crossing_node_variants.ts
+++ b/data/custom-tagging/src/presets/highway/crossing/crossing_node_variants.ts
@@ -1,0 +1,114 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+import {
+    CROSSING_NODE_MORE_FIELDS,
+    CROSSING_NODE_REFERENCE,
+    CROSSING_NODE_TRAFFIC_SIGNALS_FIELDS,
+    CROSSING_NODE_TRAFFIC_SIGNALS_MORE_FIELDS,
+    CROSSING_NODE_UNCONTROLLED_FIELDS,
+    CROSSING_NODE_UNMARKED_FIELDS
+} from './crossing_node_fields';
+import {
+    type CrossingType,
+    type NodeMarkingSlug,
+    NODE_MARKING_TAG
+} from '../crossing_shared';
+
+interface CrossingNodeVariant {
+    id: string;
+    crossing: CrossingType;
+    markings: NodeMarkingSlug;
+    icon: string;
+}
+
+const MARKED_NODE_MARKINGS: NodeMarkingSlug[] = [
+    'dots', 'lines', 'zebra', 'pictograms', 'dashes', 'surface', 'other'
+];
+
+function crossingNodeIcon(markings: NodeMarkingSlug): string {
+    return markings === 'zebra' ? 'temaki-pedestrian_crosswalk' : 'temaki-pedestrian';
+}
+
+function buildVariantList(): CrossingNodeVariant[] {
+    const variants: CrossingNodeVariant[] = [];
+
+    variants.push({
+        id: 'highway/crossing/traffic_signals',
+        crossing: 'traffic_signals',
+        markings: 'no',
+        icon: crossingNodeIcon('no')
+    });
+    for (const markings of MARKED_NODE_MARKINGS) {
+        variants.push({
+            id: `highway/crossing/traffic_signals-${markings}`,
+            crossing: 'traffic_signals',
+            markings,
+            icon: crossingNodeIcon(markings)
+        });
+    }
+    for (const markings of MARKED_NODE_MARKINGS) {
+        variants.push({
+            id: `highway/crossing/uncontrolled-${markings}`,
+            crossing: 'uncontrolled',
+            markings,
+            icon: crossingNodeIcon(markings)
+        });
+    }
+    variants.push({
+        id: 'highway/crossing/unmarked',
+        crossing: 'unmarked',
+        markings: 'no',
+        icon: crossingNodeIcon('no')
+    });
+    return variants;
+}
+
+function crossingNodeFields(crossing: CrossingType): readonly string[] {
+    if (crossing === 'traffic_signals') {
+        return CROSSING_NODE_TRAFFIC_SIGNALS_FIELDS;
+    }
+    if (crossing === 'uncontrolled') {
+        return CROSSING_NODE_UNCONTROLLED_FIELDS;
+    }
+    return CROSSING_NODE_UNMARKED_FIELDS;
+}
+
+function crossingNodeMoreFields(crossing: CrossingType): readonly string[] {
+    if (crossing === 'traffic_signals') {
+        return CROSSING_NODE_TRAFFIC_SIGNALS_MORE_FIELDS;
+    }
+    return CROSSING_NODE_MORE_FIELDS;
+}
+
+function crossingNodePreset(variant: CrossingNodeVariant): CustomPreset {
+    const tags: Record<string, string> = {
+        highway: 'crossing',
+        crossing: variant.crossing
+    };
+    const markingTag = NODE_MARKING_TAG[variant.markings];
+    if (markingTag) {
+        tags['crossing:markings'] = markingTag;
+    }
+
+    const removeWildcards = variant.markings === 'other'
+        ? { 'crossing:markings': ANY }
+        : {};
+
+    return {
+        icon: variant.icon,
+        geometry: ['vertex'],
+        fields: [...crossingNodeFields(variant.crossing)],
+        moreFields: [...crossingNodeMoreFields(variant.crossing)],
+        tags,
+        addTags: { ...tags },
+        removeTags: buildRemoveTags(tags, removeWildcards),
+        matchScore: 2,
+        reference: CROSSING_NODE_REFERENCE,
+        name: presetNameEn(variant.id)
+    };
+}
+
+export const crossingNodeVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    buildVariantList().map((v) => [v.id, crossingNodePreset(v)] as const)
+);

--- a/data/custom-tagging/src/presets/highway/crossing/crossing_node_variants.ts
+++ b/data/custom-tagging/src/presets/highway/crossing/crossing_node_variants.ts
@@ -26,8 +26,14 @@ const MARKED_NODE_MARKINGS: NodeMarkingSlug[] = [
     'dots', 'lines', 'zebra', 'pictograms', 'dashes', 'surface', 'other'
 ];
 
-function crossingNodeIcon(markings: NodeMarkingSlug): string {
-    return markings === 'zebra' ? 'temaki-pedestrian_crosswalk' : 'temaki-pedestrian';
+function crossingNodeIcon(crossing: CrossingType, markings: NodeMarkingSlug): string {
+    if (crossing === 'traffic_signals') {
+        return 'temaki-railway_signals';
+    }
+    if (markings === 'zebra') {
+        return 'temaki-pedestrian_crosswalk';
+    }
+    return 'temaki-pedestrian';
 }
 
 function buildVariantList(): CrossingNodeVariant[] {
@@ -37,14 +43,14 @@ function buildVariantList(): CrossingNodeVariant[] {
         id: 'highway/crossing/traffic_signals',
         crossing: 'traffic_signals',
         markings: 'no',
-        icon: crossingNodeIcon('no')
+        icon: crossingNodeIcon('traffic_signals', 'no')
     });
     for (const markings of MARKED_NODE_MARKINGS) {
         variants.push({
             id: `highway/crossing/traffic_signals-${markings}`,
             crossing: 'traffic_signals',
             markings,
-            icon: crossingNodeIcon(markings)
+            icon: crossingNodeIcon('traffic_signals', markings)
         });
     }
     for (const markings of MARKED_NODE_MARKINGS) {
@@ -52,14 +58,14 @@ function buildVariantList(): CrossingNodeVariant[] {
             id: `highway/crossing/uncontrolled-${markings}`,
             crossing: 'uncontrolled',
             markings,
-            icon: crossingNodeIcon(markings)
+            icon: crossingNodeIcon('uncontrolled', markings)
         });
     }
     variants.push({
         id: 'highway/crossing/unmarked',
         crossing: 'unmarked',
         markings: 'no',
-        icon: crossingNodeIcon('no')
+        icon: crossingNodeIcon('unmarked', 'no')
     });
     return variants;
 }

--- a/data/custom-tagging/src/presets/highway/crossing_shared.ts
+++ b/data/custom-tagging/src/presets/highway/crossing_shared.ts
@@ -6,6 +6,9 @@ export type CrossingType = 'traffic_signals' | 'uncontrolled' | 'unmarked';
 /** Crossing marking style; `other` leaves `crossing:markings` unset, `no` means unmarked. */
 export type MarkingSlug = 'dots' | 'lines' | 'zebra' | 'surface' | 'dashes' | 'other' | 'no';
 
+/** Markings for `highway=crossing` vertex presets (includes pictograms). */
+export type NodeMarkingSlug = MarkingSlug | 'pictograms';
+
 /** OSM `crossing:markings` value per slug; `other` omits the key (unspecified markings). */
 export const MARKING_TAG: Record<MarkingSlug, string | null> = {
     dots: 'dots',
@@ -15,4 +18,10 @@ export const MARKING_TAG: Record<MarkingSlug, string | null> = {
     dashes: 'dashes',
     other: null,
     no: 'no'
+};
+
+/** OSM `crossing:markings` for junction node presets. */
+export const NODE_MARKING_TAG: Record<NodeMarkingSlug, string | null> = {
+    ...MARKING_TAG,
+    pictograms: 'pictograms'
 };

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -16,6 +16,7 @@ import { serviceVariantPresets } from './presets/highway/service_variants';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { tactilePavingYesPresets } from './presets/highway/crossing/tactile_paving_yes';
+import { crossingNodeVariantPresets } from './presets/highway/crossing/crossing_node_variants';
 import { stopVariantPresets } from './presets/highway/stop_variants';
 import { trafficSignalsVariantPresets } from './presets/highway/traffic_signals_variants';
 import { cyclewayCrossingVariantPresets } from './presets/highway/cycleway/cycleway_crossing_variants';
@@ -67,6 +68,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...trackPrivatePresets,
     ...stepsVariantPresets,
     ...tactilePavingYesPresets,
+    ...crossingNodeVariantPresets,
     ...stopVariantPresets,
     ...trafficSignalsVariantPresets,
     ...cyclewayPathVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -829,6 +829,86 @@
         "terms": "std, dismount, bicycle, steps, stairs, staircase, stairway",
         "aliases": "std"
     },
+    "highway/crossing/traffic_signals": {
+        "name": "Traffic Signals Crossing (no markings) (node)",
+        "terms": "tsn, ts, traffic, crossing node, traffic signals crossing, traffic signals crosswalk, traffic signals pedestrian crossing, no marking crossing",
+        "aliases": "tsn"
+    },
+    "highway/crossing/traffic_signals-dashes": {
+        "name": "Traffic Signals Dashes Crossing (node)",
+        "terms": "tsdashn, tsdashns, crossing node, traffic signals crossing, traffic signals crosswalk, dashes crossing, dashes",
+        "aliases": "tsdashn"
+    },
+    "highway/crossing/traffic_signals-dots": {
+        "name": "Traffic Signals Dots Crossing (node)",
+        "terms": "tsdn, td, tdots, crossing node, traffic signals crossing, traffic signals crosswalk, dots crossing, dots",
+        "aliases": "tsdn"
+    },
+    "highway/crossing/traffic_signals-lines": {
+        "name": "Traffic Signals Lines Crossing (node)",
+        "terms": "tsln, tsl, tl, crossing node, traffic signals crossing, traffic signals crosswalk, lines crossing, lines",
+        "aliases": "tsln"
+    },
+    "highway/crossing/traffic_signals-other": {
+        "name": "Traffic Signals Crossing (other) (node)",
+        "terms": "tso, to, crossing node, traffic signals crossing, traffic signals crosswalk, other marking",
+        "aliases": "tso"
+    },
+    "highway/crossing/traffic_signals-pictograms": {
+        "name": "Traffic Signals Pictogram Crossing (node)",
+        "terms": "tspict, tpict, pict, crossing node, traffic signals crossing, pictograms crossing, pictograms",
+        "aliases": "tspict"
+    },
+    "highway/crossing/traffic_signals-surface": {
+        "name": "Traffic Signals Surface Crossing (node)",
+        "terms": "tssurf, crossing node, traffic signals crossing, surface crossing, surface",
+        "aliases": "tssurf"
+    },
+    "highway/crossing/traffic_signals-zebra": {
+        "name": "Traffic Signals Zebra Crossing (node)",
+        "terms": "tsz, tz, zt, crossing node, traffic signals crossing, zebra crossing, zebra",
+        "aliases": "tsz"
+    },
+    "highway/crossing/uncontrolled-dashes": {
+        "name": "Uncontrolled Dashes Crossing (node)",
+        "terms": "udashn, crossing node, uncontrolled crossing, uncontrolled crosswalk, dashes crossing, dashes",
+        "aliases": "udashn"
+    },
+    "highway/crossing/uncontrolled-dots": {
+        "name": "Uncontrolled Dots Crossing (node)",
+        "terms": "udots, ud, crossing node, uncontrolled crossing, uncontrolled crosswalk, dots crossing, dots",
+        "aliases": "udots"
+    },
+    "highway/crossing/uncontrolled-lines": {
+        "name": "Uncontrolled Lines Crossing (node)",
+        "terms": "uln, ul, crossing node, uncontrolled crossing, uncontrolled crosswalk, lines crossing, lines",
+        "aliases": "uln"
+    },
+    "highway/crossing/uncontrolled-other": {
+        "name": "Uncontrolled Crossing (other) (node)",
+        "terms": "uo, uno, crossing node, uncontrolled crossing, other marking",
+        "aliases": "uo"
+    },
+    "highway/crossing/uncontrolled-pictograms": {
+        "name": "Uncontrolled Pictogram Crossing (node)",
+        "terms": "upict, up, pict, crossing node, uncontrolled crossing, pictograms crossing, pictograms",
+        "aliases": "upict"
+    },
+    "highway/crossing/uncontrolled-surface": {
+        "name": "Uncontrolled Surface Crossing (node)",
+        "terms": "usurf, crossing node, uncontrolled crossing, surface crossing, surface",
+        "aliases": "usurf"
+    },
+    "highway/crossing/uncontrolled-zebra": {
+        "name": "Uncontrolled Zebra Crossing (node)",
+        "terms": "uz, unz, zu, crossing node, uncontrolled crossing, zebra crossing, zebra, crosswalk",
+        "aliases": "uz"
+    },
+    "highway/crossing/unmarked": {
+        "name": "Unmarked Crossing (node)",
+        "terms": "uc, unmarked, crossing node, unmarked crossing",
+        "aliases": "uc"
+    },
     "highway/crossing/tactile_paving_yes": {
         "name": "Tactile paving (yes)",
         "terms": "tp, tactile paving, tactile_paving, yes, rumble strip",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -829,6 +829,86 @@
         "terms": "std, vélo à pied, descendre du vélo, escalier, escaliers, marches",
         "aliases": "std"
     },
+    "highway/crossing/traffic_signals": {
+        "name": "Traversée (nœud) — Feux, sans marquage",
+        "terms": "tsn, ts, nœud, jonction, traversée, passage piéton, feux, feux de circulation, sans marquage",
+        "aliases": "tsn"
+    },
+    "highway/crossing/traffic_signals-dashes": {
+        "name": "Traversée (nœud) — Feux, tirets",
+        "terms": "tsdashn, nœud, jonction, traversée, passage piéton, feux, tirets, marquage en tirets",
+        "aliases": "tsdashn"
+    },
+    "highway/crossing/traffic_signals-dots": {
+        "name": "Traversée (nœud) — Feux, pointillés",
+        "terms": "tsdn, td, nœud, jonction, traversée, passage piéton, feux, pointillés",
+        "aliases": "tsdn"
+    },
+    "highway/crossing/traffic_signals-lines": {
+        "name": "Traversée (nœud) — Feux, lignes",
+        "terms": "tsln, tsl, nœud, jonction, traversée, passage piéton, feux, lignes",
+        "aliases": "tsln"
+    },
+    "highway/crossing/traffic_signals-other": {
+        "name": "Traversée (nœud) — Feux, autre marquage",
+        "terms": "tso, nœud, jonction, traversée, passage piéton, feux, autre marquage",
+        "aliases": "tso"
+    },
+    "highway/crossing/traffic_signals-pictograms": {
+        "name": "Traversée (nœud) — Feux, pictogrammes",
+        "terms": "tspict, nœud, jonction, traversée, passage piéton, feux, pictogrammes",
+        "aliases": "tspict"
+    },
+    "highway/crossing/traffic_signals-surface": {
+        "name": "Traversée (nœud) — Feux, surface",
+        "terms": "tssurf, nœud, jonction, traversée, passage piéton, feux, surface",
+        "aliases": "tssurf"
+    },
+    "highway/crossing/traffic_signals-zebra": {
+        "name": "Traversée (nœud) — Feux, zébrures",
+        "terms": "tsz, tz, nœud, jonction, traversée, passage piéton, feux, zébrures, zebra",
+        "aliases": "tsz"
+    },
+    "highway/crossing/uncontrolled-dashes": {
+        "name": "Traversée (nœud) — Non contrôlée, tirets",
+        "terms": "udashn, nœud, jonction, traversée, passage piéton, non contrôlée, tirets",
+        "aliases": "udashn"
+    },
+    "highway/crossing/uncontrolled-dots": {
+        "name": "Traversée (nœud) — Non contrôlée, pointillés",
+        "terms": "udots, ud, nœud, jonction, traversée, passage piéton, non contrôlée, pointillés",
+        "aliases": "udots"
+    },
+    "highway/crossing/uncontrolled-lines": {
+        "name": "Traversée (nœud) — Non contrôlée, lignes",
+        "terms": "uln, ul, nœud, jonction, traversée, passage piéton, non contrôlée, lignes",
+        "aliases": "uln"
+    },
+    "highway/crossing/uncontrolled-other": {
+        "name": "Traversée (nœud) — Non contrôlée, autre marquage",
+        "terms": "uo, nœud, jonction, traversée, passage piéton, non contrôlée, autre marquage",
+        "aliases": "uo"
+    },
+    "highway/crossing/uncontrolled-pictograms": {
+        "name": "Traversée (nœud) — Non contrôlée, pictogrammes",
+        "terms": "upict, up, nœud, jonction, traversée, passage piéton, non contrôlée, pictogrammes",
+        "aliases": "upict"
+    },
+    "highway/crossing/uncontrolled-surface": {
+        "name": "Traversée (nœud) — Non contrôlée, surface",
+        "terms": "usurf, nœud, jonction, traversée, passage piéton, non contrôlée, surface",
+        "aliases": "usurf"
+    },
+    "highway/crossing/uncontrolled-zebra": {
+        "name": "Traversée (nœud) — Non contrôlée, zébrures",
+        "terms": "uz, unz, nœud, jonction, traversée, passage piéton, non contrôlée, zébrures, zebra",
+        "aliases": "uz"
+    },
+    "highway/crossing/unmarked": {
+        "name": "Traversée (nœud) — Sans marquage",
+        "terms": "uc, nœud, jonction, traversée, passage piéton, sans marquage, unmarked",
+        "aliases": "uc"
+    },
     "highway/crossing/tactile_paving_yes": {
         "name": "Surface podotactile (oui)",
         "terms": "tp, podotactile, tactile, oui, bande podotactile",

--- a/test/spec/presets/custom/crossing_node.js
+++ b/test/spec/presets/custom/crossing_node.js
@@ -7,12 +7,14 @@ describe('custom presets — highway=crossing node', function() {
         {
             id: 'highway/crossing/traffic_signals',
             tags: { highway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'no' },
-            geometry: ['vertex']
+            geometry: ['vertex'],
+            icon: 'temaki-railway_signals'
         },
         {
             id: 'highway/crossing/traffic_signals-dots',
             tags: { highway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'dots' },
-            alias: 'tsdn'
+            alias: 'tsdn',
+            icon: 'temaki-railway_signals'
         },
         {
             id: 'highway/crossing/traffic_signals-pictograms',
@@ -35,13 +37,14 @@ describe('custom presets — highway=crossing node', function() {
         }
     ];
 
-    for (const { id, tags, geometry = ['vertex'], alias } of vertexCases) {
+    for (const { id, tags, geometry = ['vertex'], alias, icon } of vertexCases) {
         it(`defines ${id}`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
             expect(preset.geometry).to.eql(geometry);
             expect(preset.tags).to.eql(tags);
             expect(preset.addTags).to.eql(tags);
+            if (icon) expect(preset.icon).to.equal(icon);
             expect(preset.tags).to.not.have.property('footway');
             expect(preset.tags).to.not.have.property('cycleway');
             expect(preset.tags).to.not.have.property('foot');

--- a/test/spec/presets/custom/crossing_node.js
+++ b/test/spec/presets/custom/crossing_node.js
@@ -1,0 +1,65 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — highway=crossing node', function() {
+    loadCustomPresets();
+
+    const vertexCases = [
+        {
+            id: 'highway/crossing/traffic_signals',
+            tags: { highway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'no' },
+            geometry: ['vertex']
+        },
+        {
+            id: 'highway/crossing/traffic_signals-dots',
+            tags: { highway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'dots' },
+            alias: 'tsdn'
+        },
+        {
+            id: 'highway/crossing/traffic_signals-pictograms',
+            tags: { highway: 'crossing', crossing: 'traffic_signals', 'crossing:markings': 'pictograms' },
+            alias: 'tspict'
+        },
+        {
+            id: 'highway/crossing/uncontrolled-zebra',
+            tags: { highway: 'crossing', crossing: 'uncontrolled', 'crossing:markings': 'zebra' },
+            alias: 'uz'
+        },
+        {
+            id: 'highway/crossing/uncontrolled-dashes',
+            tags: { highway: 'crossing', crossing: 'uncontrolled', 'crossing:markings': 'dashes' }
+        },
+        {
+            id: 'highway/crossing/unmarked',
+            tags: { highway: 'crossing', crossing: 'unmarked', 'crossing:markings': 'no' },
+            alias: 'uc'
+        }
+    ];
+
+    for (const { id, tags, geometry = ['vertex'], alias } of vertexCases) {
+        it(`defines ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.geometry).to.eql(geometry);
+            expect(preset.tags).to.eql(tags);
+            expect(preset.addTags).to.eql(tags);
+            expect(preset.tags).to.not.have.property('footway');
+            expect(preset.tags).to.not.have.property('cycleway');
+            expect(preset.tags).to.not.have.property('foot');
+            expect(preset.tags).to.not.have.property('surface');
+        });
+
+        if (alias) {
+            it(`finds ${id} via alias ${alias}`, function() {
+                const pool = iD.presetManager.matchAllGeometry(['vertex']);
+                const found = pool.search(alias, 'vertex').collection.map((p) => p.id);
+                expect(found).to.include(id);
+            });
+        }
+    }
+
+    it('omits crossing:markings for other variants', function() {
+        const other = iD.presetManager.item('highway/crossing/traffic_signals-other');
+        expect(other.tags).to.not.have.property('crossing:markings');
+        expect(other.removeTags['crossing:markings']).to.equal('*');
+    });
+});


### PR DESCRIPTION
## Summary
- Add 16 `highway=crossing` vertex presets for junction nodes: traffic_signals / uncontrolled × markings (dots, lines, zebra, pictograms, dashes, surface, other) plus unmarked and traffic_signals without markings.
- No footway/cycleway geometry, foot/segregated modes, or access variants — nodes only.
- Includes pictograms (node-only marking in v5) plus dashes and surface for parity with line crossings.

## Test plan
- [ ] Place a vertex on a road → search `tsdn`, `tspict`, `uz`, `uc` → matching crossing node presets appear
- [ ] Apply `Traffic Signals Dots Crossing (node)` → tags `highway=crossing`, `crossing=traffic_signals`, `crossing:markings=dots`
- [ ] Apply `Uncontrolled Pictogram Crossing (node)` → `crossing:markings=pictograms`
- [ ] `npx vitest run test/spec/presets/custom/crossing_node.js`
- [ ] `yarn generate:presets:custom && yarn build:presets:custom`