### PR TITLE
Fix: warn and auto-fix missing or paved highway surface

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -268,6 +268,7 @@ export function applyCustomFields(presetManager) {
     customizeBuildingLevels(presetManager);
     customizeBusStopBench(presetManager);
     setCycleFootPathDefaultSurface(presetManager);
+    setCarHighwayDefaultSurface(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
@@ -528,6 +529,34 @@ function setCycleFootPathDefaultSurface(presetManager) {
     const preset = presetManager.item('highway/cycleway/bicycle_foot');
     if (!preset) return;
     preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
+}
+
+/** Upstream base car-highway presets that default to surface=asphalt in v5. */
+const CAR_HIGHWAY_SURFACE_PRESET_IDS = [
+    'highway/motorway',
+    'highway/trunk',
+    'highway/primary',
+    'highway/secondary',
+    'highway/tertiary',
+    'highway/unclassified',
+    'highway/residential',
+    'highway/service',
+    'highway/busway'
+];
+
+/**
+ * Default car highways to surface=asphalt via `addTags` (v5 fork parity).
+ * Drives outdated_tags incomplete-tag warnings and the Upgrade Tags fix.
+ * Idempotent; does not touch variant presets (e.g. unpaved service roads).
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function setCarHighwayDefaultSurface(presetManager) {
+    for (const presetID of CAR_HIGHWAY_SURFACE_PRESET_IDS) {
+        const preset = presetManager.item(presetID);
+        if (!preset) continue;
+        preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
+    }
 }
 
 const FLATS_FIELD = 'flats';

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -13,6 +13,18 @@ import { getDeprecatedTags } from '../osm/deprecated';
 
 /** @import { TagDiff } from '../util/util'. */
 
+/**
+ * Whether a preset `addTags` value should be applied (v5 fork: surface=paved → asphalt).
+ * @param {Record<string, string>} tags
+ * @param {string} key
+ * @param {string} addTagValue
+ * @returns {boolean}
+ */
+function shouldApplyPresetAddTag(tags, key, addTagValue) {
+  if (!addTagValue || addTagValue === '*') return !tags[key];
+  if (!tags[key]) return true;
+  return key === 'surface' && tags[key] === 'paved' && addTagValue === 'asphalt';
+}
 
 export function validationOutdatedTags() {
   const type = 'outdated_tags';
@@ -82,12 +94,11 @@ export function validationOutdatedTags() {
         // if nsi suggestion already includes this tag: don't repeat it in "incomplete tags"
         return !nsiResult?.newTags[k];
       }).forEach(k => {
-        if (!newTags[k]) {
-          if (preset.addTags[k] === '*') {
-            newTags[k] = 'yes';
-          } else if (preset.addTags[k]) {
-            newTags[k] = preset.addTags[k];
-          }
+        if (!shouldApplyPresetAddTag(newTags, k, preset.addTags[k])) return;
+        if (preset.addTags[k] === '*') {
+          newTags[k] = 'yes';
+        } else if (preset.addTags[k]) {
+          newTags[k] = preset.addTags[k];
         }
       });
     }

--- a/test/spec/presets/custom/highway_surface_default.js
+++ b/test/spec/presets/custom/highway_surface_default.js
@@ -1,0 +1,43 @@
+import { loadCustomDistJson } from './setup.js';
+
+/** Minimal upstream car-highway presets for surface=asphalt addTags tests. */
+const UPSTREAM_HIGHWAY_PRESETS = Object.fromEntries(
+    [
+        'motorway', 'trunk', 'primary', 'secondary', 'tertiary',
+        'unclassified', 'residential', 'service', 'busway'
+    ].map(highway => [
+        `highway/${highway}`,
+        {
+            icon: 'fas-road',
+            fields: ['name', 'surface'],
+            geometry: ['line'],
+            tags: { highway },
+            name: highway
+        }
+    ])
+);
+
+describe('custom highway surface defaults (v5 parity)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_HIGHWAY_PRESETS;
+        iD.fileFetcher.cache().preset_fields = {};
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    const cases = Object.keys(UPSTREAM_HIGHWAY_PRESETS);
+
+    it.each(cases)('%s addTags default surface=asphalt', function(presetID) {
+        const preset = iD.presetManager.item(presetID);
+        expect(preset, presetID).to.exist;
+        expect(preset.addTags.surface).to.equal('asphalt');
+    });
+
+    it('does not override unpaved service variant addTags', function() {
+        const preset = iD.presetManager.item('highway/service/private_unpaved');
+        expect(preset).to.exist;
+        expect(preset.addTags.surface).to.equal('unpaved');
+    });
+});

--- a/test/spec/validations/outdated_tags.js
+++ b/test/spec/validations/outdated_tags.js
@@ -33,6 +33,33 @@ describe('iD.validations.outdated_tags', function () {
         delete iD.services.nsi;
     });
 
+    const UPSTREAM_HIGHWAY_PRESETS = {
+        'highway/residential': {
+            geometry: ['line'],
+            tags: { highway: 'residential' },
+            fields: ['surface'],
+            name: 'Residential Road'
+        },
+        'highway/primary': {
+            geometry: ['line'],
+            tags: { highway: 'primary' },
+            fields: ['surface'],
+            name: 'Primary Road'
+        },
+        'highway/unclassified': {
+            geometry: ['line'],
+            tags: { highway: 'unclassified' },
+            fields: ['surface'],
+            name: 'Unclassified Road'
+        }
+    };
+
+    beforeAll(async () => {
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_HIGHWAY_PRESETS;
+        iD.fileFetcher.cache().preset_fields = {};
+        await iD.presetManager.ensureLoaded(true);
+    });
+
     beforeEach(function() {
         context = iD.coreContext().init();
     });
@@ -84,11 +111,30 @@ describe('iD.validations.outdated_tags', function () {
     });
 
     it('has no errors on good tags', async () => {
-        createWay({'highway': 'unclassified'});
+        createWay({'highway': 'unclassified', 'surface': 'asphalt'});
         var validator = iD.validationOutdatedTags(context);
         await setTimeout(20);
         var issues = validate(validator);
         expect(issues).to.have.lengthOf(0);
+    });
+
+    it.each([
+        ['missing surface', { highway: 'residential' }, 'incomplete_tags', { highway: 'residential', surface: 'asphalt' }],
+        ['surface=paved', { highway: 'primary', surface: 'paved' }, 'deprecated_tags', { highway: 'primary', surface: 'asphalt' }]
+    ])('flags imprecise surface (%s)', async (_label, tags, subtype, expected) => {
+        createWay(tags);
+        const validator = iD.validationOutdatedTags(context);
+        await setTimeout(20);
+        const issues = validate(validator);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toMatchObject({
+            type: 'outdated_tags',
+            subtype,
+            severity: 'warning',
+            entityIds: ['w-1']
+        });
+        issues[0].dynamicFixes()[0].onClick(context);
+        expect(context.graph().entity('w-1').tags).toStrictEqual(expected);
     });
 
     it('flags deprecated tag with replacement', async () => {


### PR DESCRIPTION
## Summary
- Restore v5 `addTags.surface=asphalt` on base car-highway presets (motorway through busway).
- Flag `surface` missing or `surface=paved` via `outdated_tags` with an Upgrade tags fix to `surface=asphalt`.
- Visual validation (`tag-surface-undefined`) unchanged; works with the Québec lens.

## Test plan
- [x] `npx vitest run test/spec/validations/outdated_tags.js test/spec/presets/custom/highway_surface_default.js`