### PR TITLE
Enable boundaries map feature by default

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -50,12 +50,6 @@
             .assetPath('')
             .containerNode(container);
           context.init();
-
-          // disable boundaries (unless we have an explicit disable_features list)
-          var q = iD.utilStringQs(window.location.hash);
-          if (!q.hasOwnProperty('disable_features')) {
-            context.features().disable('boundaries');
-          }
         }
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -51,12 +51,6 @@
             .containerNode(container);
           window.context = window.id = context;  // for debugging
           context.init();
-
-          // disable boundaries (unless we have an explicit disable_features list)
-          var q = iD.utilStringQs(window.location.hash);
-          if (!q.hasOwnProperty('disable_features')) {
-            context.features().disable('boundaries');
-          }
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- Remove the v5-era `index.html` hook that called `features().disable('boundaries')` on every load unless `#disable_features` was already in the URL hash.
- Boundaries now follow the standard map-features behaviour: enabled by default, user preference persisted via Map data → Map features.

## Test plan
- [ ] Fresh load: Map data → Map features → Boundaries is checked
- [ ] Boundaries render on the map (administrative limits visible)
- [ ] Uncheck Boundaries → reload → stays unchecked
- [ ] Check Boundaries again → reload → stays checked