### PR TITLE
Presets: add is_side_road field on car highways

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -30,6 +30,15 @@
                         "sidewalk": "Yes"
                     }
                 },
+                "is_side_road": {
+                    "label": "Side road",
+                    "options": {
+                        "undefined": "Unknown",
+                        "yes": "Yes (pocket)",
+                        "double": "Double carriageway",
+                        "rotary": "Turn pocket"
+                    }
+                },
                 "post_box/type": {
                     "label": "Box type",
                     "options": {

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -27,6 +27,15 @@
                         "sidewalk": "Oui"
                     }
                 },
+                "is_side_road": {
+                    "label": "Boisé latéral (carmain)",
+                    "options": {
+                        "undefined": "Inconnu",
+                        "yes": "Oui (carmain)",
+                        "double": "Double voie",
+                        "rotary": "Voie de virage"
+                    }
+                },
                 "capacity_charging": {
                     "label": "Capacité de recharge pour véhicules électriques",
                     "placeholder": "1, 5, 10..."

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -173,6 +173,14 @@ export const customFields = {
         options: ['undefined', 'sidewalk'],
         geometry: ['line'],
         prerequisiteTag: { key: 'foot', valueNot: 'no' }
+    },
+    // Marks a carriageway as a side road / carmain (side_road=*). Cycles through the
+    // wiki values on click; unset removes the tag. See Key:side_road.
+    is_side_road: {
+        key: 'side_road',
+        type: 'defaultCheck',
+        options: ['undefined', 'yes', 'double', 'rotary'],
+        geometry: ['line']
     }
 };
 
@@ -210,8 +218,13 @@ const MANAGED_LANE_FIELDS = [
 // the lane / placement fields fold into directional groups, which lay their
 // sub-rows out compactly themselves (see uiFieldDirectionalGroup / CSS).
 const SMALL_FIELDS = [
-    'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway', 'is_sidewalk'
+    'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway', 'is_sidewalk', 'is_side_road'
 ];
+
+// highway=* values that may carry side_road=* (car mains; not motorway or *_link ramps).
+const SIDE_ROAD_HIGHWAYS = new Set([
+    'residential', 'unclassified', 'tertiary', 'secondary', 'primary', 'trunk'
+]);
 
 // highway=* values that should offer the sidewalk field
 const SIDEWALK_HIGHWAYS = new Set([
@@ -340,6 +353,15 @@ export function applyCustomFields(presetManager) {
         const afterDual = fields.indexOf('dual_carriageway');
         const junctionAt = afterDual === -1 ? dualAt : afterDual + 1;
         fields.splice(junctionAt < 0 ? fields.length : junctionAt, 0, 'junction_oneway');
+
+        // side road (carmain): default field after dual_carriageway on car highways.
+        if (SIDE_ROAD_HIGHWAYS.has(highway)) {
+            removeField(fields, 'is_side_road');
+            removeField(moreFields, 'is_side_road');
+            const sideRoadAt = fields.indexOf('dual_carriageway');
+            const insertAt = sideRoadAt === -1 ? junctionAt : sideRoadAt + 1;
+            fields.splice(insertAt < 0 ? fields.length : insertAt, 0, 'is_side_road');
+        }
 
         // advisory speed: default field right after `maxspeed` (hidden by its
         // prerequisite until highway=motorway_link or junction=roundabout). Drop

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -221,9 +221,11 @@ const SMALL_FIELDS = [
     'oneway', 'maxspeed', 'maxspeed_advisory', 'minspeed', 'surface', 'sidewalk', 'ref_road_number', 'dual_carriageway', 'is_sidewalk', 'is_side_road'
 ];
 
-// highway=* values that may carry side_road=* (car mains; not motorway or *_link ramps).
+// highway=* values that may carry side_road=* (car mains). Excludes motorway and
+// motorway_link only; other *_link ramps are included.
 const SIDE_ROAD_HIGHWAYS = new Set([
-    'residential', 'unclassified', 'tertiary', 'secondary', 'primary', 'trunk'
+    'residential', 'unclassified', 'tertiary', 'secondary', 'primary', 'trunk',
+    'trunk_link', 'tertiary_link', 'secondary_link', 'primary_link'
 ]);
 
 // highway=* values that should offer the sidewalk field

--- a/test/spec/presets/custom/highway_side_road.js
+++ b/test/spec/presets/custom/highway_side_road.js
@@ -1,0 +1,74 @@
+import { loadCustomDistJson, loadCustomPresets } from './setup.js';
+
+const SIDE_ROAD_HIGHWAYS = ['residential', 'unclassified', 'tertiary', 'secondary', 'primary', 'trunk'];
+
+/** Minimal upstream road presets for is_side_road injection tests. */
+const UPSTREAM_ROAD_PRESETS = {
+    'highway/residential': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway', 'maxspeed', 'lanes', 'surface', 'structure', 'access'],
+        moreFields: ['sidewalk', 'cycleway'],
+        geometry: ['line'],
+        tags: { highway: 'residential' },
+        name: 'Residential Road'
+    },
+    'highway/motorway': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway', 'maxspeed', 'lanes', 'surface', 'structure', 'access'],
+        moreFields: ['sidewalk'],
+        geometry: ['line'],
+        tags: { highway: 'motorway' },
+        name: 'Motorway'
+    },
+    'highway/primary_link': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway', 'maxspeed', 'lanes', 'surface', 'structure', 'access'],
+        geometry: ['line'],
+        tags: { highway: 'primary_link' },
+        name: 'Primary Link'
+    }
+};
+
+describe('custom fields — is_side_road', function() {
+    loadCustomPresets();
+
+    for (const highway of SIDE_ROAD_HIGHWAYS) {
+        it(`offers is_side_road on highway/${highway}_sidewalk_both`, function() {
+            const preset = iD.presetManager.item(`highway/${highway}_sidewalk_both`);
+            expect(preset, highway).to.exist;
+            const fieldIds = preset.fields().map((f) => f.id);
+            expect(fieldIds, highway).to.include('is_side_road');
+            expect(preset.originalFields, highway).to.include('is_side_road');
+        });
+    }
+});
+
+describe('custom fields — is_side_road (upstream road presets)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_ROAD_PRESETS;
+        iD.fileFetcher.cache().preset_fields = {};
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    it('injects is_side_road after dual_carriageway on highway/residential', function() {
+        const preset = iD.presetManager.item('highway/residential');
+        expect(preset).to.exist;
+        expect(preset.originalFields).to.include('is_side_road');
+        const dualIndex = preset.originalFields.indexOf('dual_carriageway');
+        const sideRoadIndex = preset.originalFields.indexOf('is_side_road');
+        expect(dualIndex).to.be.at.least(0);
+        expect(sideRoadIndex).to.equal(dualIndex + 1);
+    });
+
+    for (const id of ['highway/motorway', 'highway/primary_link']) {
+        it(`does not offer is_side_road on ${id}`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            const fieldIds = preset.fields().map((f) => f.id);
+            expect(fieldIds, id).to.not.include('is_side_road');
+        });
+    }
+});

