### PR TITLE
Fix: laneList crash on multiselect with different lanes

### DIFF
--- a/modules/ui/fields/lane_list.ts
+++ b/modules/ui/fields/lane_list.ts
@@ -79,7 +79,7 @@ export function uiFieldLaneList(
                 .attr('class', 'lane-multiselect-conflict field-warning')
                 .merge(notice);
             notice.text(t('inspector.multiple_values'));
-            wrap.selectAll('.field-warning').not('.lane-multiselect-conflict').remove();
+            wrap.selectAll('.field-warning:not(.lane-multiselect-conflict)').remove();
             return;
         }
 


### PR DESCRIPTION
## Summary
- Shift-selecting ways with different `lanes*` values triggered `TypeError: … .not is not a function` in `lane_list.ts` instead of showing « multiple values ».
- d3-selection has no `.not()` method (jQuery API); use a CSS `:not()` selector instead.

Regresses [PR #104](https://github.com/kaligrafy/iD/pull/104) line 82.

## Test plan
- [ ] Shift+click two road segments with different `lanes` (e.g. 2 and 3) — no console error
- [ ] Inspector lane fields show « multiple values »
- [ ] Selection halo remains visible