### PR TITLE
Add motorway link transition preset (1 lane, 100 km/h)

### DIFF
--- a/data/custom-tagging/src/presets/highway/motorway_link_transition.ts
+++ b/data/custom-tagging/src/presets/highway/motorway_link_transition.ts
@@ -1,0 +1,34 @@
+import type { CustomPreset } from '../../types';
+import { buildRemoveTags } from '../../lib/tag_helpers';
+import { presetNameEn } from '../../preset_name_en';
+
+const ID = 'highway/motorway_link/placement_transition_oneway_1_100';
+
+const MOTORWAY_LINK_FIELDS = ['{highway/motorway}'] as const;
+const REFERENCE = { key: 'highway', value: 'motorway_link' } as const;
+
+const TAGS = {
+    highway: 'motorway_link',
+    placement: 'transition',
+    lanes: '1',
+    oneway: 'yes',
+    surface: 'asphalt',
+    maxspeed: '100'
+} as const;
+
+const motorwayLinkTransitionPreset: CustomPreset = {
+    icon: 'iD-highway-motorway-link',
+    geometry: ['line'],
+    fields: [...MOTORWAY_LINK_FIELDS],
+    moreFields: [...MOTORWAY_LINK_FIELDS],
+    tags: { ...TAGS },
+    addTags: { ...TAGS },
+    removeTags: buildRemoveTags({ ...TAGS }),
+    matchScore: 2,
+    reference: REFERENCE,
+    name: presetNameEn(ID)
+};
+
+export const motorwayLinkTransitionPresets: Record<string, CustomPreset> = {
+    [ID]: motorwayLinkTransitionPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -14,6 +14,7 @@ import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_varia
 import { restrictedFootwayVariantPresets } from './presets/highway/footway/restricted_footway_variants';
 import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_variants';
 import { serviceVariantPresets } from './presets/highway/service_variants';
+import { motorwayLinkTransitionPresets } from './presets/highway/motorway_link_transition';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { tactilePavingYesPresets } from './presets/highway/crossing/tactile_paving_yes';
@@ -67,6 +68,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...footwayCrossingVariantPresets,
     ...streetSidewalkVariantPresets,
     ...serviceVariantPresets,
+    ...motorwayLinkTransitionPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,
     ...tactilePavingYesPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -902,6 +902,11 @@
         "terms": "put, track, private, woods road, forest road, logging road, fire road, farm road, agricultural road, unmaintained, offroad, 4wd, 4x4",
         "aliases": "put"
     },
+    "highway/motorway_link/placement_transition_oneway_1_100": {
+        "name": "Motorway link (transition, 1 lane, 100 km/h)",
+        "terms": "mlt1, motorway link, ramp, transition, placement transition, oneway, one lane, 1 lane, asphalt, 100, maxspeed 100",
+        "aliases": "mlt1"
+    },
     "highway/steps_customers": {
         "name": "Customers steps",
         "terms": "stc, customers, steps, stairs, staircase, stairway",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -902,6 +902,11 @@
         "terms": "put, chemin, piste, privé, chemin forestier, chemin de ferme, non entretenu, hors route, 4x4",
         "aliases": "put"
     },
+    "highway/motorway_link/placement_transition_oneway_1_100": {
+        "name": "Lien autoroute (transition, 1 voie, 100 km/h)",
+        "terms": "mlt1, lien autoroute, bretelle, transition, placement transition, sens unique, une voie, 1 voie, asphalt, 100, maxspeed 100",
+        "aliases": "mlt1"
+    },
     "highway/steps_customers": {
         "name": "Escalier clients",
         "terms": "stc, clients, escalier, escaliers, marches",

--- a/test/spec/presets/custom/motorway_link.js
+++ b/test/spec/presets/custom/motorway_link.js
@@ -1,0 +1,30 @@
+import { loadCustomPresets } from './setup.js';
+
+const ID = 'highway/motorway_link/placement_transition_oneway_1_100';
+
+const EXPECTED_TAGS = {
+    highway: 'motorway_link',
+    placement: 'transition',
+    lanes: '1',
+    oneway: 'yes',
+    surface: 'asphalt',
+    maxspeed: '100'
+};
+
+describe('custom presets — motorway link transition', function() {
+    loadCustomPresets();
+
+    it(`defines ${ID} with expected tags`, function() {
+        const preset = iD.presetManager.item(ID);
+        expect(preset, ID).to.exist;
+        expect(preset.tags).to.include(EXPECTED_TAGS);
+        expect(preset.addTags).to.include(EXPECTED_TAGS);
+        expect(preset.addable()).to.be.true;
+    });
+
+    it('finds preset via search alias mlt1', function() {
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        const ids = pool.search('mlt1', 'line').collection.map((p) => p.id);
+        expect(ids).to.include(ID);
+    });
+});


### PR DESCRIPTION
## Summary
- Add custom preset `highway/motorway_link/placement_transition_oneway_1_100` with `placement=transition`, `lanes=1`, `oneway=yes`, `surface=asphalt`, `maxspeed=100`
- Register preset in custom tagging registry with EN/FR locale strings and search alias `mlt1`
- Add spec tests for preset tags and search alias

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npm run test:spec -- test/spec/presets/custom/motorway_link.js`