--- a/test/spec/presets/custom/highway_side_road.js
+++ b/test/spec/presets/custom/highway_side_road.js
@@ -26,6 +26,13 @@ const UPSTREAM_ROAD_PRESETS = {
         geometry: ['line'],
         tags: { highway: 'primary_link' },
         name: 'Primary Link'
+    },
+    'highway/motorway_link': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway', 'maxspeed', 'lanes', 'surface', 'structure', 'access'],
+        geometry: ['line'],
+        tags: { highway: 'motorway_link' },
+        name: 'Motorway Link'
     }
 };
 
@@ -63,7 +70,13 @@ describe('custom fields — is_side_road (upstream road presets)', function() {
         expect(sideRoadIndex).to.equal(dualIndex + 1);
     });
 
-    for (const id of ['highway/motorway', 'highway/primary_link']) {
+    it('offers is_side_road on highway/primary_link', function() {
+        const preset = iD.presetManager.item('highway/primary_link');
+        expect(preset).to.exist;
+        expect(preset.fields().map((f) => f.id)).to.include('is_side_road');
+    });
+
+    for (const id of ['highway/motorway', 'highway/motorway_link']) {
         it(`does not offer is_side_road on ${id}`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;


### PR DESCRIPTION
## Summary
- Add runtime `is_side_road` field (`side_road=yes` / `double` / `rotary`) on car highways — same pattern as `is_sidewalk` on cycleways.
- Covers residential, unclassified, tertiary, secondary, primary, trunk, and their `*_link` ramps; excludes motorway and motorway_link only.
- Inject after `dual_carriageway` in the road field block; EN/FR labels in custom locales.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/highway_side_road.js`