### PR TITLE
Fix: revert follow-segment to the v5 insert algorithm

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -446,6 +446,7 @@ en:
       annotation:
         points: Followed a line.
       nodes_are_not_shared_by_both_ways: The two nodes are not shared by both the source and target ways.
+      nodes_are_not_consecutive_in_target: The two nodes are not one after the other in the target way.
       source_or_target_way_is_closed_but_has_less_than_4_nodes: The source or target way is closed but has fewer than 4 nodes.
       connected_to_hidden: This can't be followed because it is connected to a hidden feature.
       not_downloaded: This can't be followed because parts of it have not yet been downloaded.

--- a/modules/actions/follow_segment.ts
+++ b/modules/actions/follow_segment.ts
@@ -1,252 +1,141 @@
 // =============================================================================
-// FOLLOW SEGMENT - Replace a portion of a target way (between two nodes shared
-// with a source way) by the matching portion of the source way, so the target
-// "follows" the source geometry between those two nodes.
+// FOLLOW SEGMENT - Insert a source way's node path into a target way, between
+// two nodes shared by both, so the target's edge follows the source's shape
+// there.
 //
 // Named "follow segment" to avoid clashing with iD's built-in draw-mode
 // "follow" (operations.follow, key F).
 //
-// Works for open ways and for closed ways (rings). A ring has two arcs between
-// the start and end nodes: one arc is replaced by the source path, the other is
-// kept, and the result is reassembled so the ring always stays closed,
-// regardless of the node order. Intersection nodes (shared with other ways or
-// carrying tags) on the replaced part are snapped onto the new path instead of
-// being dropped.
+// This is the v5 "follow" algorithm (see git history of `id/modules/actions/
+// follow_old.js`), ported to v6. It only inserts the source's nodes as-is
+// between the two shared nodes, without touching anything else on the target,
+// so the result exactly matches the source's curve. In exchange, it requires
+// the two shared nodes to be a single target edge (adjacent, or - on a closed
+// way - the two ends of the wrap-around edge). A later iteration may lift that
+// restriction (v6 briefly had a more general version that also handled
+// multi-node spans and preserved intersections by snapping them onto the new
+// path, but snapping could break a smooth source curve into short segments).
 // =============================================================================
 
