### PR TITLE
Improve direction arrows on selected ways

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -165,10 +165,10 @@ g.vertex.shared .stroke {
     fill: #bbb;
 }
 g.midpoint .fill {
-    fill: #eee;
+    fill: #e8e8e8;
     stroke: #444;
-    stroke-opacity: .6;
-    opacity: .7;
+    stroke-opacity: .50;
+    opacity: .60;
 }
 
 g.vertex .shadow,
@@ -260,6 +260,11 @@ text {
 .viewfieldgroup path.viewfield,
 .sidedgroup path.sided {
     stroke-width: 6px;
+}
+
+/* Direction glyphs redrawn above street labels (see svgMidpoints.drawGlyphs). */
+.layer-osm.midpoint-glyphs {
+    pointer-events: none;
 }
 
 text.arealabel-halo,

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -289,7 +289,8 @@ export function rendererMap(context) {
                 .call(drawVertices.drawSelected, graph, map.extent())
                 .call(drawLines, graph, data, filter)
                 .call(drawAreas, graph, data, filter)
-                .call(drawMidpoints, graph, data, filter, map.trimmedExtent());
+                .call(drawMidpoints, graph, data, filter, map.trimmedExtent())
+                .call(drawMidpoints.drawGlyphs, graph);
 
             dispatch.call('drawn', this, { full: false });
 
@@ -401,7 +402,8 @@ export function rendererMap(context) {
             .call(drawAreas, graph, data, filter)
             .call(drawMidpoints, graph, data, filter, map.trimmedExtent())
             .call(drawPoints, graph, data, filter)
-            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw);
+            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw)
+            .call(drawMidpoints.drawGlyphs, graph);
 
         dispatch.call('drawn', this, {full: true});
     }

