### PR TITLE
Feat: turn:lanes:both_ways and placement middle_of:0

### DIFF
--- a/data/locales/custom/en.json
+++ b/data/locales/custom/en.json
@@ -103,16 +103,28 @@
                     "label": "Placement"
                 },
                 "placement_forward": {
-                    "label": "Placement ↑"
+                    "label": "Placement ↑",
+                    "options": {
+                        "middle_of:0": "Middle of centre buffer (lane 0)"
+                    }
                 },
                 "placement_backward": {
-                    "label": "Placement ↓"
+                    "label": "Placement ↓",
+                    "options": {
+                        "middle_of:0": "Middle of centre buffer (lane 0)"
+                    }
                 },
                 "lanes_forward": {
                     "label": "Lanes ↑"
                 },
                 "lanes_backward": {
                     "label": "Lanes ↓"
+                },
+                "lanes_both_ways": {
+                    "label": "Lanes ⇄"
+                },
+                "turn_lanes_both_ways": {
+                    "label": "Turn ⇄"
                 },
                 "width_lanes_start": {
                     "label": "Lane transition start"

--- a/data/locales/custom/fr.json
+++ b/data/locales/custom/fr.json
@@ -103,16 +103,28 @@
                     "label": "Placement"
                 },
                 "placement_forward": {
-                    "label": "Placement ↑"
+                    "label": "Placement ↑",
+                    "options": {
+                        "middle_of:0": "Milieu du tampon central (voie 0)"
+                    }
                 },
                 "placement_backward": {
-                    "label": "Placement ↓"
+                    "label": "Placement ↓",
+                    "options": {
+                        "middle_of:0": "Milieu du tampon central (voie 0)"
+                    }
                 },
                 "lanes_forward": {
                     "label": "Voies ↑"
                 },
                 "lanes_backward": {
                     "label": "Voies ↓"
+                },
+                "lanes_both_ways": {
+                    "label": "Voies ⇄"
+                },
+                "turn_lanes_both_ways": {
+                    "label": "Virage ⇄"
                 },
                 "width_lanes_start": {
                     "label": "Transition de largeurs début"

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -48,6 +48,14 @@ export const customFields = {
         geometry: ['line'],
         prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
     },
+    // Centre bidirectional lane count (rare); optional via "+ add field", not in lanes_group.
+    lanes_both_ways: {
+        key: 'lanes:both_ways',
+        type: 'number',
+        minValue: 0,
+        geometry: ['line'],
+        prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
+    },
     // Directional groups: one header with compact `↕` / `↑` / `↓` sub-rows for a
     // bare key and its per-direction variants (see uiFieldDirectionalGroup). Each
     // sub-row reuses its member field's renderer and prerequisite, so the
@@ -81,12 +89,14 @@ export const customFields = {
         prerequisiteTag: [
             laneFields.turn_lanes.prerequisiteTag,
             laneFields.turn_lanes_forward.prerequisiteTag,
-            laneFields.turn_lanes_backward.prerequisiteTag
+            laneFields.turn_lanes_backward.prerequisiteTag,
+            laneFields.turn_lanes_both_ways.prerequisiteTag
         ],
         members: [
             { id: 'turn_lanes', label: '↕' },
             { id: 'turn_lanes_forward', label: '↑' },
-            { id: 'turn_lanes_backward', label: '↓' }
+            { id: 'turn_lanes_backward', label: '↓' },
+            { id: 'turn_lanes_both_ways', label: '⇄' }
         ]
     },
     change_lanes_group: {
@@ -207,9 +217,9 @@ const LANE_BLOCK = [
 // order and never duplicate an entry.
 const MANAGED_LANE_FIELDS = [
     'lanes', ...LANE_BLOCK,
-    'lanes_forward', 'lanes_backward',
+    'lanes_forward', 'lanes_backward', 'lanes_both_ways',
     'placement', 'placement_forward', 'placement_backward',
-    'turn_lanes', 'turn_lanes_forward', 'turn_lanes_backward',
+    'turn_lanes', 'turn_lanes_forward', 'turn_lanes_backward', 'turn_lanes_both_ways',
     'change_lanes', 'change_lanes_forward', 'change_lanes_backward'
 ];
 
@@ -262,6 +272,7 @@ export function applyCustomFields(presetManager) {
     customizeCycleway(presetManager);
     customizeOnewayBicycle(presetManager);
     customizeAccess(presetManager);
+    customizePlacement(presetManager);
     customizePostBox(presetManager);
     customizeCyclewaySidewalk(presetManager);
     customizeLanduseFlats(presetManager);
@@ -378,6 +389,10 @@ export function applyCustomFields(presetManager) {
         if (maxspeedIndex === -1) moreFields.push('maxspeed_advisory');
         else fields.splice(maxspeedIndex + 1, 0, 'maxspeed_advisory');
 
+        // Centre bidirectional lane count: optional only (rare), not in lanes_group.
+        removeField(fields, 'lanes_both_ways');
+        if (moreFields.indexOf('lanes_both_ways') === -1) moreFields.push('lanes_both_ways');
+
         // minimum speed: default field on motorways (common in Québec), just
         // below the advisory/maxspeed rows. Upstream keeps it in moreFields.
         if (highway === 'motorway') {
@@ -468,6 +483,24 @@ function customizeAccess(presetManager) {
         'access', 'foot', 'motor_vehicle', 'routing:motor_vehicle',
         'bicycle', 'routing:bicycle', 'bus', 'routing:bus', 'psv'
     ];
+}
+
+const PLACEMENT_MIDDLE_OF_ZERO = 'middle_of:0';
+
+/**
+ * Add `middle_of:0` to directional placement combos (centre buffer between carriageways).
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function customizePlacement(presetManager) {
+    for (const id of ['placement_forward', 'placement_backward']) {
+        const field = presetManager.field(id);
+        if (!field) continue;
+        if (!field.options) field.options = [];
+        if (field.options.indexOf(PLACEMENT_MIDDLE_OF_ZERO) === -1) {
+            field.options.unshift(PLACEMENT_MIDDLE_OF_ZERO);
+        }
+    }
 }
 
 /**

--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -48,7 +48,7 @@ export const customFields = {
         geometry: ['line'],
         prerequisiteTag: { allOf: [{ key: 'oneway', valueNot: 'yes' }, { key: 'lanes', valueGreaterThan: 2 }] }
     },
-    // Centre bidirectional lane count (rare); optional via "+ add field", not in lanes_group.
+    // Centre bidirectional lane count; ⇄ row in lanes_group (hidden until lanes > 2).
     lanes_both_ways: {
         key: 'lanes:both_ways',
         type: 'number',
@@ -69,7 +69,8 @@ export const customFields = {
         members: [
             { id: 'lanes', label: '↕' },
             { id: 'lanes_forward', label: '↑' },
-            { id: 'lanes_backward', label: '↓' }
+            { id: 'lanes_backward', label: '↓' },
+            { id: 'lanes_both_ways', label: '⇄' }
         ]
     },
     placement_group: {
@@ -388,10 +389,6 @@ export function applyCustomFields(presetManager) {
         const maxspeedIndex = fields.indexOf('maxspeed');
         if (maxspeedIndex === -1) moreFields.push('maxspeed_advisory');
         else fields.splice(maxspeedIndex + 1, 0, 'maxspeed_advisory');
-
-        // Centre bidirectional lane count: optional only (rare), not in lanes_group.
-        removeField(fields, 'lanes_both_ways');
-        if (moreFields.indexOf('lanes_both_ways') === -1) moreFields.push('lanes_both_ways');
 
         // minimum speed: default field on motorways (common in Québec), just
         // below the advisory/maxspeed rows. Upstream keeps it in moreFields.

--- a/modules/presets/lane_fields.js
+++ b/modules/presets/lane_fields.js
@@ -27,6 +27,7 @@ export const laneFields = {
     turn_lanes:          laneField('turn:lanes',          { allOf: [ONE_WAY, { key: 'lanes' }] }),
     turn_lanes_forward:  laneField('turn:lanes:forward',  { allOf: [TWO_WAY, { key: 'lanes:forward' }] }),
     turn_lanes_backward: laneField('turn:lanes:backward', { allOf: [TWO_WAY, { key: 'lanes:backward' }] }),
+    turn_lanes_both_ways: laneField('turn:lanes:both_ways', { key: 'lanes:both_ways', valueGreaterThan: 0 }),
     change_lanes:          laneField('change:lanes',          { allOf: [ONE_WAY, { key: 'lanes' }] }),
     change_lanes_forward:  laneField('change:lanes:forward',  { allOf: [TWO_WAY, { key: 'lanes:forward' }] }),
     change_lanes_backward: laneField('change:lanes:backward', { allOf: [TWO_WAY, { key: 'lanes:backward' }] }),

--- a/test/spec/presets/custom/lane_placement_fields.js
+++ b/test/spec/presets/custom/lane_placement_fields.js
@@ -1,0 +1,56 @@
+import { prerequisiteTagSatisfied } from '../../../../modules/ui/field.js';
+import { loadCustomDistJson } from './setup.js';
+
+const UPSTREAM_RESIDENTIAL = {
+    'highway/residential': {
+        icon: 'fas-road',
+        fields: ['name', 'oneway', 'maxspeed', 'lanes', 'surface', 'structure', 'access'],
+        moreFields: ['sidewalk', 'cycleway'],
+        geometry: ['line'],
+        tags: { highway: 'residential' },
+        name: 'Residential Road'
+    }
+};
+
+describe('custom fields — lanes both_ways and placement', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_RESIDENTIAL;
+        iD.fileFetcher.cache().preset_fields = {};
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    it('keeps lanes_both_ways optional and exposes turn_lanes_both_ways when set', function() {
+        const lanesGroup = iD.presetManager.field('lanes_group');
+        expect(lanesGroup.members.map((m) => m.id)).to.eql(['lanes', 'lanes_forward', 'lanes_backward']);
+
+        const turnGroup = iD.presetManager.field('turn_lanes_group');
+        expect(turnGroup.members.map((m) => m.id)).to.eql([
+            'turn_lanes', 'turn_lanes_forward', 'turn_lanes_backward', 'turn_lanes_both_ways'
+        ]);
+
+        const turnBoth = iD.presetManager.field('turn_lanes_both_ways');
+        expect(turnBoth.key).to.equal('turn:lanes:both_ways');
+        expect(prerequisiteTagSatisfied(turnBoth.prerequisiteTag, { 'lanes:both_ways': '1' })).to.be.true;
+        expect(prerequisiteTagSatisfied(turnBoth.prerequisiteTag, { 'lanes:both_ways': '0' })).to.be.false;
+        expect(prerequisiteTagSatisfied(turnBoth.prerequisiteTag, {})).to.be.false;
+    });
+
+    it('offers lanes_both_ways via moreFields on residential roads', function() {
+        const preset = iD.presetManager.item('highway/residential');
+        expect(preset).to.exist;
+        expect(preset.originalFields).to.not.include('lanes_both_ways');
+        expect(preset.originalMoreFields).to.include('lanes_both_ways');
+    });
+
+    it.each(['placement_forward', 'placement_backward'])(
+        'adds middle_of:0 to %s options',
+        function(fieldId) {
+            const field = iD.presetManager.field(fieldId);
+            expect(field, fieldId).to.exist;
+            expect(field.options[0]).to.equal('middle_of:0');
+        }
+    );
+});

--- a/test/spec/presets/custom/lane_placement_fields.js
+++ b/test/spec/presets/custom/lane_placement_fields.js
@@ -22,9 +22,11 @@ describe('custom fields — lanes both_ways and placement', function() {
         await iD.presetManager.ensureLoaded(true);
     });
 
-    it('keeps lanes_both_ways optional and exposes turn_lanes_both_ways when set', function() {
+    it('adds lanes_both_ways to lanes group and turn_lanes_both_ways when set', function() {
         const lanesGroup = iD.presetManager.field('lanes_group');
-        expect(lanesGroup.members.map((m) => m.id)).to.eql(['lanes', 'lanes_forward', 'lanes_backward']);
+        expect(lanesGroup.members.map((m) => m.id)).to.eql([
+            'lanes', 'lanes_forward', 'lanes_backward', 'lanes_both_ways'
+        ]);
 
         const turnGroup = iD.presetManager.field('turn_lanes_group');
         expect(turnGroup.members.map((m) => m.id)).to.eql([
@@ -38,11 +40,11 @@ describe('custom fields — lanes both_ways and placement', function() {
         expect(prerequisiteTagSatisfied(turnBoth.prerequisiteTag, {})).to.be.false;
     });
 
-    it('offers lanes_both_ways via moreFields on residential roads', function() {
+    it('includes lanes_both_ways in lanes_group on residential roads', function() {
         const preset = iD.presetManager.item('highway/residential');
         expect(preset).to.exist;
-        expect(preset.originalFields).to.not.include('lanes_both_ways');
-        expect(preset.originalMoreFields).to.include('lanes_both_ways');
+        expect(preset.originalFields).to.include('lanes_group');
+        expect(preset.originalMoreFields).to.not.include('lanes_both_ways');
     });
 
     it.each(['placement_forward', 'placement_backward'])(


### PR DESCRIPTION
## Summary
- Add `turn_lanes_both_ways` field (⇄ row in turn group) shown when `lanes:both_ways` > 0.
- Keep `lanes:both_ways` out of the default lanes group; offer it via "+ add field" (`moreFields`).
- Add `middle_of:0` to `placement:forward` and `placement:backward` combo options (centre buffer between carriageways).

## Test plan
- [x] `npx vitest run test/spec/presets/custom/lane_placement_fields.js`
- [x] `npx vitest run test/spec/ui/fields/lane_list.js`
- [ ] Set `lanes:both_ways=1` on a two-way road → Turn ⇄ row appears
- [ ] Placement ↑/↓ dropdown includes `middle_of:0`