### PR TITLE
Fix is_sidewalk on segregated cycleway path presets

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -462,21 +462,30 @@ function customizePostBox(presetManager) {
     fields.splice(refIndex === -1 ? fields.length : refIndex + 1, 0, 'post_box/type');
 }
 
-// Presets that should offer the `is_sidewalk` check. Their `{...}` variants
-// (e.g. highway/path/bicycle_foot → {highway/cycleway/bicycle_foot}) inherit it.
-const IS_SIDEWALK_PRESETS = ['highway/cycleway', 'highway/cycleway/bicycle_foot'];
+/**
+ * Line cycleway presets that may carry `footway=sidewalk` (paths and links, not crossings).
+ * Custom presets reference `{highway/cycleway}`; the build expands that to a frozen field
+ * list from upstream (see scripts/custom_presets_config.js), so runtime fields like
+ * `is_sidewalk` must be spliced onto each preset here — not only the parent.
+ *
+ * @param {{ id: string, geometry?: string[] }} preset
+ * @returns {boolean}
+ */
+function isCyclewayLinePreset(preset) {
+    if (!preset.id.startsWith('highway/cycleway')) return false;
+    if (preset.id.includes('/crossing/')) return false;
+    return preset.geometry && preset.geometry.indexOf('line') !== -1;
+}
 
 /**
- * Offer the `is_sidewalk` check on the cycleway / cycle-and-foot-path presets, to
- * flag a way that runs along a sidewalk (footway=sidewalk). Inserted after
- * `oneway`; idempotent.
+ * Offer the `is_sidewalk` check on cycleway line presets, to flag a way that runs
+ * along a sidewalk (footway=sidewalk). Inserted after `oneway`; idempotent.
  *
  * @param {Object} presetManager - the preset system (`presetManager`)
  */
 function customizeCyclewaySidewalk(presetManager) {
-    IS_SIDEWALK_PRESETS.forEach(id => {
-        const preset = presetManager.item(id);
-        if (!preset) return;
+    presetManager.collection.forEach(preset => {
+        if (!isCyclewayLinePreset(preset)) return;
         const fields = preset.originalFields;
         if (fields.indexOf('is_sidewalk') !== -1) return;
         const onewayIndex = fields.indexOf('oneway');

--- a/test/spec/presets/custom/cycleway.js
+++ b/test/spec/presets/custom/cycleway.js
@@ -31,6 +31,26 @@ describe('custom presets — cycleway', function() {
         });
     }
 
+    for (const id of [
+        'highway/cycleway',
+        'highway/cycleway/bicycle_foot',
+        'highway/cycleway/bicycle_foot_segregated',
+        'highway/cycleway/cycleway_link'
+    ]) {
+        it(`offers is_sidewalk on ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            const fieldIds = preset.fields().map((f) => f.id);
+            expect(fieldIds, id).to.include('is_sidewalk');
+            expect(preset.originalFields, id).to.include('is_sidewalk');
+        });
+    }
+
+    it('does not offer is_sidewalk on cycleway crossing presets', function() {
+        const preset = iD.presetManager.item('highway/cycleway/crossing/traffic_signals-dots_no_foot');
+        const fieldIds = preset.fields().map((f) => f.id);
+        expect(fieldIds).to.not.include('is_sidewalk');
+    });
+
     it('finds cycleway path presets via search aliases', function() {
         const pool = iD.presetManager.matchAllGeometry(['line']);
         expect(pool.search('cnf', 'line').collection.map((p) => p.id)).to.include('highway/cycleway');


### PR DESCRIPTION
## Summary
- Splice the `is_sidewalk` check onto every line `highway/cycleway/*` preset (paths and links, not crossings)
- Build-time expansion of `{highway/cycleway}` freezes upstream fields, so runtime-only fields cannot rely on inheritance from the parent preset
- Add parametric tests for path/link presets and a negative test on cycleway crossings

## Test plan
- [x] `npx vitest run test/spec/presets/custom/cycleway.js -t is_sidewalk`
- [x] Manual: « Cycle & Foot Path (segregated) » shows « Est aussi un trottoir » after One Way