--- a/modules/svg/midpoints.js
+++ b/modules/svg/midpoints.js
@@ -5,6 +5,9 @@ import { geoAngle, geoLineIntersection, geoVecInterp, geoVecLength } from '../ge
 
 export function svgMidpoints(projection, context) {
     var targetRadius = 8;
+    var SHADOW_POINTS = '-12,16 18,0 -12,-16';
+    var FILL_POINTS = '-5,8 10,0 -5,-8';
+    var _glyphData = [];
 
     function drawTargets(selection, graph, entities, filter) {
         var fillClass = context.getDebug('target') ? 'pink ' : 'nocolor ';
@@ -51,6 +54,7 @@ export function svgMidpoints(projection, context) {
         if ((mode && mode.id !== 'select') || !context.map().withinEditableZoom()) {
             drawLayer.selectAll('.midpoint').remove();
             touchLayer.selectAll('.midpoint.target').remove();
+            _glyphData = [];
             return;
         }
 
@@ -68,10 +72,10 @@ export function svgMidpoints(projection, context) {
             for (var j = 0; j < nodes.length - 1; j++) {
                 var a = nodes[j];
                 var b = nodes[j + 1];
-                var id = [a.id, b.id].sort().join('-');
+                var edgeId = [a.id, b.id].sort().join('-');
 
-                if (midpoints[id]) {
-                    midpoints[id].parents.push(entity);
+                if (midpoints[edgeId]) {
+                    midpoints[edgeId].parents.push(entity);
                 } else if (geoVecLength(projection(a.loc), projection(b.loc)) > 40) {
                     var point = geoVecInterp(a.loc, b.loc, 0.5);
                     var loc = null;
@@ -91,9 +95,9 @@ export function svgMidpoints(projection, context) {
                     }
 
                     if (loc) {
-                        midpoints[id] = {
+                        midpoints[edgeId] = {
                             type: 'midpoint',
-                            id: id,
+                            id: edgeId,
                             loc: loc,
                             edge: [a.id, b.id],
                             parents: [entity]
@@ -130,12 +134,12 @@ export function svgMidpoints(projection, context) {
 
         enter
             .append('polygon')
-            .attr('points', '-6,8 10,0 -6,-8')
+            .attr('points', SHADOW_POINTS)
             .attr('class', 'shadow');
 
         enter
             .append('polygon')
-            .attr('points', '-3,4 5,0 -3,-4')
+            .attr('points', FILL_POINTS)
             .attr('class', 'fill');
 
         groups = groups
@@ -155,11 +159,59 @@ export function svgMidpoints(projection, context) {
         groups.select('polygon.shadow');
         groups.select('polygon.fill');
 
+        _glyphData = groups.data();
+
 
         // Draw touch targets..
         touchLayer
             .call(drawTargets, graph, Object.values(midpoints), midpointFilter);
     }
 
+
+    // Direction glyphs above street labels (labels layer is painted later).
+    function drawGlyphs(selection, graph) {
+        var glyphLayer = selection.selectAll('.layer-osm.midpoint-glyphs');
+        var mode = context.mode();
+
+        if ((mode && mode.id !== 'select') || !context.map().withinEditableZoom()) {
+            glyphLayer.selectAll('.midpoint').remove();
+            return;
+        }
+
+        var glyphs = glyphLayer.selectAll('.midpoint')
+            .data(_glyphData, function(d) { return d.id; });
+
+        glyphs.exit()
+            .remove();
+
+        var enter = glyphs.enter()
+            .append('g')
+            .attr('class', 'midpoint midpoint-glyph');
+
+        enter
+            .append('polygon')
+            .attr('points', SHADOW_POINTS)
+            .attr('class', 'shadow');
+
+        enter
+            .append('polygon')
+            .attr('points', FILL_POINTS)
+            .attr('class', 'fill');
+
+        glyphs.merge(enter)
+            .attr('transform', function(d) {
+                var translate = svgPointTransform(projection);
+                var a = graph.entity(d.edge[0]);
+                var b = graph.entity(d.edge[1]);
+                var angle = geoAngle(a, b, projection) * (180 / Math.PI);
+                return translate(d) + ' rotate(' + angle + ')';
+            })
+            .call(svgTagClasses().tags(
+                function(d) { return d.parents[0].tags; }
+            ));
+    }
+
+
+    drawMidpoints.drawGlyphs = drawGlyphs;
     return drawMidpoints;
 }

--- a/modules/svg/osm.js
+++ b/modules/svg/osm.js
@@ -4,7 +4,7 @@ export function svgOsm(projection, context, dispatch) {
 
     function drawOsm(selection) {
         selection.selectAll('.layer-osm')
-            .data(['covered', 'areas', 'lines', 'points', 'auxiliary', 'labels'])
+            .data(['covered', 'areas', 'lines', 'points', 'auxiliary', 'labels', 'midpoint-glyphs'])
             .enter()
             .append('g')
             .attr('class', function(d) { return 'layer-osm ' + d; });

--- a/test/spec/svg/osm.js
+++ b/test/spec/svg/osm.js
@@ -8,13 +8,14 @@ describe('iD.svgOsm', function () {
     it('creates default osm layers', function () {
         container.call(iD.svgOsm());
         var layers = container.selectAll('g.layer-osm').nodes();
-        expect(layers.length).to.eql(6);
+        expect(layers.length).to.eql(7);
         expect(d3.select(layers[0]).classed('covered')).to.be.true;
         expect(d3.select(layers[1]).classed('areas')).to.be.true;
         expect(d3.select(layers[2]).classed('lines')).to.be.true;
         expect(d3.select(layers[3]).classed('points')).to.be.true;
         expect(d3.select(layers[4]).classed('auxiliary')).to.be.true;
         expect(d3.select(layers[5]).classed('labels')).to.be.true;
+        expect(d3.select(layers[6]).classed('midpoint-glyphs')).to.be.true;
     });
 
     it('creates default osm point layers', function () {


### PR DESCRIPTION
## Summary
- Enlarge midpoint direction triangles on selected ways so they extend slightly past the road edge
- Add a `midpoint-glyphs` OSM layer painted after labels, keeping arrows visible when a street has a name
- Slightly increase midpoint fill contrast in map CSS

## Test plan
- [ ] Select a named highway in select mode — direction arrows remain visible above the street name
- [ ] Select a way without a name — arrows still render as before
- [ ] Deselect the way — arrows disappear
- [ ] `npm run test` — svg midpoints and osm layer specs pass