### PR TITLE
Add barrier block preset and fix lift gate motor_vehicle handling

### DIFF
--- a/data/custom-tagging/src/presets/barrier/access_barriers.ts
+++ b/data/custom-tagging/src/presets/barrier/access_barriers.ts
@@ -1,5 +1,7 @@
 import type { CustomPreset, PresetGeometry } from '../../types';
+import { ANY, buildRemoveTags } from '../../lib/tag_helpers';
 import { presetNameEn } from '../../preset_name_en';
+import { blockMotorVehicleNo } from './block_motor_vehicle_no';
 import { gateFootBicycleYes } from './gate_foot_bicycle_yes';
 
 type AccessKind = 'customers' | 'private';
@@ -18,17 +20,21 @@ const ACCESS_BARRIERS: AccessBarrierVariant[] = [
 ];
 
 function accessBarrierPreset(presetId: string, variant: AccessBarrierVariant, geometry: PresetGeometry[]): CustomPreset {
-    const icon = variant.barrier === 'lift_gate' ? 'temaki-lift_gate' : 'maki-barrier';
+    const isLiftGate = variant.barrier === 'lift_gate';
+    const icon = isLiftGate ? 'temaki-lift_gate' : 'maki-barrier';
+    const addTags = { barrier: variant.barrier, access: variant.access };
     const preset: CustomPreset = {
         icon,
         geometry,
-        fields: ['access', 'opening_hours'],
-        tags: { barrier: variant.barrier, access: variant.access },
-        name: presetNameEn(presetId)
+        // Lift gates: `access_restricted` only — full `access` field would preserve motor_vehicle.
+        fields: isLiftGate ? ['access_restricted', 'opening_hours'] : ['access', 'opening_hours'],
+        tags: { ...addTags },
+        name: presetNameEn(presetId),
+        matchScore: 2
     };
-    // Beat generic `barrier/gate` when matching nodes on ways.
-    if (geometry.includes('vertex') && !geometry.includes('line')) {
-        preset.matchScore = 2;
+    if (isLiftGate) {
+        preset.addTags = { ...addTags };
+        preset.removeTags = buildRemoveTags(addTags, { motor_vehicle: ANY, foot: ANY, bicycle: ANY });
     }
     return preset;
 }
@@ -46,5 +52,6 @@ function accessBarrierPresetsForVariant(variant: AccessBarrierVariant): [string,
 /** Customer/private gates, lift gates, and public foot/bicycle gate (v5 Transition). */
 export const accessBarrierPresets: Record<string, CustomPreset> = {
     ...Object.fromEntries(ACCESS_BARRIERS.flatMap(accessBarrierPresetsForVariant)),
-    'barrier/gate_foot_bicycle_yes': gateFootBicycleYes
+    'barrier/gate_foot_bicycle_yes': gateFootBicycleYes,
+    'barrier/block_motor_vehicle_no': blockMotorVehicleNo
 };

--- a/data/custom-tagging/src/presets/barrier/block_motor_vehicle_no.ts
+++ b/data/custom-tagging/src/presets/barrier/block_motor_vehicle_no.ts
@@ -1,0 +1,20 @@
+import type { CustomPreset } from '../../types';
+import { buildRemoveTags } from '../../lib/tag_helpers';
+import { presetNameEn } from '../../preset_name_en';
+
+const BLOCK_MOTOR_VEHICLE_NO_TAGS = {
+    barrier: 'block',
+    motor_vehicle: 'no'
+} as const;
+
+/** Block barrier with motor vehicles prohibited (v5 Transition). */
+export const blockMotorVehicleNo: CustomPreset = {
+    icon: 'fas-cube',
+    geometry: ['point', 'vertex'],
+    fields: ['access', 'material'],
+    tags: { ...BLOCK_MOTOR_VEHICLE_NO_TAGS },
+    addTags: { ...BLOCK_MOTOR_VEHICLE_NO_TAGS },
+    removeTags: buildRemoveTags({ ...BLOCK_MOTOR_VEHICLE_NO_TAGS }),
+    matchScore: 2,
+    name: presetNameEn('barrier/block_motor_vehicle_no')
+};

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -63,6 +63,11 @@
         "terms": "clg, lift gate, customers",
         "aliases": "clg"
     },
+    "barrier/block_motor_vehicle_no": {
+        "name": "Block (no motor vehicles)",
+        "terms": "bmnv, block, motor vehicle, no motor vehicles",
+        "aliases": "bmnv"
+    },
     "barrier/gate_foot_bicycle_yes": {
         "name": "Public gate (foot and bicycle, no motor vehicles)",
         "terms": "pugfb, pubg, gate, foot, bicycle, pedestrian, cycling, no motor vehicles",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -63,6 +63,11 @@
         "terms": "clg, blc, barrière levante, clients",
         "aliases": "clg"
     },
+    "barrier/block_motor_vehicle_no": {
+        "name": "Bloc (pas de véhicules motorisés)",
+        "terms": "bpmv, bloc, véhicule motorisé, pas de véhicules motorisés",
+        "aliases": "bpmv"
+    },
     "barrier/gate_foot_bicycle_yes": {
         "name": "Barrière Publique (piétons et vélos, pas de véhicules motorisés)",
         "terms": "pugfb, bppv, barrière, piéton, vélo, cyclisme, pas de véhicules motorisés",

--- a/test/spec/presets/custom/barrier.js
+++ b/test/spec/presets/custom/barrier.js
@@ -39,5 +39,29 @@ describe('custom presets — barrier', function() {
             bicycle: 'yes',
             motor_vehicle: 'no'
         });
+
+        const customersLiftgate = iD.presetManager.item('barrier/customers_liftgate');
+        expect(customersLiftgate, 'customers lift gate').to.exist;
+        expect(customersLiftgate.name()).to.equal('Customers lift gate');
+        expect(customersLiftgate.tags).to.include({ barrier: 'lift_gate', access: 'customers' });
+        expect(customersLiftgate.geometry).to.eql(['vertex', 'line']);
+        expect(customersLiftgate.originalFields).to.eql(['access_restricted', 'opening_hours']);
+        expect(customPresets['barrier/customers_liftgate'].removeTags).to.include({ motor_vehicle: '*' });
+        expect(customPresets['barrier/customers_liftgate'].matchScore).to.equal(2);
+
+        const privateLiftgate = iD.presetManager.item('barrier/private_liftgate');
+        expect(privateLiftgate, 'private lift gate').to.exist;
+        expect(privateLiftgate.name()).to.equal('Private lift gate');
+        expect(privateLiftgate.tags).to.include({ barrier: 'lift_gate', access: 'private' });
+        expect(privateLiftgate.originalFields).to.eql(['access_restricted', 'opening_hours']);
+        expect(customPresets['barrier/private_liftgate'].removeTags).to.include({ motor_vehicle: '*' });
+        expect(customPresets['barrier/private_liftgate'].matchScore).to.equal(2);
+
+        const blockNoMotor = iD.presetManager.item('barrier/block_motor_vehicle_no');
+        expect(blockNoMotor, 'block no motor vehicles').to.exist;
+        expect(blockNoMotor.name()).to.equal('Block (no motor vehicles)');
+        expect(blockNoMotor.tags).to.eql({ barrier: 'block', motor_vehicle: 'no' });
+        expect(blockNoMotor.geometry).to.eql(['point', 'vertex']);
+        expect(customPresets['barrier/block_motor_vehicle_no'].matchScore).to.equal(2);
     });
 });


### PR DESCRIPTION
## Summary
- Add custom preset `barrier/block_motor_vehicle_no` (`barrier=block`, `motor_vehicle=no`) with EN/FR locales and alias `bmnv` / `bpmv`.
- Fix lift gate presets (`customers` / `private`): use `access_restricted` instead of full `access` field so `motor_vehicle` is not preserved on preset change; `removeTags` clears `motor_vehicle`, `foot`, and `bicycle`.
- Extend barrier preset tests for block, lift gates, and `matchScore`.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/barrier.js`
- [ ] Search `bmnv` / `clg` / `plg` in preset search
- [ ] Apply lift gate preset after block or public gate — confirm `motor_vehicle` is absent