### PR TITLE
Add name field to crossing presets

### DIFF
--- a/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_fields.ts
+++ b/data/custom-tagging/src/presets/highway/cycleway/cycleway_crossing_fields.ts
@@ -3,18 +3,21 @@ export const CYCLEWAY_CROSSING_TRAFFIC_SIGNALS_FIELDS = [
     'crossing',
     '{@templates/crossing/traffic_signal}',
     '{@templates/crossing/markings}',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 export const CYCLEWAY_CROSSING_UNCONTROLLED_FIELDS = [
     'crossing',
     '{@templates/crossing/markings_yes}',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 export const CYCLEWAY_CROSSING_UNMARKED_FIELDS = [
     'crossing',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 export const CYCLEWAY_CROSSING_MORE_FIELDS = [

--- a/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
+++ b/data/custom-tagging/src/presets/highway/footway/footway_crossing_fields.ts
@@ -3,25 +3,29 @@ export const FOOTWAY_CROSSING_TRAFFIC_SIGNALS_FIELDS = [
     'crossing',
     '{@templates/crossing/traffic_signal}',
     '{@templates/crossing/markings}',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 export const FOOTWAY_CROSSING_UNCONTROLLED_FIELDS = [
     'crossing',
     '{@templates/crossing/markings_yes}',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 export const FOOTWAY_CROSSING_UNMARKED_FIELDS = [
     'crossing',
-    'surface'
+    'surface',
+    'name'
 ] as const;
 
 /** Unmarked crossings with `access` (use `access_restricted` field). */
 export const FOOTWAY_CROSSING_UNMARKED_RESTRICTED_FIELDS = [
     'crossing',
     'surface',
-    'access_restricted'
+    'access_restricted',
+    'name'
 ] as const;
 
 /** Uncontrolled zebra crossings with fixed `access` (use `access_restricted` field). */
@@ -29,7 +33,8 @@ export const FOOTWAY_CROSSING_UNCONTROLLED_RESTRICTED_FIELDS = [
     'crossing',
     '{@templates/crossing/markings_yes}',
     'surface',
-    'access_restricted'
+    'access_restricted',
+    'name'
 ] as const;
 
 export const FOOTWAY_CROSSING_MORE_FIELDS = [

--- a/test/spec/presets/custom/cycleway.js
+++ b/test/spec/presets/custom/cycleway.js
@@ -19,6 +19,7 @@ describe('custom presets — cycleway', function() {
         it(`defines ${id} without required bicycle or lcn tags`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
+            expect(preset.originalFields).to.include('name');
             expect(preset.tags).to.include(tags);
             expect(preset.tags).to.not.have.property('bicycle');
             expect(preset.tags).to.not.have.property('lcn');
@@ -61,6 +62,7 @@ describe('custom presets — cycleway', function() {
     it('loads cycleway link preset with expected name', function() {
         const cycleway = iD.presetManager.item('highway/cycleway/cycleway_link');
         expect(cycleway, 'cycleway link preset').to.exist;
+        expect(cycleway.originalFields).to.include('name');
         expect(cycleway.addable()).to.be.true;
     });
 
@@ -73,6 +75,7 @@ describe('custom presets — cycleway', function() {
     it('defines traffic signals dots cycleway crossing preset tags', function() {
         const preset = iD.presetManager.item('highway/cycleway/crossing/traffic_signals-dots_no_foot');
         expect(preset, 'traffic signals dots no foot').to.exist;
+        expect(preset.originalFields).to.include('name');
         expect(preset.name()).to.equal('Traffic Signals Dots Cycleway Crossing No Foot');
         expect(preset.tags).to.include({
             highway: 'cycleway',

--- a/test/spec/presets/custom/footway.js
+++ b/test/spec/presets/custom/footway.js
@@ -177,6 +177,8 @@ describe('custom presets — footway', function() {
         });
         expect(yes.tags).to.include({ footway: 'sidewalk', bicycle: 'yes' });
         expect(dismount.addTags.surface).to.equal('concrete');
+        expect(dismount.originalFields).to.include('name');
+        expect(yes.originalFields).to.include('name');
     });
 
     it('finds sidewalk presets via alias search', function() {

--- a/test/spec/presets/custom/footway_crossing.js
+++ b/test/spec/presets/custom/footway_crossing.js
@@ -6,6 +6,7 @@ describe('custom presets — footway crossing', function() {
     it('defines traffic signals footway crossing without markings', function() {
         const preset = iD.presetManager.item('highway/footway/crossing/traffic_signals');
         expect(preset, 'traffic signals no markings').to.exist;
+        expect(preset.originalFields).to.include('name');
         expect(preset.tags).to.include({
             crossing: 'traffic_signals',
             'crossing:markings': 'no'


### PR DESCRIPTION
## Summary
- Add `name` to all footway and cycleway crossing preset field lists (v5 parity).
- Sidewalk and cycleway path presets already expose `name` via `{highway/footway}` / `{highway/cycleway}` upstream expansion; tests lock that in.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npm run test:spec -- -t "custom presets"`
- [ ] Select a footway crossing preset and confirm the Name field appears in the inspector
- [ ] Select a cycleway crossing preset and confirm the Name field appears
- [ ] Select a sidewalk or cycleway path preset and confirm Name is still present