### PR TITLE
Preset shortcuts: gates, service subtypes, crossings, entrance points

### DIFF
--- a/data/custom-tagging/src/presets/barrier/access_barriers.ts
+++ b/data/custom-tagging/src/presets/barrier/access_barriers.ts
@@ -1,4 +1,4 @@
-import type { CustomPreset } from '../../types';
+import type { CustomPreset, PresetGeometry } from '../../types';
 import { presetNameEn } from '../../preset_name_en';
 import { gateFootBicycleYes } from './gate_foot_bicycle_yes';
 
@@ -17,19 +17,34 @@ const ACCESS_BARRIERS: AccessBarrierVariant[] = [
     { id: 'barrier/private_liftgate', barrier: 'lift_gate', access: 'private' }
 ];
 
-function accessBarrierPreset(variant: AccessBarrierVariant): CustomPreset {
+function accessBarrierPreset(presetId: string, variant: AccessBarrierVariant, geometry: PresetGeometry[]): CustomPreset {
     const icon = variant.barrier === 'lift_gate' ? 'temaki-lift_gate' : 'maki-barrier';
-    return {
+    const preset: CustomPreset = {
         icon,
-        geometry: ['vertex', 'line'],
+        geometry,
         fields: ['access', 'opening_hours'],
         tags: { barrier: variant.barrier, access: variant.access },
-        name: presetNameEn(variant.id)
+        name: presetNameEn(presetId)
     };
+    // Beat generic `barrier/gate` when matching nodes on ways.
+    if (geometry.includes('vertex') && !geometry.includes('line')) {
+        preset.matchScore = 2;
+    }
+    return preset;
+}
+
+function accessBarrierPresetsForVariant(variant: AccessBarrierVariant): [string, CustomPreset][] {
+    if (variant.barrier === 'gate') {
+        return [
+            [variant.id, accessBarrierPreset(variant.id, variant, ['vertex'])],
+            [`${variant.id}_line`, accessBarrierPreset(`${variant.id}_line`, variant, ['line'])]
+        ];
+    }
+    return [[variant.id, accessBarrierPreset(variant.id, variant, ['vertex', 'line'])]];
 }
 
 /** Customer/private gates, lift gates, and public foot/bicycle gate (v5 Transition). */
 export const accessBarrierPresets: Record<string, CustomPreset> = {
-    ...Object.fromEntries(ACCESS_BARRIERS.map((v) => [v.id, accessBarrierPreset(v)] as const)),
+    ...Object.fromEntries(ACCESS_BARRIERS.flatMap(accessBarrierPresetsForVariant)),
     'barrier/gate_foot_bicycle_yes': gateFootBicycleYes
 };

--- a/data/custom-tagging/src/presets/entrance/entrance_variants.ts
+++ b/data/custom-tagging/src/presets/entrance/entrance_variants.ts
@@ -56,7 +56,7 @@ function entrancePreset(variant: EntranceVariant): CustomPreset {
     const addTags = variant.addTags ?? variant.tags;
     return {
         icon: variant.icon,
-        geometry: ['vertex'],
+        geometry: ['point', 'vertex'],
         fields: [...variant.fields],
         tags: variant.tags,
         ...(variant.addTags || variant.removeWildcards ? {
@@ -82,7 +82,7 @@ const ROUTING_ENTRANCE_VARIANTS: RoutingEntranceVariant[] = [
 function routingEntrancePreset(variant: RoutingEntranceVariant): CustomPreset {
     return {
         icon: 'maki-marker',
-        geometry: ['vertex'],
+        geometry: ['point', 'vertex'],
         fields: ['routing_entrance'],
         tags: variant.tags,
         matchScore: 0.8,

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_variants.ts
@@ -68,6 +68,8 @@ interface UnmarkedExtraVariant {
     extraTags: Record<string, string>;
     fields: readonly string[];
     removeWildcards?: Record<string, typeof ANY>;
+    /** Default `surface=asphalt` when drawing (not baked into `tags`). */
+    defaultAsphalt?: boolean;
 }
 
 /** v5 unmarked footway crossings (surface or access variants). */
@@ -86,26 +88,52 @@ const UNMARKED_EXTRA_VARIANTS: UnmarkedExtraVariant[] = [
         id: 'highway/footway/crossing/unmarked_customers',
         extraTags: { access: 'customers' },
         fields: FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS,
-        removeWildcards: { bicycle: ANY }
+        removeWildcards: { bicycle: ANY },
+        defaultAsphalt: true
     },
     {
         id: 'highway/footway/crossing/unmarked_private',
         extraTags: { access: 'private' },
         fields: FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS,
-        removeWildcards: { bicycle: ANY }
+        removeWildcards: { bicycle: ANY },
+        defaultAsphalt: true
     }
 ];
 
-/** v5 zebra footway crossings with restricted access. */
-const ZEBRA_ACCESS_VARIANTS: UnmarkedExtraVariant[] = [
+interface UncontrolledAccessVariant {
+    id: string;
+    markings: Extract<MarkingSlug, 'zebra' | 'lines'>;
+    extraTags: Record<string, string>;
+    fields: readonly string[];
+    removeWildcards?: Record<string, typeof ANY>;
+}
+
+/** v5 uncontrolled zebra/lines footway crossings with restricted access. */
+const UNCONTROLLED_ACCESS_VARIANTS: UncontrolledAccessVariant[] = [
     {
         id: 'highway/footway/crossing/uncontrolled-zebra_customers',
+        markings: 'zebra',
         extraTags: { access: 'customers' },
         fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
         removeWildcards: { bicycle: ANY }
     },
     {
         id: 'highway/footway/crossing/uncontrolled-zebra_private',
+        markings: 'zebra',
+        extraTags: { access: 'private' },
+        fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    },
+    {
+        id: 'highway/footway/crossing/uncontrolled-lines_customers',
+        markings: 'lines',
+        extraTags: { access: 'customers' },
+        fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
+        removeWildcards: { bicycle: ANY }
+    },
+    {
+        id: 'highway/footway/crossing/uncontrolled-lines_private',
+        markings: 'lines',
         extraTags: { access: 'private' },
         fields: FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS,
         removeWildcards: { bicycle: ANY }
@@ -122,6 +150,7 @@ function unmarkedExtraPreset(variant: UnmarkedExtraVariant): CustomPreset {
         'crossing:markings': 'no',
         ...variant.extraTags
     };
+    const addTags = variant.defaultAsphalt ? { ...tags, surface: 'asphalt' } : { ...tags };
 
     return {
         icon: 'temaki-pedestrian',
@@ -129,20 +158,20 @@ function unmarkedExtraPreset(variant: UnmarkedExtraVariant): CustomPreset {
         fields: [...variant.fields],
         moreFields: [...FOOTWAY_CROSSING_MORE_FIELDS],
         tags,
-        addTags: { ...tags },
-        removeTags: buildRemoveTags({ ...tags }, variant.removeWildcards ?? FOOTWAY_CROSSING_REMOVE_WILDCARDS),
+        addTags,
+        removeTags: buildRemoveTags(addTags, variant.removeWildcards ?? FOOTWAY_CROSSING_REMOVE_WILDCARDS),
         matchScore: 2,
         reference: FOOTWAY_CROSSING_REFERENCE,
         name: presetNameEn(variant.id)
     };
 }
 
-function zebraAccessPreset(variant: UnmarkedExtraVariant): CustomPreset {
+function uncontrolledAccessPreset(variant: UncontrolledAccessVariant): CustomPreset {
     const tags: Record<string, string> = {
         highway: 'footway',
         footway: 'crossing',
         crossing: 'uncontrolled',
-        'crossing:markings': 'zebra',
+        'crossing:markings': variant.markings,
         ...variant.extraTags
     };
     const addTags: Record<string, string> = {
@@ -151,7 +180,7 @@ function zebraAccessPreset(variant: UnmarkedExtraVariant): CustomPreset {
     };
 
     return {
-        icon: 'temaki-pedestrian_crosswalk',
+        icon: footwayCrossingIcon(variant.markings),
         geometry: ['line'],
         fields: [...variant.fields],
         moreFields: [...FOOTWAY_CROSSING_MORE_FIELDS],
@@ -214,5 +243,5 @@ function footwayCrossingPreset(variant: FootwayCrossingVariant): CustomPreset {
 export const footwayCrossingVariantPresets: Record<string, CustomPreset> = {
     ...Object.fromEntries(buildVariantList().map((v) => [v.id, footwayCrossingPreset(v)] as const)),
     ...Object.fromEntries(UNMARKED_EXTRA_VARIANTS.map((v) => [v.id, unmarkedExtraPreset(v)] as const)),
-    ...Object.fromEntries(ZEBRA_ACCESS_VARIANTS.map((v) => [v.id, zebraAccessPreset(v)] as const))
+    ...Object.fromEntries(UNCONTROLLED_ACCESS_VARIANTS.map((v) => [v.id, uncontrolledAccessPreset(v)] as const))
 };

--- a/data/custom-tagging/src/presets/highway/service_variants.ts
+++ b/data/custom-tagging/src/presets/highway/service_variants.ts
@@ -75,18 +75,30 @@ function accessRoadPresets(access: string): Record<string, CustomPreset> {
 }
 
 interface SubtypeVariant {
-    access: 'customers' | 'private';
+    access: 'customers' | 'private' | 'destination';
     service: 'driveway' | 'parking_aisle';
     unpaved?: boolean;
 }
 
+const SUBTYPE_ACCESS_TAGS: Record<SubtypeVariant['access'], Record<string, string>> = {
+    customers: { access: 'customers' },
+    private: { access: 'private' },
+    destination: { motor_vehicle: 'destination' }
+};
+
 const SUBTYPES: SubtypeVariant[] = [
     { access: 'customers', service: 'driveway' },
     { access: 'customers', service: 'parking_aisle' },
+    { access: 'customers', service: 'driveway', unpaved: true },
+    { access: 'customers', service: 'parking_aisle', unpaved: true },
     { access: 'private', service: 'driveway' },
     { access: 'private', service: 'parking_aisle' },
     { access: 'private', service: 'driveway', unpaved: true },
-    { access: 'private', service: 'parking_aisle', unpaved: true }
+    { access: 'private', service: 'parking_aisle', unpaved: true },
+    { access: 'destination', service: 'driveway' },
+    { access: 'destination', service: 'parking_aisle' },
+    { access: 'destination', service: 'driveway', unpaved: true },
+    { access: 'destination', service: 'parking_aisle', unpaved: true }
 ];
 
 function subtypeId(v: SubtypeVariant): string {
@@ -95,7 +107,11 @@ function subtypeId(v: SubtypeVariant): string {
 }
 
 function subtypePreset(v: SubtypeVariant): CustomPreset {
-    const tags: Record<string, string> = { highway: 'service', service: v.service, access: v.access };
+    const tags: Record<string, string> = {
+        highway: 'service',
+        service: v.service,
+        ...SUBTYPE_ACCESS_TAGS[v.access]
+    };
     if (v.unpaved) tags.surface = 'unpaved';
     const addTags = v.unpaved ? { ...tags } : { ...tags, surface: 'asphalt' };
 

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -54,6 +54,10 @@
         "terms": "cg, gate, customers",
         "aliases": "cg"
     },
+    "barrier/customers_gate_line": {
+        "name": "Customers gate (line)",
+        "terms": "customers gate barrier line"
+    },
     "barrier/customers_liftgate": {
         "name": "Customers lift gate",
         "terms": "clg, lift gate, customers",
@@ -68,6 +72,10 @@
         "name": "Private gate",
         "terms": "pg, gate, private",
         "aliases": "pg"
+    },
+    "barrier/private_gate_line": {
+        "name": "Private gate (line)",
+        "terms": "private gate barrier line"
     },
     "barrier/private_liftgate": {
         "name": "Private lift gate",
@@ -384,6 +392,16 @@
         "terms": "ulns, ul, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, lines crossing, lines",
         "aliases": "ulns"
     },
+    "highway/footway/crossing/uncontrolled-lines_customers": {
+        "name": "Uncontrolled Lines Footway Crossing (Customers)",
+        "terms": "ulcn, 4l, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, lines crossing, lines, customers",
+        "aliases": "4l"
+    },
+    "highway/footway/crossing/uncontrolled-lines_private": {
+        "name": "Uncontrolled Lines Footway Crossing (Private)",
+        "terms": "ulnp, 5l, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, lines crossing, lines, private",
+        "aliases": "5l"
+    },
     "highway/footway/crossing/uncontrolled-other": {
         "name": "Uncontrolled Footway Crossing (Other)",
         "terms": "ucons, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, other marking",
@@ -401,13 +419,13 @@
     },
     "highway/footway/crossing/uncontrolled-zebra_customers": {
         "name": "Uncontrolled Zebra Footway Crossing (Customers)",
-        "terms": "uzcn, uzc, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, customers",
-        "aliases": "uzcn"
+        "terms": "uzcn, 4k, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, customers",
+        "aliases": "4k"
     },
     "highway/footway/crossing/uncontrolled-zebra_private": {
         "name": "Uncontrolled Zebra Footway Crossing (Private)",
-        "terms": "uznp, uzp, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, private",
-        "aliases": "uznp"
+        "terms": "uznp, 5k, footway crossing, uncontrolled footway crossing, uncontrolled crosswalk, uncontrolled pedestrian crossing, zebra crossing, zebra, private",
+        "aliases": "5k"
     },
     "highway/footway/crossing/unmarked": {
         "name": "Unmarked Footway Crossing",
@@ -426,13 +444,13 @@
     },
     "highway/footway/crossing/unmarked_customers": {
         "name": "Unmarked Footway Crossing (Customers)",
-        "terms": "ucn, uc, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, customers",
-        "aliases": "ucn"
+        "terms": "ucn, 4u, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, customers, asphalt",
+        "aliases": "4u"
     },
     "highway/footway/crossing/unmarked_private": {
         "name": "Unmarked Footway Crossing (Private)",
-        "terms": "unp, up, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, private",
-        "aliases": "unp"
+        "terms": "unp, 5u, footway crossing, unmarked footway crossing, unmarked crosswalk, no marking crossing, private, asphalt",
+        "aliases": "5u"
     },
     "highway/footway/bicycle_dismount_asphalt": {
         "name": "Foot path (bicycle dismount asphalt)",
@@ -739,6 +757,16 @@
         "terms": "scpa, customers, parking aisle, service, access road",
         "aliases": "scpa"
     },
+    "highway/service/customers_unpaved_driveway": {
+        "name": "Customers unpaved driveway",
+        "terms": "scud, 4du, customers, unpaved, driveway, service, access road",
+        "aliases": "4du"
+    },
+    "highway/service/customers_unpaved_parking_aisle": {
+        "name": "Customers unpaved parking aisle",
+        "terms": "scupa, 4pu, customers, unpaved, parking aisle, service, access road",
+        "aliases": "4pu"
+    },
     "highway/service/private_driveway": {
         "name": "Private driveway",
         "terms": "spd, private, driveway, service, access road",
@@ -751,13 +779,33 @@
     },
     "highway/service/private_unpaved_driveway": {
         "name": "Private unpaved driveway",
-        "terms": "spud, private, unpaved, driveway, service, access road",
-        "aliases": "spud"
+        "terms": "spud, 5du, private, unpaved, driveway, service, access road",
+        "aliases": "5du"
     },
     "highway/service/private_unpaved_parking_aisle": {
         "name": "Private unpaved parking aisle",
-        "terms": "spupa, private, unpaved, parking aisle, service, access road",
-        "aliases": "spupa"
+        "terms": "spupa, 5pu, private, unpaved, parking aisle, service, access road",
+        "aliases": "5pu"
+    },
+    "highway/service/destination_driveway": {
+        "name": "Destination driveway",
+        "terms": "sdd, 6d, destination, driveway, service, motor_vehicle",
+        "aliases": "6d"
+    },
+    "highway/service/destination_parking_aisle": {
+        "name": "Destination parking aisle",
+        "terms": "sdpa, 6p, destination, parking aisle, service, motor_vehicle",
+        "aliases": "6p"
+    },
+    "highway/service/destination_unpaved_driveway": {
+        "name": "Destination unpaved driveway",
+        "terms": "sdud, 6du, destination, unpaved, driveway, service, motor_vehicle",
+        "aliases": "6du"
+    },
+    "highway/service/destination_unpaved_parking_aisle": {
+        "name": "Destination unpaved parking aisle",
+        "terms": "sdupa, 6pu, destination, unpaved, parking aisle, service, motor_vehicle",
+        "aliases": "6pu"
     },
     "highway/service/customers": {
         "name": "Customers service road",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -54,6 +54,10 @@
         "terms": "cg, bc, barrière, clients",
         "aliases": "cg"
     },
+    "barrier/customers_gate_line": {
+        "name": "Barrière Clients (ligne)",
+        "terms": "barrière clients ligne"
+    },
     "barrier/customers_liftgate": {
         "name": "Barrière levante Clients",
         "terms": "clg, blc, barrière levante, clients",
@@ -68,6 +72,10 @@
         "name": "Barrière Privée",
         "terms": "pg, bp, barrière, privée",
         "aliases": "pg"
+    },
+    "barrier/private_gate_line": {
+        "name": "Barrière Privée (ligne)",
+        "terms": "barrière privée ligne"
     },
     "barrier/private_liftgate": {
         "name": "Barrière levante Privée",
@@ -384,6 +392,16 @@
         "terms": "ulns, ulns, ul, uclns, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, lignes, marquage en lignes",
         "aliases": "ulns"
     },
+    "highway/footway/crossing/uncontrolled-lines_customers": {
+        "name": "Traversée piétonne — Lignes (clients)",
+        "terms": "ulcn, 4l, traversée piétonne, passage piéton, traversée, non contrôlé, lignes, marquage lignes, clients",
+        "aliases": "4l"
+    },
+    "highway/footway/crossing/uncontrolled-lines_private": {
+        "name": "Traversée piétonne — Lignes (privé)",
+        "terms": "ulnp, 5l, traversée piétonne, passage piéton, traversée, non contrôlé, lignes, marquage lignes, privé",
+        "aliases": "5l"
+    },
     "highway/footway/crossing/uncontrolled-other": {
         "name": "Traversée piétonne — Non contrôlé, autre",
         "terms": "ucons, ucons, traversée piétonne, passage piéton, passage piéton, traversée, non contrôlé, sans signalisation, autre marquage, marquage autre",
@@ -401,13 +419,13 @@
     },
     "highway/footway/crossing/uncontrolled-zebra_customers": {
         "name": "Traversée piétonne — Zébrée (clients)",
-        "terms": "uzcn, uzc, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, clients",
-        "aliases": "uzcn"
+        "terms": "uzcn, 4k, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, clients",
+        "aliases": "4k"
     },
     "highway/footway/crossing/uncontrolled-zebra_private": {
         "name": "Traversée piétonne — Zébrée (privé)",
-        "terms": "uznp, uzp, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, privé",
-        "aliases": "uznp"
+        "terms": "uznp, 5k, traversée piétonne, passage piéton, traversée, non contrôlé, zébrée, passage zébré, bandes zébrées, privé",
+        "aliases": "5k"
     },
     "highway/footway/crossing/unmarked": {
         "name": "Traversée piétonne — Non marqué",
@@ -426,13 +444,13 @@
     },
     "highway/footway/crossing/unmarked_customers": {
         "name": "Traversée piétonne — Non marqué (clients)",
-        "terms": "ucn, uc, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, clients",
-        "aliases": "ucn"
+        "terms": "ucn, 4u, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, clients, asphalte",
+        "aliases": "4u"
     },
     "highway/footway/crossing/unmarked_private": {
         "name": "Traversée piétonne — Non marqué (privé)",
-        "terms": "unp, up, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, privé",
-        "aliases": "unp"
+        "terms": "unp, 5u, traversée piétonne, passage piéton, traversée, non marqué, sans marquage, privé, asphalte",
+        "aliases": "5u"
     },
     "highway/footway/bicycle_dismount_asphalt": {
         "name": "Chemin piéton (vélo à pied, asphalte)",
@@ -739,6 +757,16 @@
         "terms": "scpa, clients, allée de stationnement, voie de service, service",
         "aliases": "scpa"
     },
+    "highway/service/customers_unpaved_driveway": {
+        "name": "Entrée clients non revêtue",
+        "terms": "scud, 4du, clients, non revêtue, entrée, allée, voie de service",
+        "aliases": "4du"
+    },
+    "highway/service/customers_unpaved_parking_aisle": {
+        "name": "Allée de stationnement clients non revêtue",
+        "terms": "scupa, 4pu, clients, non revêtue, allée de stationnement, voie de service",
+        "aliases": "4pu"
+    },
     "highway/service/private_driveway": {
         "name": "Entrée privée",
         "terms": "spd, privé, entrée, allée, voie de service, service",
@@ -751,13 +779,33 @@
     },
     "highway/service/private_unpaved_driveway": {
         "name": "Entrée privée non revêtue",
-        "terms": "spud, privé, non revêtue, entrée, allée, voie de service",
-        "aliases": "spud"
+        "terms": "spud, 5du, privé, non revêtue, entrée, allée, voie de service",
+        "aliases": "5du"
     },
     "highway/service/private_unpaved_parking_aisle": {
         "name": "Allée de stationnement privée non revêtue",
-        "terms": "spupa, privé, non revêtue, allée de stationnement, voie de service",
-        "aliases": "spupa"
+        "terms": "spupa, 5pu, privé, non revêtue, allée de stationnement, voie de service",
+        "aliases": "5pu"
+    },
+    "highway/service/destination_driveway": {
+        "name": "Entrée destination",
+        "terms": "sdd, 6d, destination, entrée, allée, voie de service, motor_vehicle",
+        "aliases": "6d"
+    },
+    "highway/service/destination_parking_aisle": {
+        "name": "Allée de stationnement destination",
+        "terms": "sdpa, 6p, destination, allée de stationnement, voie de service, motor_vehicle",
+        "aliases": "6p"
+    },
+    "highway/service/destination_unpaved_driveway": {
+        "name": "Entrée destination non revêtue",
+        "terms": "sdud, 6du, destination, non revêtue, entrée, allée, voie de service",
+        "aliases": "6du"
+    },
+    "highway/service/destination_unpaved_parking_aisle": {
+        "name": "Allée de stationnement destination non revêtue",
+        "terms": "sdupa, 6pu, destination, non revêtue, allée de stationnement, voie de service",
+        "aliases": "6pu"
     },
     "highway/service/customers": {
         "name": "Voie de service clients",

--- a/test/spec/presets/custom/barrier.js
+++ b/test/spec/presets/custom/barrier.js
@@ -1,13 +1,34 @@
-import { loadCustomPresets } from './setup.js';
+import { loadCustomPresets, loadCustomDistJson } from './setup.js';
+import { presetShortcutDrawingGeometry } from '../../../../modules/core/preset_shortcut_format.js';
 
 describe('custom presets — barrier', function() {
     loadCustomPresets();
 
-    it('loads barrier gate presets from locales', function() {
+    it('loads barrier gate presets from locales', async function() {
+        const { customPresets } = await loadCustomDistJson();
+
         const customersGate = iD.presetManager.item('barrier/customers_gate');
         expect(customersGate, 'customers gate').to.exist;
         expect(customersGate.name()).to.equal('Customers gate');
         expect(customersGate.tags).to.include({ barrier: 'gate', access: 'customers' });
+        expect(customersGate.geometry).to.eql(['vertex']);
+        expect(customPresets['barrier/customers_gate'].matchScore).to.equal(2);
+        expect(presetShortcutDrawingGeometry(customersGate)).to.equal('point');
+
+        const customersGateLine = iD.presetManager.item('barrier/customers_gate_line');
+        expect(customersGateLine, 'customers gate line').to.exist;
+        expect(customersGateLine.geometry).to.eql(['line']);
+
+        const privateGate = iD.presetManager.item('barrier/private_gate');
+        expect(privateGate, 'private gate').to.exist;
+        expect(privateGate.geometry).to.eql(['vertex']);
+        expect(customPresets['barrier/private_gate'].matchScore).to.equal(2);
+        expect(presetShortcutDrawingGeometry(privateGate)).to.equal('point');
+
+        const privateGateLine = iD.presetManager.item('barrier/private_gate_line');
+        expect(privateGateLine, 'private gate line').to.exist;
+        expect(privateGateLine.geometry).to.eql(['line']);
+        expect(presetShortcutDrawingGeometry(privateGateLine)).to.equal('line');
 
         const publicGate = iD.presetManager.item('barrier/gate_foot_bicycle_yes');
         expect(publicGate, 'public foot/bicycle gate').to.exist;

--- a/test/spec/presets/custom/entrance.js
+++ b/test/spec/presets/custom/entrance.js
@@ -20,6 +20,7 @@ describe('custom presets — entrance', function() {
             expect(preset, id).to.exist;
             expect(preset.icon).to.equal(icon);
             expect(preset.matchGeometry('vertex')).to.be.true;
+            expect(preset.matchGeometry('point')).to.be.true;
             expect(preset.matchScore(tags)).to.be.above(0);
         });
     }
@@ -36,6 +37,7 @@ describe('custom presets — entrance', function() {
             expect(preset, id).to.exist;
             expect(preset.icon).to.equal('maki-marker');
             expect(preset.matchGeometry('vertex')).to.be.true;
+            expect(preset.matchGeometry('point')).to.be.true;
             expect(preset.matchScore(tags)).to.be.above(0);
             expect(preset.fields().map((f) => f.id)).to.include('routing_entrance');
         });
@@ -55,6 +57,14 @@ describe('custom presets — entrance', function() {
         const preset = iD.presetManager.match(point, graph);
         expect(preset.id).to.equal('entrance/main');
         expect(preset.icon).to.equal('iD-entrance-main');
+    });
+
+    it('matches home entrance on a standalone point node', function() {
+        const point = new iD.osmNode({ loc: [0, 0], tags: { entrance: 'home' } });
+        const graph = new iD.coreGraph([point]);
+        expect(point.geometry(graph)).to.equal('point');
+        const preset = iD.presetManager.match(point, graph);
+        expect(preset.id).to.equal('entrance/home');
     });
 
     it('defines private entrance preset tags and removeTags', function() {

--- a/test/spec/presets/custom/footway_crossing.js
+++ b/test/spec/presets/custom/footway_crossing.js
@@ -58,26 +58,45 @@ describe('custom presets — footway crossing', function() {
         });
         const asphalt = iD.presetManager.item('highway/footway/crossing/unmarked_asphalt');
         expect(asphalt.tags).to.include({ surface: 'asphalt' });
-        expect(iD.presetManager.item('highway/footway/crossing/unmarked_customers').tags).to.include({
-            access: 'customers'
-        });
+        const customers = iD.presetManager.item('highway/footway/crossing/unmarked_customers');
+        expect(customers.tags).to.include({ access: 'customers' });
+        expect(customers.tags).to.not.have.property('surface');
+        expect(customers.addTags).to.include({ surface: 'asphalt', access: 'customers' });
     });
 
-    const zebraAccessCases = [
+    const uncontrolledAccessCases = [
         {
             id: 'highway/footway/crossing/uncontrolled-zebra_customers',
+            markings: 'zebra',
             access: 'customers',
-            name: 'Uncontrolled Zebra Footway Crossing (Customers)'
+            name: 'Uncontrolled Zebra Footway Crossing (Customers)',
+            alias: '4k'
         },
         {
             id: 'highway/footway/crossing/uncontrolled-zebra_private',
+            markings: 'zebra',
             access: 'private',
-            name: 'Uncontrolled Zebra Footway Crossing (Private)'
+            name: 'Uncontrolled Zebra Footway Crossing (Private)',
+            alias: '5k'
+        },
+        {
+            id: 'highway/footway/crossing/uncontrolled-lines_customers',
+            markings: 'lines',
+            access: 'customers',
+            name: 'Uncontrolled Lines Footway Crossing (Customers)',
+            alias: '4l'
+        },
+        {
+            id: 'highway/footway/crossing/uncontrolled-lines_private',
+            markings: 'lines',
+            access: 'private',
+            name: 'Uncontrolled Lines Footway Crossing (Private)',
+            alias: '5l'
         }
     ];
 
-    zebraAccessCases.forEach(function({ id, access, name }) {
-        it(`${id} sets zebra crossing tags, default asphalt, and ${access} access`, function() {
+    uncontrolledAccessCases.forEach(function({ id, markings, access, name, alias }) {
+        it(`${id} sets ${markings} crossing tags, default asphalt, and ${access} access`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
             expect(preset.name()).to.equal(name);
@@ -85,7 +104,7 @@ describe('custom presets — footway crossing', function() {
                 highway: 'footway',
                 footway: 'crossing',
                 crossing: 'uncontrolled',
-                'crossing:markings': 'zebra',
+                'crossing:markings': markings,
                 access
             });
             expect(preset.tags).to.not.have.property('surface');
@@ -96,5 +115,19 @@ describe('custom presets — footway crossing', function() {
             expect(preset.originalFields).to.include('surface');
             expect(preset.originalFields).to.include('access_restricted');
         });
+
+        it(`finds ${id} by alias ${alias}`, function() {
+            const pool = iD.presetManager.matchAllGeometry(['line']);
+            const byAlias = pool.search(alias, 'line').collection.map((p) => p.id);
+            expect(byAlias).to.include(id);
+        });
+    });
+
+    it('finds restricted unmarked crossings by alias', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        expect(pool.search('4u', 'line').collection.map((p) => p.id))
+            .to.include('highway/footway/crossing/unmarked_customers');
+        expect(pool.search('5u', 'line').collection.map((p) => p.id))
+            .to.include('highway/footway/crossing/unmarked_private');
     });
 });

--- a/test/spec/presets/custom/service.js
+++ b/test/spec/presets/custom/service.js
@@ -38,12 +38,18 @@ const ROAD_CASES = Object.keys(ACCESS).flatMap((access) => {
 });
 
 const SUBTYPE_CASES = [
-    { id: 'highway/service/customers_driveway', service: 'driveway', access: 'customers', paved: true },
-    { id: 'highway/service/customers_parking_aisle', service: 'parking_aisle', access: 'customers', paved: true },
-    { id: 'highway/service/private_driveway', service: 'driveway', access: 'private', paved: true },
-    { id: 'highway/service/private_parking_aisle', service: 'parking_aisle', access: 'private', paved: true },
-    { id: 'highway/service/private_unpaved_driveway', service: 'driveway', access: 'private', paved: false },
-    { id: 'highway/service/private_unpaved_parking_aisle', service: 'parking_aisle', access: 'private', paved: false }
+    { id: 'highway/service/customers_driveway', service: 'driveway', restrictionTags: { access: 'customers' }, paved: true },
+    { id: 'highway/service/customers_parking_aisle', service: 'parking_aisle', restrictionTags: { access: 'customers' }, paved: true },
+    { id: 'highway/service/customers_unpaved_driveway', service: 'driveway', restrictionTags: { access: 'customers' }, paved: false },
+    { id: 'highway/service/customers_unpaved_parking_aisle', service: 'parking_aisle', restrictionTags: { access: 'customers' }, paved: false },
+    { id: 'highway/service/private_driveway', service: 'driveway', restrictionTags: { access: 'private' }, paved: true },
+    { id: 'highway/service/private_parking_aisle', service: 'parking_aisle', restrictionTags: { access: 'private' }, paved: true },
+    { id: 'highway/service/private_unpaved_driveway', service: 'driveway', restrictionTags: { access: 'private' }, paved: false },
+    { id: 'highway/service/private_unpaved_parking_aisle', service: 'parking_aisle', restrictionTags: { access: 'private' }, paved: false },
+    { id: 'highway/service/destination_driveway', service: 'driveway', restrictionTags: { motor_vehicle: 'destination' }, paved: true },
+    { id: 'highway/service/destination_parking_aisle', service: 'parking_aisle', restrictionTags: { motor_vehicle: 'destination' }, paved: true },
+    { id: 'highway/service/destination_unpaved_driveway', service: 'driveway', restrictionTags: { motor_vehicle: 'destination' }, paved: false },
+    { id: 'highway/service/destination_unpaved_parking_aisle', service: 'parking_aisle', restrictionTags: { motor_vehicle: 'destination' }, paved: false }
 ];
 
 describe('custom presets — service roads', function() {
@@ -65,11 +71,11 @@ describe('custom presets — service roads', function() {
         });
     });
 
-    SUBTYPE_CASES.forEach(function({ id, service, access, paved }) {
+    SUBTYPE_CASES.forEach(function({ id, service, restrictionTags, paved }) {
         it(`defines subtype ${id}`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
-            expect(preset.tags).to.include({ highway: 'service', service, access });
+            expect(preset.tags).to.include({ highway: 'service', service, ...restrictionTags });
             expect(preset.addTags.surface).to.equal(paved ? 'asphalt' : 'unpaved');
         });
     });
@@ -93,8 +99,14 @@ describe('custom presets — service roads', function() {
         const pool = iD.presetManager.matchAllGeometry(['line']);
         const byScsb = pool.search('scsb', 'line').collection.map((p) => p.id);
         expect(byScsb).to.include('highway/service/customers_sidewalk_both');
-        const bySpud = pool.search('spud', 'line').collection.map((p) => p.id);
-        expect(bySpud).to.include('highway/service/private_unpaved_driveway');
+        const by4du = pool.search('4du', 'line').collection.map((p) => p.id);
+        expect(by4du).to.include('highway/service/customers_unpaved_driveway');
+        const by5du = pool.search('5du', 'line').collection.map((p) => p.id);
+        expect(by5du).to.include('highway/service/private_unpaved_driveway');
+        const by6d = pool.search('6d', 'line').collection.map((p) => p.id);
+        expect(by6d).to.include('highway/service/destination_driveway');
+        const by6pu = pool.search('6pu', 'line').collection.map((p) => p.id);
+        expect(by6pu).to.include('highway/service/destination_unpaved_parking_aisle');
     });
 
     it('defines the private unmaintained track preset', function() {


### PR DESCRIPTION
## Summary
- Split customers/private gate presets into vertex (`pg`/`cg`) and line variants so shortcuts place nodes on ways
- Add service driveway/parking aisle presets for customers (incl. unpaved), private (shortcut aliases), and destination (`6d`/`6p`/`6du`/`6pu`)
- Add customers/private footway crossings (unmarked, zebra, lines) with default asphalt and shortcuts `4u`/`4k`/`4l`, `5u`/`5k`/`5l`
- Allow entrance presets on standalone `point` nodes for batch home entrance placement

## Test plan
- [x] `npm run build:presets:custom`
- [x] `vitest` on `barrier`, `entrance`, `footway_crossing`, `service` custom preset specs
- [ ] Shortcut `pg`/`cg` enters add-point mode (not line draw)
- [ ] `4du`, `6d`, `4u`, `4l` draw expected service/crossing features
- [ ] Entrance/home shortcut places standalone nodes without building vertex