-import { actionDeleteNode } from './delete_node';
-
-/** Index after `i`, wrapping on a closed way; `null` past an open way's end. */
-function nextNodeIdx(nodes: string[], closed: boolean, i: number): number | null {
-    if (closed) {
-        if (nodes.length < 3) return null;
-        return i === nodes.length - 1 ? 1 : i + 1;   // skip index 0 (duplicate of last)
-    }
-    return i === nodes.length - 1 ? null : i + 1;
+/** Way node ids, typed (works around the never[] inference of OsmWay.nodes). */
+function nodeIds(way: iD.OsmWay): EntityID[] {
+    return way.nodes;
 }
 
-/** True when `i` is the (duplicated) first/last node of a closed way. */
-function indexIsFirstOrLastOfClosed(nodes: string[], closed: boolean, i: number): boolean {
-    return closed && (i === 0 || i === nodes.length - 1);
+/** First target node that is also on the source way (or the explicit one). */
+function getStartNodeId(explicit: EntityID | undefined, tgtNodes: EntityID[], srcNodes: EntityID[]): EntityID | null {
+    if (explicit) return explicit;
+    return tgtNodes.find((id) => srcNodes.indexOf(id) >= 0) ?? null;
 }
 
-/**
- * Node ids walked from `startIdx` to `endIdx`, both included. A closed way walks
- * forward (wrapping); an open way walks in natural order and is always returned
- * oriented start -> end.
- */
-function nodesBetween(nodes: string[], closed: boolean, startIdx: number, endIdx: number): string[] {
-    if (nodes.length < 2 || startIdx < 0 || endIdx < 0 || startIdx === endIdx ||
-        (indexIsFirstOrLastOfClosed(nodes, closed, startIdx) && indexIsFirstOrLastOfClosed(nodes, closed, endIdx))) {
-        return [];
-    }
-    let reverse = false;
-    if (!closed && startIdx > endIdx) {
-        [startIdx, endIdx] = [endIdx, startIdx];
-        reverse = true;
-    }
-    let idx: number | null = startIdx;
-    const between = [nodes[startIdx]];
-    const endIsFirstOrLast = indexIsFirstOrLastOfClosed(nodes, closed, endIdx);
-    while (idx !== endIdx) {
-        idx = nextNodeIdx(nodes, closed, idx);
-        if (idx === null || !nodes[idx]) return [];
-        between.push(nodes[idx]);
-        if (endIsFirstOrLast && (idx === 0 || idx === nodes.length - 1)) break;
-    }
-    return reverse ? between.reverse() : between;
+/** Next shared node after the start (or the explicit one). */
+function getEndNodeId(startNodeId: EntityID | null, explicit: EntityID | undefined, tgtNodes: EntityID[], srcNodes: EntityID[]): EntityID | null {
+    if (explicit) return explicit;
+    return tgtNodes.find((id) => srcNodes.indexOf(id) >= 0 && id !== startNodeId) ?? null;
 }
 
-type Loc = [number, number];
-
-/** Location of a node id (the union entity type hides `loc`, so narrow it here). */
-function nodeLoc(graph: iD.Graph, id: string): Loc {
-    return (graph.entity(id) as { loc: Loc }).loc;
-}
-
-/** Closest point on segment [a, b] to `p`, with its parameter `t` and distance. */
-function closestPointOnSegment(p: Loc, a: Loc, b: Loc): { point: Loc; t: number; distance: number } {
-    const dx = b[0] - a[0];
-    const dy = b[1] - a[1];
-    const lengthSq = dx * dx + dy * dy;
-    if (lengthSq === 0) {
-        return { point: a, t: 0, distance: Math.hypot(p[0] - a[0], p[1] - a[1]) };
-    }
-    let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / lengthSq;
-    t = Math.max(0, Math.min(1, t));
-    const point: Loc = [a[0] + t * dx, a[1] + t * dy];
-    return { point, t, distance: Math.hypot(p[0] - point[0], p[1] - point[1]) };
-}
-
-/** Closest point on the polyline `nodeIds` to `p`, with the segment it lands on. */
-function closestPointOnPath(graph: iD.Graph, p: Loc, nodeIds: string[]) {
-    let best: { point: Loc; segmentIndex: number; t: number; distance: number } | null = null;
-    let bestDistance = Infinity;
-    for (let i = 0; i < nodeIds.length - 1; i++) {
-        const r = closestPointOnSegment(p, nodeLoc(graph, nodeIds[i]), nodeLoc(graph, nodeIds[i + 1]));
-        if (r.distance < bestDistance) {
-            bestDistance = r.distance;
-            best = { point: r.point, segmentIndex: i, t: r.t, distance: r.distance };
-        }
-    }
-    return best;
+/** True when `startIdx`/`endIdx` are the two ends of a closed way's wrap-around edge (index 0 and the duplicated last index), in either order. */
+function isClosedWayWrapEdge(nodesCount: number, startIdx: number, endIdx: number): boolean {
+    return (startIdx === 0 && endIdx === nodesCount - 2) || (endIdx === 0 && startIdx === nodesCount - 2);
 }
 
 /**
- * Average distance of an arc's interior nodes to the source path. Used to pick
- * which target arc the source is meant to replace, independently of the order in
- * which the two shared nodes were selected. An arc with no interior (a direct
- * edge between the two shared nodes) counts as closest.
+ * Build an action that replaces the edge of the target way between `startNodeId`
+ * and `endNodeId` (both shared with the source way) by the source way's node
+ * path between those same two nodes.
+ *
+ * @param selectedIds - `[targetWayId, sourceWayId, startNodeId?, endNodeId?]`; when the
+ *   node ids are omitted, the first two nodes shared by both ways are used
+ * @returns an iD action of the form (graph) => graph
  */
-function arcDistanceToPath(graph: iD.Graph, arc: string[], path: string[]): number {
-    const interior = arc.slice(1, -1);
-    if (interior.length === 0) return 0;
-    let sum = 0;
-    for (const id of interior) {
-        const closest = closestPointOnPath(graph, nodeLoc(graph, id), path);
-        sum += closest ? closest.distance : 0;
-    }
-    return sum / interior.length;
-}
-
-export function actionFollowSegment(selectedIDs: EntityID[], reverse = false) {
-
-    /** First target node that is also on the source way (or the explicit one). */
-    function getStartNodeId(explicit: EntityID | undefined, tgtNodes: string[], srcNodes: string[]): string | null {
-        if (explicit) return explicit;
-        return tgtNodes.find(id => srcNodes.indexOf(id) >= 0) ?? null;
-    }
-
-    /** Next shared node after the start (or the explicit one). */
-    function getEndNodeId(startNodeId: string | null, explicit: EntityID | undefined, tgtNodes: string[], srcNodes: string[]): string | null {
-        if (explicit) return explicit;
-        return tgtNodes.find(id => srcNodes.indexOf(id) >= 0 && id !== startNodeId) ?? null;
-    }
-
-    /**
-     * Replace the interior of `replacedArc` (an oriented run of target node ids,
-     * endpoints included) with `orientedSrc` (the source path, same endpoints and
-     * orientation). Intersection nodes on the replaced interior are snapped onto
-     * the new path and kept. Returns the new run (endpoints included), the updated
-     * graph, and the set of preserved node ids.
-     */
-    function replaceArc(graph: iD.Graph, replacedArc: string[], orientedSrc: string[]) {
-        const interior = replacedArc.slice(1, -1);
-
-        // intersection nodes: connected to another way or carrying tags
-        const intersections = interior
-            .map(id => graph.entity(id) as any)
-            .filter(node => graph.parentWays(node).length > 1 || node.hasNonGeometryTags());
-
-        const toInsert: { segmentIndex: number; t: number; nodeId: string }[] = [];
-        for (const node of intersections) {
-            const closest = closestPointOnPath(graph, node.loc, orientedSrc);
-            if (!closest) continue;
-            graph = graph.replace((graph.entity(node.id) as any).move(closest.point));
-            toInsert.push({ segmentIndex: closest.segmentIndex, t: closest.t, nodeId: node.id });
-        }
-        toInsert.sort((a, b) => a.segmentIndex !== b.segmentIndex ? a.segmentIndex - b.segmentIndex : a.t - b.t);
-
-        // weave the snapped intersection nodes into the source path
-        const seq: string[] = [];
-        let k = 0;
-        for (let i = 0; i < orientedSrc.length; i++) {
-            seq.push(orientedSrc[i]);
-            while (k < toInsert.length && toInsert[k].segmentIndex === i) {
-                seq.push(toInsert[k].nodeId);
-                k++;
-            }
-        }
-        return { seq, graph, preserved: new Set(intersections.map(n => n.id)) };
-    }
-
-    /** Delete the replaced interior nodes that became orphan and tagless. */
-    function deleteOrphans(graph: iD.Graph, interior: string[], preserved: Set<string>): iD.Graph {
-        for (const nodeId of interior) {
-            if (preserved.has(nodeId) || !graph.hasEntity(nodeId)) continue;
-            const node = graph.entity(nodeId);
-            if (!node.hasNonGeometryTags() && !graph.isShared(node) && graph.parentWays(node).length === 0) {
-                graph = actionDeleteNode(node.id)(graph);
-            }
-        }
-        return graph;
-    }
+export function actionFollowSegment(selectedIds: EntityID[]) {
 
     const action = function (graph: iD.Graph): iD.Graph {
-        const tgtWay = graph.entity(selectedIDs[0]) as any;
+        let tgtWay = graph.entity<iD.OsmWay>(selectedIds[0]);
         const tgtClosed = tgtWay.isClosed();
-        const tgtNodes: string[] = tgtWay.nodes.slice();
-        const srcWay = graph.entity(selectedIDs[1]) as any;
+        const tgtNodes = nodeIds(tgtWay);
+        const tgtNodesCount = tgtNodes.length;
+        const srcWay = graph.entity<iD.OsmWay>(selectedIds[1]);
         const srcClosed = srcWay.isClosed();
-        const srcNodes: string[] = srcWay.nodes.slice();
+        const srcNodes = nodeIds(srcWay);
+        const srcNodesCount = srcNodes.length;
 
-        const startNodeId = getStartNodeId(selectedIDs[2], tgtNodes, srcNodes);
-        const endNodeId = getEndNodeId(startNodeId, selectedIDs[3], tgtNodes, srcNodes);
+        const startNodeId = getStartNodeId(selectedIds[2], tgtNodes, srcNodes);
+        const endNodeId = getEndNodeId(startNodeId, selectedIds[3], tgtNodes, srcNodes);
 
-        const startTgt = tgtNodes.indexOf(startNodeId as string);
-        const endTgt = tgtNodes.indexOf(endNodeId as string);
-        const startSrc = srcNodes.indexOf(startNodeId as string);
-        const endSrc = srcNodes.indexOf(endNodeId as string);
+        let startSrc = srcNodes.indexOf(startNodeId as EntityID);
+        let endSrc = srcNodes.indexOf(endNodeId as EntityID);
+        let startTgt = tgtNodes.indexOf(startNodeId as EntityID);
+        let endTgt = tgtNodes.indexOf(endNodeId as EntityID);
 
-        // source geometry oriented from the start node to the end node
-        const srcPath = nodesBetween(srcNodes, srcClosed, startSrc, endSrc);
-        if (srcPath.length === 0) return graph;
-
-        if (!tgtClosed) {
-            // open way: replace the [start, end] run in place, keeping the rest
-            let lo = startTgt, hi = endTgt;
-            if (lo > hi) [lo, hi] = [hi, lo];
-            const replacedArc = tgtNodes.slice(lo, hi + 1);
-            const orientedSrc = tgtNodes[lo] === srcPath[0] ? srcPath : [...srcPath].reverse();
-
-            const r = replaceArc(graph, replacedArc, orientedSrc);
-            graph = r.graph;
-            const newNodes = [...tgtNodes.slice(0, lo), ...r.seq, ...tgtNodes.slice(hi + 1)];
-            graph = graph.replace(tgtWay.update({ nodes: newNodes }));
-            return deleteOrphans(graph, replacedArc.slice(1, -1), r.preserved);
+        // walk the source forward (only meaningful for an open source; a closed one has no "backward")
+        if (!srcClosed && startSrc > endSrc) {
+            [startSrc, endSrc] = [endSrc, startSrc];
+        }
+        // walk the target forward (skipped when either way is closed: their wrap-around indices aren't ordered this way)
+        if (!tgtClosed && !srcClosed && startTgt > endTgt) {
+            [startTgt, endTgt] = [endTgt, startTgt];
         }
 
-        // closed way: pick the arc to replace, keep the other, reassemble closed
-        const arc1 = nodesBetween(tgtNodes, true, startTgt, endTgt);   // start -> end
-        const arc2 = nodesBetween(tgtNodes, true, endTgt, startTgt);   // end -> start
-        if (arc1.length === 0 || arc2.length === 0) return graph;
+        const tgtIsWrapEdge = tgtClosed && isClosedWayWrapEdge(tgtNodesCount, startTgt, endTgt);
+        const sameDirection = srcNodes[startSrc] === tgtNodes[startTgt];
 
-        // Replace the arc closest to the source path (order-independent); `reverse`
-        // flips the choice to the far arc.
-        let replaceArc1 = arcDistanceToPath(graph, arc1, srcPath) <= arcDistanceToPath(graph, arc2, srcPath);
-        if (reverse) replaceArc1 = !replaceArc1;
-        const replacedArc = replaceArc1 ? arc1 : arc2;
-        const keptArc = replaceArc1 ? arc2 : arc1;
-        // source path oriented to match the replaced arc's endpoints
-        const orientedSrc = replacedArc[0] === srcPath[0] ? srcPath : [...srcPath].reverse();
+        let insertAt = endTgt;
+        let srcIdx = srcClosed && startSrc === srcNodesCount - 2 ? 0 : startSrc + 1;
+        let srcStep = sameDirection ? 1 : 0;
 
-        const r = replaceArc(graph, replacedArc, orientedSrc);
-        graph = r.graph;
-        // replaced run, then the kept arc without its shared joint -> closed ring
-        const ring = [...r.seq, ...keptArc.slice(1)];
-        graph = graph.replace(tgtWay.update({ nodes: ring }));
-        return deleteOrphans(graph, replacedArc.slice(1, -1), r.preserved);
+        if (srcClosed) {
+            const tgtAscending = endTgt > startTgt;
+            srcStep = tgtAscending ? 1 : 0;
+            insertAt = tgtAscending ? endTgt : startTgt;
+            if (tgtIsWrapEdge) {
+                insertAt = tgtNodesCount - 1;
+                srcStep = tgtAscending ? 0 : 1;
+            }
+        } else if (tgtIsWrapEdge) {
+            insertAt = tgtNodesCount - 1;
+            srcStep = 0;
+        }
+
+        const newTgtNodes = tgtNodes.slice();
+        while (srcIdx !== endSrc) {
+            newTgtNodes.splice(insertAt, 0, srcNodes[srcIdx]);
+            insertAt += srcStep;
+            // jump back to the first node once past the source's duplicated last node
+            srcIdx = srcClosed && srcIdx + 1 === srcNodesCount - 1 ? 0 : srcIdx + 1;
+        }
+
+        tgtWay = tgtWay.update({ nodes: newTgtNodes });
+        return graph.replace(tgtWay);
     };
 
     action.disabled = function (graph: iD.Graph): string | false {
-        const tgtWay = graph.entity(selectedIDs[0]) as any;
-        const tgtNodes: string[] = tgtWay.nodes.slice();
-        const srcWay = graph.entity(selectedIDs[1]) as any;
-        const srcNodes: string[] = srcWay.nodes.slice();
-        const startNodeId = getStartNodeId(selectedIDs[2], tgtNodes, srcNodes);
-        const endNodeId = getEndNodeId(startNodeId, selectedIDs[3], tgtNodes, srcNodes);
+        const tgtWay = graph.entity<iD.OsmWay>(selectedIds[0]);
+        const tgtClosed = tgtWay.isClosed();
+        const tgtNodes = nodeIds(tgtWay);
+        const srcWay = graph.entity<iD.OsmWay>(selectedIds[1]);
+        const srcNodes = nodeIds(srcWay);
 
-        const startTgt = tgtNodes.indexOf(startNodeId as string);
-        const endTgt = tgtNodes.indexOf(endNodeId as string);
-        const startSrc = srcNodes.indexOf(startNodeId as string);
-        const endSrc = srcNodes.indexOf(endNodeId as string);
+        const startNodeId = getStartNodeId(selectedIds[2], tgtNodes, srcNodes);
+        const endNodeId = getEndNodeId(startNodeId, selectedIds[3], tgtNodes, srcNodes);
+
+        const startTgt = tgtNodes.indexOf(startNodeId as EntityID);
+        const endTgt = tgtNodes.indexOf(endNodeId as EntityID);
+        const startSrc = srcNodes.indexOf(startNodeId as EntityID);
+        const endSrc = srcNodes.indexOf(endNodeId as EntityID);
 
         if (startTgt === -1 || endTgt === -1 || startSrc === -1 || endSrc === -1) {
             return 'nodes_are_not_shared_by_both_ways';
         }
         // a closed way repeats its first node, so it needs at least 4 entries here
-        if ((tgtWay.isClosed() && tgtNodes.length < 4) || (srcWay.isClosed() && srcNodes.length < 4)) {
+        if ((tgtClosed && tgtNodes.length < 4) || (srcWay.isClosed() && srcNodes.length < 4)) {
             return 'source_or_target_way_is_closed_but_has_less_than_4_nodes';
+        }
+        if (tgtClosed && isClosedWayWrapEdge(tgtNodes.length, startTgt, endTgt)) {
+            return false;
+        }
+        if (Math.abs(startTgt - endTgt) !== 1) {
+            return 'nodes_are_not_consecutive_in_target';
         }
         return false;
     };

--- a/test/spec/actions/follow_segment.js
+++ b/test/spec/actions/follow_segment.js
@@ -10,25 +10,24 @@ describe('iD.actionFollowSegment', function () {
         return new iD.coreGraph(entities);
     }
 
-    // Square ring a-b-c-d-a with two shared nodes b, c, plus an outside node x
-    // sitting near the b-c edge (so the b-c arc is the one closest to the source).
+    var openNodes = [
+        { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+        { id: 'c', loc: [2, 0] }, { id: 'd', loc: [3, 0] },
+        { id: 'x', loc: [1, 1] }, { id: 'y', loc: [2, 1] }
+    ];
+
+    // Square ring a-b-c-d-a; the wrap-around edge is d-a (the duplicated node).
     var ringNodes = [
-        { id: 'a', loc: [0, 0] },
-        { id: 'b', loc: [1, 0] },
-        { id: 'c', loc: [1, 1] },
-        { id: 'd', loc: [0, 1] },
-        { id: 'x', loc: [1.2, 0.5] }
+        { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+        { id: 'c', loc: [1, 1] }, { id: 'd', loc: [0, 1] },
+        { id: 'x', loc: [-1, 0.5] }
     ];
 
     // Parametric cases that assert the resulting target way node order exactly.
     var cases = [
         {
-            name: 'open way: inserts the source nodes between the shared nodes',
-            nodes: [
-                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
-                { id: 'c', loc: [2, 0] }, { id: 'd', loc: [3, 0] },
-                { id: 'x', loc: [1, 1] }, { id: 'y', loc: [2, 1] }
-            ],
+            name: 'open way: inserts the source nodes between the two adjacent shared nodes',
+            nodes: openNodes,
             ways: [
                 { id: 'tgt', nodes: ['a', 'b', 'c', 'd'] },
                 { id: 'src', nodes: ['b', 'x', 'y', 'c'] }
@@ -38,11 +37,7 @@ describe('iD.actionFollowSegment', function () {
         },
         {
             name: 'open way: result is independent of the start/end selection order',
-            nodes: [
-                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
-                { id: 'c', loc: [2, 0] }, { id: 'd', loc: [3, 0] },
-                { id: 'x', loc: [1, 1] }, { id: 'y', loc: [2, 1] }
-            ],
+            nodes: openNodes,
             ways: [
                 { id: 'tgt', nodes: ['a', 'b', 'c', 'd'] },
                 { id: 'src', nodes: ['b', 'x', 'y', 'c'] }
@@ -51,85 +46,53 @@ describe('iD.actionFollowSegment', function () {
             expected: ['a', 'b', 'x', 'y', 'c', 'd']
         },
         {
-            name: 'closed way: replaces the arc closest to the source, stays closed',
-            nodes: ringNodes,
+            name: 'open way: result is independent of the source way\'s own direction',
+            nodes: openNodes,
             ways: [
-                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
-                { id: 'src', nodes: ['b', 'x', 'c'] }
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd'] },
+                { id: 'src', nodes: ['c', 'y', 'x', 'b'] }  // reversed
             ],
             selectedIDs: ['tgt', 'src'],
-            expected: ['b', 'x', 'c', 'd', 'a', 'b']
+            expected: ['a', 'b', 'x', 'y', 'c', 'd']
         },
         {
-            name: 'closed way: same result whatever the start/end selection order',
+            name: 'closed target way: replaces its wrap-around edge, stays closed',
             nodes: ringNodes,
             ways: [
                 { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
-                { id: 'src', nodes: ['b', 'x', 'c'] }
-            ],
-            selectedIDs: ['tgt', 'src', 'c', 'b'],  // end then start
-            expected: ['b', 'x', 'c', 'd', 'a', 'b']
-        },
-        {
-            name: 'closed way: reverse replaces the far arc and stays closed',
-            nodes: ringNodes,
-            ways: [
-                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
-                { id: 'src', nodes: ['b', 'x', 'c'] }
+                { id: 'src', nodes: ['d', 'x', 'a'] }
             ],
             selectedIDs: ['tgt', 'src'],
-            reverse: true,
-            expected: ['c', 'x', 'b', 'c']
+            expected: ['a', 'b', 'c', 'd', 'x', 'a']
+        },
+        {
+            name: 'closed target way: same result whatever the start/end selection order',
+            nodes: ringNodes,
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
+                { id: 'src', nodes: ['d', 'x', 'a'] }
+            ],
+            selectedIDs: ['tgt', 'src', 'd', 'a'],  // start/end swapped
+            expected: ['a', 'b', 'c', 'd', 'x', 'a']
+        },
+        {
+            name: 'closed source way: inserts the source\'s ring between the two adjacent shared nodes',
+            nodes: openNodes,
+            ways: [
+                { id: 'tgt', nodes: ['a', 'b', 'c'] },
+                { id: 'src', nodes: ['b', 'x', 'y', 'c', 'b'] }
+            ],
+            selectedIDs: ['tgt', 'src'],
+            expected: ['a', 'b', 'x', 'y', 'c']
         }
     ];
 
     cases.forEach(function (c) {
         it(c.name, function () {
             var graph = makeGraph(c.nodes, c.ways);
-            graph = iD.actionFollowSegment(c.selectedIDs, c.reverse || false)(graph);
+            graph = iD.actionFollowSegment(c.selectedIDs)(graph);
             expect(graph.entity('tgt').nodes).to.eql(c.expected);
-            // a closed result must keep its first node repeated at the end
-            var nodes = graph.entity('tgt').nodes;
-            if (c.ways[0].nodes[0] === c.ways[0].nodes[c.ways[0].nodes.length - 1]) {
-                expect(nodes[0]).to.equal(nodes[nodes.length - 1]);
-            }
         });
-    });
-
-    it('reverse on a closed way deletes the orphan tagless nodes of the replaced arc', function () {
-        var graph = makeGraph(ringNodes, [
-            { id: 'tgt', nodes: ['a', 'b', 'c', 'd', 'a'] },
-            { id: 'src', nodes: ['b', 'x', 'c'] }
-        ]);
-        graph = iD.actionFollowSegment(['tgt', 'src'], true)(graph);
-        expect(graph.hasEntity('d')).not.to.be.ok;  // far-arc interior, now orphan
-        expect(graph.hasEntity('a')).not.to.be.ok;
-        expect(graph.hasEntity('x')).to.be.ok;       // from the source path
-    });
-
-    it('preserves an intersection node by snapping it onto the new path', function () {
-        // m sits on the replaced segment of the target and is shared with way w2,
-        // so it must survive (moved onto the source path) instead of being deleted.
-        var graph = makeGraph(
-            [
-                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
-                { id: 'm', loc: [1.5, 0.1] }, { id: 'c', loc: [2, 0] },
-                { id: 'd', loc: [3, 0] }, { id: 'x', loc: [1.5, 1] },
-                { id: 'n', loc: [1.5, -1] }
-            ],
-            [
-                { id: 'tgt', nodes: ['a', 'b', 'm', 'c', 'd'] },
-                { id: 'src', nodes: ['b', 'x', 'c'] },
-                { id: 'w2', nodes: ['m', 'n'] }  // makes m an intersection node
-            ]
-        );
-        graph = iD.actionFollowSegment(['tgt', 'src'])(graph);
-        var nodes = graph.entity('tgt').nodes;
-        expect(graph.hasEntity('m')).to.be.ok;
-        expect(nodes).to.include('m');
-        expect(nodes).to.include('x');
-        expect(nodes[0]).to.equal('a');
-        expect(nodes[nodes.length - 1]).to.equal('d');
     });
 
     it('is disabled when the ways share no nodes', function () {
@@ -144,5 +107,35 @@ describe('iD.actionFollowSegment', function () {
             ]
         );
         expect(iD.actionFollowSegment(['tgt', 'src']).disabled(graph)).to.equal('nodes_are_not_shared_by_both_ways');
+    });
+
+    it('is disabled when the shared nodes are not adjacent in the target', function () {
+        var graph = makeGraph(
+            [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'm', loc: [1.5, 0.1] }, { id: 'c', loc: [2, 0] },
+                { id: 'd', loc: [3, 0] }, { id: 'x', loc: [1.5, 1] }
+            ],
+            [
+                { id: 'tgt', nodes: ['a', 'b', 'm', 'c', 'd'] },
+                { id: 'src', nodes: ['b', 'x', 'c'] }
+            ]
+        );
+        expect(iD.actionFollowSegment(['tgt', 'src']).disabled(graph)).to.equal('nodes_are_not_consecutive_in_target');
+    });
+
+    it('is disabled when the source way is closed but has fewer than 4 nodes', function () {
+        var graph = makeGraph(
+            [
+                { id: 'a', loc: [0, 0] }, { id: 'b', loc: [1, 0] },
+                { id: 'x', loc: [1, 1] }
+            ],
+            [
+                { id: 'tgt', nodes: ['a', 'b', 'x'] },
+                { id: 'src', nodes: ['b', 'x', 'b'] }
+            ]
+        );
+        expect(iD.actionFollowSegment(['tgt', 'src']).disabled(graph))
+            .to.equal('source_or_target_way_is_closed_but_has_less_than_4_nodes');
     });
 });


### PR DESCRIPTION
## Summary
- The v6 rewrite of follow-segment generalized it to multi-node spans by snapping preserved intersection nodes onto the new path — but that snapping was breaking smooth source curves into short segments joined by straight lines.
- Reverts to the simpler v5 algorithm (`id/modules/actions/follow_old.js`): the source path is inserted as-is between two adjacent shared nodes (or a closed way's wrap-around edge), so the result always matches the source curve exactly.
- Trade-off: follow-segment is now restricted to a single target edge (adjacent shared nodes). Multi-node spans can be revisited later without reintroducing the snapping artifact.

## Test plan
- [x] `npx vitest run test/spec/actions/follow_segment.js` — 9 passing cases (open way, closed way wrap edge, closed source way, reversed selection order, disabled checks)
- [x] `npx vitest run` — full suite, 3037 passing