### PR TITLE
Improve way direction arrows on selected streets

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -9,6 +9,7 @@
 
 /* IE/Edge needs these overrides for markers to show up */
 .layer-osm path.oneway-marker-path          { fill: #000; }
+.layer-osm path.way-direction-marker-path   { fill: #555; }
 .layer-osm path.sided-marker-natural-path   { fill: rgb(170, 170, 170); }
 .layer-osm path.sided-marker-coastline-path { fill: #77dede; }
 .layer-osm path.sided-marker-barrier-path   { fill: #ddd; }
@@ -258,7 +259,8 @@ text {
 
 .onewaygroup path.oneway,
 .viewfieldgroup path.viewfield,
-.sidedgroup path.sided {
+.sidedgroup path.sided,
+.waydirectiongroup path.way-direction {
     stroke-width: 6px;
 }
 

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -9,7 +9,7 @@ import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
 import { prefs } from '../core/preferences';
 import { geoExtent, geoRawMercator, geoScaleToZoom, geoZoomToScale } from '../geo';
 import { modeBrowse } from '../modes/browse';
-import { svgAreas, svgLabels, svgLayers, svgLines, svgMidpoints, svgPoints, svgVertices } from '../svg';
+import { svgAreas, svgLabels, svgLayers, svgLines, svgMidpoints, svgPoints, svgVertices, svgWayDirection } from '../svg';
 import { utilFastMouse, utilFunctor, utilSetTransform, utilEntityAndDeepMemberIDs } from '../util/util';
 import { utilBindOnce } from '../util/bind_once';
 import { utilDetect } from '../util/detect';
@@ -41,6 +41,7 @@ export function rendererMap(context) {
     var drawAreas;
     var drawMidpoints;
     var drawLabels;
+    var drawWayDirection;
 
     var _selection = d3_select(null);
     var supersurface = d3_select(null);
@@ -289,7 +290,8 @@ export function rendererMap(context) {
                 .call(drawVertices.drawSelected, graph, map.extent())
                 .call(drawLines, graph, data, filter)
                 .call(drawAreas, graph, data, filter)
-                .call(drawMidpoints, graph, data, filter, map.trimmedExtent());
+                .call(drawMidpoints, graph, data, filter, map.trimmedExtent())
+                .call(drawWayDirection, graph, data);
 
             dispatch.call('drawn', this, { full: false });
 
@@ -401,7 +403,8 @@ export function rendererMap(context) {
             .call(drawAreas, graph, data, filter)
             .call(drawMidpoints, graph, data, filter, map.trimmedExtent())
             .call(drawPoints, graph, data, filter)
-            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw);
+            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw)
+            .call(drawWayDirection, graph, data);
 
         dispatch.call('drawn', this, {full: true});
     }
@@ -414,6 +417,7 @@ export function rendererMap(context) {
         drawAreas = svgAreas(projection, context);
         drawMidpoints = svgMidpoints(projection, context);
         drawLabels = svgLabels(projection, context);
+        drawWayDirection = svgWayDirection(projection, context);
     };
 
     function editOff() {

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -35,8 +35,8 @@ export function svgDefs(context) {
                 .attr('viewBox', '0 0 10 5')
                 .attr('refX', 4)
                 .attr('refY', 2.5)
-                .attr('markerWidth', 2)
-                .attr('markerHeight', 2)
+                .attr('markerWidth', 2.4)
+                .attr('markerHeight', 2.4)
                 .attr('markerUnits', 'strokeWidth')
                 .attr('orient', 'auto')
                 .append('path')
@@ -49,6 +49,24 @@ export function svgDefs(context) {
         addOnewayMarker('black', '#333'); // default
         addOnewayMarker('white', '#fff'); // for dark lines (bridges under construction, railways, etc.)
         addOnewayMarker('gray', '#eee'); // for railway lines
+
+        _defsSelection
+            .append('marker')
+            .attr('id', 'ideditor-way-direction-marker')
+            .attr('viewBox', '0 0 10 5')
+            .attr('refX', 4)
+            .attr('refY', 2.5)
+            .attr('markerWidth', 2.8)
+            .attr('markerHeight', 2.8)
+            .attr('markerUnits', 'strokeWidth')
+            .attr('orient', 'auto')
+            .append('path')
+            .attr('class', 'way-direction-marker-path')
+            .attr('d', 'M 6,3 L 0,3 L 0,2 L 6,2 L 5,0 L 10,2.5 L 5,5 z')
+            .attr('stroke', '#fff')
+            .attr('stroke-width', '0.35')
+            .attr('fill', '#555')
+            .attr('opacity', '0.92');
 
 
         function addSidedMarker(name, options) {

--- a/modules/svg/index.ts
+++ b/modules/svg/index.ts
@@ -27,5 +27,6 @@ export { svgTagPattern } from './tag_pattern.js';
 export { svgTouch } from './touch.js';
 export { svgTurns } from './turns.js';
 export { svgVertices } from './vertices.js';
+export { svgWayDirection } from './way_direction.js';
 export { svgMapilioImages } from './mapilio_images.js';
 export { svgPanoramaxImages } from './panoramax_images.js';

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -298,9 +298,12 @@ export function svgLines(projection, context) {
 
         Object.keys(pathdata).forEach(function(k) {
             var v = pathdata[k];
-            var onewayArr = v.filter(function(d) { return d.isOneWay(); });
+            var onewayArr = v.filter(function(d) {
+                // Selected ways use the way-direction overlay (above labels).
+                return d.isOneWay() && context.selectedIDs().indexOf(d.id) === -1;
+            });
             var onewaySegments = svgMarkerSegments(
-                projection, graph, 36,
+                projection, graph, 28,
                 entity => entity.isOneWayBackwards(),
                 entity => entity.isBiDirectional(),
             );

--- a/modules/svg/osm.js
+++ b/modules/svg/osm.js
@@ -4,7 +4,7 @@ export function svgOsm(projection, context, dispatch) {
 
     function drawOsm(selection) {
         selection.selectAll('.layer-osm')
-            .data(['covered', 'areas', 'lines', 'points', 'auxiliary', 'labels'])
+            .data(['covered', 'areas', 'lines', 'points', 'auxiliary', 'labels', 'way-direction'])
             .enter()
             .append('g')
             .attr('class', function(d) { return 'layer-osm ' + d; });

--- a/modules/svg/way_direction.js
+++ b/modules/svg/way_direction.js
@@ -1,0 +1,70 @@
+import { svgMarkerSegments } from './helpers';
+import { utilArrayFlatten } from '../util';
+
+/** Pixel spacing between direction arrows on selected ways (denser than oneway). */
+const SEGMENT_SPACING = 22;
+
+const MARKER_URL = 'url(#ideditor-way-direction-marker)';
+
+/**
+ * Draws direction arrows along selected line ways in select mode.
+ * Rendered above street labels so forward/backward tagging stays readable.
+ *
+ * @param {iD.Projection} projection
+ * @param {iD.Context} context
+ */
+export function svgWayDirection(projection, context) {
+    return function drawWayDirection(selection, graph, entities) {
+        var layer = selection.selectAll('.layer-osm.way-direction');
+
+        if (context.mode()?.id !== 'select') {
+            layer.selectAll('.waydirectiongroup').remove();
+            return;
+        }
+
+        var selectedIDs = context.selectedIDs();
+        if (!selectedIDs.length) {
+            layer.selectAll('.waydirectiongroup').remove();
+            return;
+        }
+
+        var ways = entities.filter(function(entity) {
+            return entity.type === 'way' && entity.geometry(graph) === 'line';
+        });
+
+        // Partial redraw may pass only changed entities; keep every selected line.
+        selectedIDs.forEach(function(id) {
+            var selected = graph.hasEntity(id);
+            if (!selected || ways.indexOf(selected) !== -1) return;
+            if (selected.geometry(graph) !== 'line') return;
+            ways.push(selected);
+        });
+
+        ways = ways.filter(function(way) {
+            return selectedIDs.indexOf(way.id) !== -1 && way.nodes.length >= 2;
+        });
+
+        var segments = svgMarkerSegments(projection, graph, SEGMENT_SPACING);
+        var directiondata = utilArrayFlatten(ways.map(segments));
+
+        var group = layer.selectAll('.waydirectiongroup').data([0]);
+        group = group.enter()
+            .append('g')
+            .attr('class', 'waydirectiongroup')
+            .merge(group);
+
+        var markers = group
+            .selectAll('path')
+            .data(directiondata, function(d) { return d.id + '-' + d.index; });
+
+        markers.exit()
+            .remove();
+
+        markers.enter()
+            .append('path')
+            .attr('class', 'way-direction')
+            .merge(markers)
+            .attr('marker-mid', MARKER_URL)
+            .attr('d', function(d) { return d.d; });
+    };
+}

--- a/test/spec/svg/osm.js
+++ b/test/spec/svg/osm.js
@@ -8,13 +8,14 @@ describe('iD.svgOsm', function () {
     it('creates default osm layers', function () {
         container.call(iD.svgOsm());
         var layers = container.selectAll('g.layer-osm').nodes();
-        expect(layers.length).to.eql(6);
+        expect(layers.length).to.eql(7);
         expect(d3.select(layers[0]).classed('covered')).to.be.true;
         expect(d3.select(layers[1]).classed('areas')).to.be.true;
         expect(d3.select(layers[2]).classed('lines')).to.be.true;
         expect(d3.select(layers[3]).classed('points')).to.be.true;
         expect(d3.select(layers[4]).classed('auxiliary')).to.be.true;
         expect(d3.select(layers[5]).classed('labels')).to.be.true;
+        expect(d3.select(layers[6]).classed('way-direction')).to.be.true;
     });
 
     it('creates default osm point layers', function () {

--- a/test/spec/svg/way_direction.js
+++ b/test/spec/svg/way_direction.js
@@ -1,0 +1,72 @@
+describe('iD.svgWayDirection', function() {
+    var context, surface;
+    var projection = d3.geoProjection(function(x, y) { return [x, -y]; })
+        .translate([0, 0])
+        .scale(iD.geoZoomToScale(17))
+        .clipExtent([[0, 0], [Infinity, Infinity]]);
+
+    beforeEach(function() {
+        context = iD.coreContext().assetPath('../dist/').init();
+        d3.select(document.createElement('div'))
+            .attr('class', 'main-map')
+            .call(context.map().centerZoom([0, 0], 17));
+        surface = context.surface();
+        surface.call(iD.svgOsm());
+        surface.call(iD.svgDefs(context));
+    });
+
+    function loadGraph(entities) {
+        context.history().merge(entities);
+    }
+
+    function draw(graph, entities) {
+        surface.call(iD.svgWayDirection(projection, context), graph, entities);
+    }
+
+    it('draws multiple direction markers on a selected way in select mode', function() {
+        var nodes = [
+            new iD.osmNode({ id: 'a', loc: [0, 0] }),
+            new iD.osmNode({ id: 'b', loc: [0.05, 0] }),
+            new iD.osmNode({ id: 'c', loc: [0.1, 0] })
+        ];
+        var way = new iD.osmWay({ id: 'w1', tags: { highway: 'residential', name: 'Rue Test' }, nodes: ['a', 'b', 'c'] });
+        var graph = new iD.coreGraph(nodes.concat(way));
+        loadGraph(nodes.concat(way));
+
+        context.enter(iD.modeSelect(context, [way.id]));
+        draw(graph, [way]);
+
+        var markers = surface.selectAll('g.waydirectiongroup > path');
+        expect(markers.size()).to.be.above(1);
+        expect(markers.nodes()[0].attributes['marker-mid'].nodeValue)
+            .to.eql('url(#ideditor-way-direction-marker)');
+    });
+
+    it('removes direction markers outside select mode', function() {
+        var a = new iD.osmNode({ id: 'a', loc: [0, 0] });
+        var b = new iD.osmNode({ id: 'b', loc: [0.05, 0] });
+        var way = new iD.osmWay({ id: 'w1', tags: { highway: 'residential' }, nodes: [a.id, b.id] });
+        var graph = new iD.coreGraph([a, b, way]);
+        loadGraph([a, b, way]);
+
+        context.enter(iD.modeSelect(context, [way.id]));
+        draw(graph, [way]);
+        expect(surface.selectAll('g.waydirectiongroup > path').size()).to.be.above(0);
+
+        context.enter(iD.modeBrowse(context));
+        draw(graph, [way]);
+        expect(surface.selectAll('g.waydirectiongroup > path').size()).to.eql(0);
+    });
+
+    it('does not draw direction markers for unselected ways', function() {
+        var a = new iD.osmNode({ id: 'a', loc: [0, 0] });
+        var b = new iD.osmNode({ id: 'b', loc: [0.05, 0] });
+        var way = new iD.osmWay({ id: 'w1', tags: { highway: 'residential' }, nodes: [a.id, b.id] });
+        var graph = new iD.coreGraph([a, b, way]);
+        loadGraph([a, b, way]);
+
+        context.enter(iD.modeSelect(context, [a.id]));
+        draw(graph, [way]);
+        expect(surface.selectAll('g.waydirectiongroup > path').size()).to.eql(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Draw direction arrows along selected line ways in select mode (new `way-direction` layer above street labels)
- Use denser spacing, larger markers, and higher contrast than before
- Suppress duplicate oneway markers on selected ways; slightly denser/larger oneway arrows elsewhere

## Test plan
- [x] `npm run test:spec -- test/spec/svg/way_direction.js test/spec/svg/osm.js test/spec/svg/lines.js`
- [ ] Select a bidirectional street and confirm multiple visible arrows along the way, above the name label
- [ ] Edit forward/backward lane fields and verify arrow direction matches way node order
- [ ] Deselect or leave select mode — arrows disappear