### PR TITLE
Add informal path and foot path dismount unpaved presets

### DIFF
--- a/data/custom-tagging/src/presets/entrance/entrance_variants.ts
+++ b/data/custom-tagging/src/presets/entrance/entrance_variants.ts
@@ -1,4 +1,5 @@
 import type { CustomPreset } from '../../types';
+import { ANY, buildRemoveTags } from '../../lib/tag_helpers';
 import { presetNameEn } from '../../preset_name_en';
 
 const FIELDS_ADDRESS_FIRST = [
@@ -28,6 +29,8 @@ interface EntranceVariant {
     icon: string;
     tags: Record<string, string>;
     fields: readonly string[];
+    addTags?: Record<string, string>;
+    removeWildcards?: Record<string, typeof ANY>;
 }
 
 /** Fork entrance vertex presets with custom icons from v5. */
@@ -38,15 +41,28 @@ const ENTRANCE_VARIANTS: EntranceVariant[] = [
     { id: 'entrance/home', icon: 'iD-entrance-home', tags: { entrance: 'home' }, fields: FIELDS_ADDRESS_FIRST },
     { id: 'entrance/garage', icon: 'iD-entrance-garage', tags: { entrance: 'garage' }, fields: FIELDS_STANDARD },
     { id: 'entrance/secondary', icon: 'iD-entrance-secondary', tags: { entrance: 'secondary' }, fields: FIELDS_MINIMAL },
-    { id: 'entrance/emergency', icon: 'iD-entrance-emergency', tags: { entrance: 'emergency' }, fields: FIELDS_MINIMAL }
+    { id: 'entrance/emergency', icon: 'iD-entrance-emergency', tags: { entrance: 'emergency' }, fields: FIELDS_MINIMAL },
+    {
+        id: 'entrance/private',
+        icon: 'iD-entrance',
+        tags: { entrance: 'yes', access: 'private' },
+        addTags: { entrance: 'yes', access: 'private' },
+        fields: FIELDS_STANDARD,
+        removeWildcards: { access: ANY }
+    }
 ];
 
 function entrancePreset(variant: EntranceVariant): CustomPreset {
+    const addTags = variant.addTags ?? variant.tags;
     return {
         icon: variant.icon,
         geometry: ['vertex'],
         fields: [...variant.fields],
         tags: variant.tags,
+        ...(variant.addTags || variant.removeWildcards ? {
+            addTags,
+            removeTags: buildRemoveTags(addTags, variant.removeWildcards ?? {})
+        } : {}),
         matchScore: 0.8,
         name: presetNameEn(variant.id)
     };

--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_variants.ts
@@ -46,6 +46,15 @@ function buildVariantList(): CyclewayCrossingVariant[] {
     const uncontrolledMarkings: MarkingSlug[] = ['dots', 'lines', 'zebra', 'dashes', 'other'];
     const variants: CyclewayCrossingVariant[] = [];
 
+    for (const footMode of footModes) {
+        variants.push({
+            id: `highway/cycleway/crossing/traffic_signals_${footMode}`,
+            crossing: 'traffic_signals',
+            markings: 'no',
+            footMode,
+            icon: cyclewayCrossingIcon('traffic_signals', 'no')
+        });
+    }
     for (const markings of trafficMarkings) {
         for (const footMode of footModes) {
             variants.push({

--- a/data/custom-tagging/src/presets/highway/footway/bicycle_dismount_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/bicycle_dismount_variants.ts
@@ -7,12 +7,13 @@ const BICYCLE_YES_REFERENCE = { key: 'footway', value: 'footway_bicycle_yes' } a
 
 interface BicycleDismountVariant {
     id: string;
-    surface?: 'asphalt' | 'concrete';
+    surface?: 'asphalt' | 'concrete' | 'unpaved';
 }
 
 const BICYCLE_DISMOUNT_VARIANTS: BicycleDismountVariant[] = [
     { id: 'highway/footway/bicycle_dismount_asphalt', surface: 'asphalt' },
     { id: 'highway/footway/bicycle_dismount_concrete', surface: 'concrete' },
+    { id: 'highway/footway/bicycle_dismount_unpaved', surface: 'unpaved' },
     { id: 'highway/footway/bicycle_dismount_other' }
 ];
 

--- a/data/custom-tagging/src/presets/highway/footway/informal_path_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/informal_path_variants.ts
@@ -1,0 +1,42 @@
+import type { CustomPreset } from '../../../types';
+import { ANY, buildRemoveTags } from '../../../lib/tag_helpers';
+import { presetNameEn } from '../../../preset_name_en';
+
+const INFORMAL_REMOVE_WILDCARDS = { access: ANY, bicycle: ANY, footway: ANY, highway: ANY } as const;
+
+interface InformalPathVariant {
+    id: string;
+    bicycle: 'dismount' | 'yes';
+    surface: 'unpaved' | 'grass';
+}
+
+const INFORMAL_PATH_VARIANTS: InformalPathVariant[] = [
+    { id: 'highway/footway/informal_bicycle_dismount_unpaved', bicycle: 'dismount', surface: 'unpaved' },
+    { id: 'highway/footway/informal_bicycle_dismount_grass', bicycle: 'dismount', surface: 'grass' },
+    { id: 'highway/footway/informal_bicycle_yes_unpaved', bicycle: 'yes', surface: 'unpaved' }
+];
+
+function informalPathPreset(variant: InformalPathVariant): CustomPreset {
+    const tags = {
+        highway: 'path',
+        informal: 'yes',
+        bicycle: variant.bicycle,
+        surface: variant.surface
+    };
+
+    return {
+        icon: 'iD-other-line',
+        geometry: ['line'],
+        fields: ['{highway/path}'],
+        moreFields: ['{highway/path}'],
+        tags,
+        addTags: { ...tags },
+        removeTags: buildRemoveTags(tags, INFORMAL_REMOVE_WILDCARDS),
+        matchScore: 2,
+        name: presetNameEn(variant.id)
+    };
+}
+
+export const informalPathVariantPresets: Record<string, CustomPreset> = Object.fromEntries(
+    INFORMAL_PATH_VARIANTS.map((v) => [v.id, informalPathPreset(v)] as const)
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -5,6 +5,7 @@ import { parkingCondition } from './fields/parking_condition';
 import { routingEntrance } from './fields/routing_entrance';
 import { placement } from './fields/placement';
 import { roofLevels } from './fields/roof_levels';
+import { informalPathVariantPresets } from './presets/highway/footway/informal_path_variants';
 import { bicycleDismountVariantPresets } from './presets/highway/footway/bicycle_dismount_variants';
 import { accessAisleVariantPresets } from './presets/highway/footway/access_aisle_variants';
 import { footwayLinkVariantPresets } from './presets/highway/footway/footway_link_variants';
@@ -58,6 +59,7 @@ export const customTemplates: Record<string, CustomTemplatePreset> = {
 /** Preset path (e.g. `highway/footway/footway_link_bicycle_dismount`) → definition under `presets/`. */
 export const customPresets: Record<string, CustomPreset> = {
     ...bicycleDismountVariantPresets,
+    ...informalPathVariantPresets,
     ...accessAisleVariantPresets,
     ...footwayLinkVariantPresets,
     ...restrictedFootwayVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -424,6 +424,11 @@
         "terms": "bdc, footway, foot path, pedestrian path, bicycle dismount, dismount, concrete",
         "aliases": "bdc"
     },
+    "highway/footway/bicycle_dismount_unpaved": {
+        "name": "Foot path (bicycle dismount unpaved)",
+        "terms": "bdu, footway, foot path, pedestrian path, bicycle dismount, dismount, unpaved, gravel, dirt",
+        "aliases": "bdu"
+    },
     "highway/footway/bicycle_dismount_other": {
         "name": "Foot path (bicycle dismount)",
         "terms": "bdo, footway, foot path, pedestrian path, bicycle dismount, dismount",
@@ -453,6 +458,21 @@
         "name": "Customers informal path",
         "terms": "cfi, footway, informal path, desire path, trail, customers, hiking, walk",
         "aliases": "cfi"
+    },
+    "highway/footway/informal_bicycle_dismount_unpaved": {
+        "name": "Informal path (bicycle dismount unpaved)",
+        "terms": "ibdu, path, informal path, desire path, trail, bicycle dismount, dismount, unpaved, gravel, dirt, hiking, walk",
+        "aliases": "ibdu"
+    },
+    "highway/footway/informal_bicycle_dismount_grass": {
+        "name": "Informal path (bicycle dismount grass)",
+        "terms": "ibdg, path, informal path, desire path, trail, bicycle dismount, dismount, grass, hiking, walk",
+        "aliases": "ibdg"
+    },
+    "highway/footway/informal_bicycle_yes_unpaved": {
+        "name": "Informal path (bicycle yes unpaved)",
+        "terms": "ibyu, path, informal path, desire path, trail, bicycle yes, cycling, unpaved, gravel, dirt, hiking, walk",
+        "aliases": "ibyu"
     },
     "highway/footway/customers_asphalt": {
         "name": "Customers foot path (asphalt)",

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -309,6 +309,21 @@
         "terms": "cus, cycleway crossing, unmarked cycleway crossing, unmarked crosswalk, no marking crossing, segregated",
         "aliases": "cus"
     },
+    "highway/cycleway/crossing/traffic_signals_no_foot": {
+        "name": "Traffic Signals Cycleway Crossing No Foot (No Markings)",
+        "terms": "ctsnf, ctsn, cycleway crossing, traffic signals cycleway crossing, traffic signals crosswalk, traffic signals bicycle crossing, no marking crossing, no foot",
+        "aliases": "ctsnf"
+    },
+    "highway/cycleway/crossing/traffic_signals_not_segregated": {
+        "name": "Traffic Signals Cycleway Crossing Not Segregated (No Markings)",
+        "terms": "ctsnns, ctsn, cycleway crossing, traffic signals cycleway crossing, traffic signals crosswalk, traffic signals bicycle crossing, no marking crossing, not segregated",
+        "aliases": "ctsnns"
+    },
+    "highway/cycleway/crossing/traffic_signals_segregated": {
+        "name": "Traffic Signals Cycleway Crossing Segregated (No Markings)",
+        "terms": "ctsns, ctsn, cycleway crossing, traffic signals cycleway crossing, traffic signals crosswalk, traffic signals bicycle crossing, no marking crossing, segregated",
+        "aliases": "ctsns"
+    },
     "highway/cycleway/cycleway_link": {
         "name": "Cycleway link",
         "aliases": "cl",

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -94,6 +94,11 @@
         "name": "Main Entrance / Exit",
         "terms": "entrance, exit, door, main"
     },
+    "entrance/private": {
+        "name": "Private Entrance / Exit",
+        "terms": "pe, entrance, exit, door, private",
+        "aliases": "pe"
+    },
     "entrance/secondary": {
         "name": "Secondary Exit",
         "terms": "secondary exit, door"

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -94,6 +94,11 @@
         "name": "Entrée principale / sortie",
         "terms": "entrée, porte, accès, principal, principale, sortie"
     },
+    "entrance/private": {
+        "name": "Entrée privée / sortie",
+        "terms": "pe, entrée, sortie, porte, privé, privée",
+        "aliases": "pe"
+    },
     "entrance/secondary": {
         "name": "Sortie secondaire",
         "terms": "sortie secondaire, porte"

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -424,6 +424,11 @@
         "terms": "bdc, footway, chemin piéton, sentier, vélo à pied, béton",
         "aliases": "bdc"
     },
+    "highway/footway/bicycle_dismount_unpaved": {
+        "name": "Chemin piéton (vélo à pied, non revêtu)",
+        "terms": "bdu, footway, chemin piéton, sentier, vélo à pied, non revêtu, gravelle, terre",
+        "aliases": "bdu"
+    },
     "highway/footway/bicycle_dismount_other": {
         "name": "Chemin piéton (vélo à pied)",
         "terms": "bdo, footway, chemin piéton, sentier, vélo à pied",
@@ -453,6 +458,21 @@
         "name": "Sentier informel — clients",
         "terms": "cfi, footway, sentier informel, sentier, chemin de traverse, clients, randonnée",
         "aliases": "cfi"
+    },
+    "highway/footway/informal_bicycle_dismount_unpaved": {
+        "name": "Sentier informel (vélo à pied, non revêtu)",
+        "terms": "ibdu, path, sentier informel, chemin de traverse, vélo à pied, non revêtu, gravelle, terre, randonnée, marche",
+        "aliases": "ibdu"
+    },
+    "highway/footway/informal_bicycle_dismount_grass": {
+        "name": "Sentier informel (vélo à pied, gazon)",
+        "terms": "ibdg, path, sentier informel, chemin de traverse, vélo à pied, gazon, randonnée, marche",
+        "aliases": "ibdg"
+    },
+    "highway/footway/informal_bicycle_yes_unpaved": {
+        "name": "Sentier informel (vélo autorisé, non revêtu)",
+        "terms": "ibyu, path, sentier informel, chemin de traverse, vélo autorisé, cyclisme, non revêtu, gravelle, terre, randonnée, marche",
+        "aliases": "ibyu"
     },
     "highway/footway/customers_asphalt": {
         "name": "Chemin piéton — clients (asphalte)",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -309,6 +309,21 @@
         "terms": "cus, us, un, traversée cyclable, passage cyclable, passage pour vélo, traversée, non marqué, sans marquage, ségrégué",
         "aliases": "cus"
     },
+    "highway/cycleway/crossing/traffic_signals_no_foot": {
+        "name": "Traversée cyclable — Feux, sans marquage, sans piétons",
+        "terms": "ctsnf, ctsn, traversée cyclable, passage cyclable, passage pour vélo, traversée, feux, feux de circulation, signalisation, sans marquage, sans piétons, piétons interdits",
+        "aliases": "ctsnf"
+    },
+    "highway/cycleway/crossing/traffic_signals_not_segregated": {
+        "name": "Traversée cyclable — Feux, sans marquage, non ségrégué",
+        "terms": "ctsnns, ctsn, traversée cyclable, passage cyclable, passage pour vélo, traversée, feux, feux de circulation, signalisation, sans marquage, non ségrégué, mixte",
+        "aliases": "ctsnns"
+    },
+    "highway/cycleway/crossing/traffic_signals_segregated": {
+        "name": "Traversée cyclable — Feux, sans marquage, ségrégué",
+        "terms": "ctsns, ctsn, traversée cyclable, passage cyclable, passage pour vélo, traversée, feux, feux de circulation, signalisation, sans marquage, ségrégué",
+        "aliases": "ctsns"
+    },
     "highway/cycleway/cycleway_link": {
         "name": "Lien cyclable",
         "aliases": "cl",

--- a/test/spec/presets/custom/cycleway.js
+++ b/test/spec/presets/custom/cycleway.js
@@ -137,5 +137,17 @@ describe('custom presets — cycleway', function() {
             expect(preset.tags).to.not.have.property('bicycle');
             expect(preset.addTags).to.not.have.property('bicycle');
         });
+
+        it(`defines traffic signals no-marking cycleway crossing for ${footMode}`, function() {
+            const preset = iD.presetManager.item(`highway/cycleway/crossing/traffic_signals_${footMode}`);
+            expect(preset, `traffic_signals_${footMode}`).to.exist;
+            expect(preset.tags).to.include({
+                highway: 'cycleway',
+                cycleway: 'crossing',
+                crossing: 'traffic_signals',
+                'crossing:markings': 'no',
+                ...footTags
+            });
+        });
     }
 });

--- a/test/spec/presets/custom/entrance.js
+++ b/test/spec/presets/custom/entrance.js
@@ -10,7 +10,8 @@ describe('custom presets — entrance', function() {
         ['entrance/home', 'iD-entrance-home', { entrance: 'home' }],
         ['entrance/garage', 'iD-entrance-garage', { entrance: 'garage' }],
         ['entrance/secondary', 'iD-entrance-secondary', { entrance: 'secondary' }],
-        ['entrance/emergency', 'iD-entrance-emergency', { entrance: 'emergency' }]
+        ['entrance/emergency', 'iD-entrance-emergency', { entrance: 'emergency' }],
+        ['entrance/private', 'iD-entrance', { entrance: 'yes', access: 'private' }]
     ];
 
     for (const [id, icon, tags] of entranceIcons) {
@@ -54,5 +55,12 @@ describe('custom presets — entrance', function() {
         const preset = iD.presetManager.match(point, graph);
         expect(preset.id).to.equal('entrance/main');
         expect(preset.icon).to.equal('iD-entrance-main');
+    });
+
+    it('defines private entrance preset tags and removeTags', function() {
+        const preset = iD.presetManager.item('entrance/private');
+        expect(preset.tags).to.eql({ entrance: 'yes', access: 'private' });
+        expect(preset.addTags).to.eql({ entrance: 'yes', access: 'private' });
+        expect(preset.removeTags).to.include({ access: '*' });
     });
 });

--- a/test/spec/presets/custom/footway.js
+++ b/test/spec/presets/custom/footway.js
@@ -136,12 +136,33 @@ describe('custom presets — footway', function() {
     it('defines bicycle dismount footway presets by surface', function() {
         const asphalt = iD.presetManager.item('highway/footway/bicycle_dismount_asphalt');
         const concrete = iD.presetManager.item('highway/footway/bicycle_dismount_concrete');
+        const unpaved = iD.presetManager.item('highway/footway/bicycle_dismount_unpaved');
         const other = iD.presetManager.item('highway/footway/bicycle_dismount_other');
         expect(asphalt.tags).to.include({ highway: 'footway', bicycle: 'dismount', surface: 'asphalt' });
         expect(concrete.tags).to.include({ surface: 'concrete' });
+        expect(unpaved.tags).to.include({ surface: 'unpaved' });
         expect(other.tags).to.include({ bicycle: 'dismount' });
         expect(other.tags).to.not.have.property('surface');
         expect(other.tags).to.not.have.property('footway');
+    });
+
+    it('defines informal path presets with bicycle and surface', function() {
+        const dismountUnpaved = iD.presetManager.item('highway/footway/informal_bicycle_dismount_unpaved');
+        const dismountGrass = iD.presetManager.item('highway/footway/informal_bicycle_dismount_grass');
+        const yesUnpaved = iD.presetManager.item('highway/footway/informal_bicycle_yes_unpaved');
+        expect(dismountUnpaved.tags).to.eql({
+            highway: 'path',
+            informal: 'yes',
+            bicycle: 'dismount',
+            surface: 'unpaved'
+        });
+        expect(dismountGrass.tags).to.include({ bicycle: 'dismount', surface: 'grass' });
+        expect(yesUnpaved.tags).to.eql({
+            highway: 'path',
+            informal: 'yes',
+            bicycle: 'yes',
+            surface: 'unpaved'
+        });
     });
 
     it('defines sidewalk bicycle dismount and yes preset tags', function() {


### PR DESCRIPTION
## Summary
- **Informal path (bicycle dismount unpaved)** — `highway=path`, `informal=yes`, `bicycle=dismount`, `surface=unpaved` (`ibdu`)
- **Informal path (bicycle dismount grass)** — same with `surface=grass` (`ibdg`)
- **Foot path (bicycle dismount unpaved)** — `highway=footway`, `bicycle=dismount`, `surface=unpaved` (`bdu`), alongside existing asphalt/concrete variants
- **Informal path (bicycle yes unpaved)** — `highway=path`, `informal=yes`, `bicycle=yes`, `surface=unpaved` (`ibyu`)

EN/FR names, terms, and search aliases in `data/locales/custom_presets/`.

## Test plan
- [ ] `npm run build:presets:custom`
- [ ] `npx vitest run test/spec/presets/custom/footway.js`
- [ ] Search `ibdu`, `ibdg`, `bdu`, `ibyu` in Add feature → line
- [ ] Verify tags on each preset match the table above