### PR TITLE
Fix: crossing_ways validation ignores links/paths that dead-end at a road node

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -243,6 +243,15 @@ export function validationCrossingWays(context) {
     }
 
 
+    // A path only crosses the road at a node if it continues past that node on
+    // both sides. A path/link that ends there (its first or last node) merges
+    // into the road/junction instead, which needs no crossing tags.
+    function isInteriorNode(way, nodeId) {
+        var idx = way.nodes.indexOf(nodeId);
+        return idx > 0 && idx < way.nodes.length - 1;
+    }
+
+
     function findSharedVertexCrossings(way1, graph) {
         var edgeCrossInfos = [];
         if (way1.type !== 'way') return edgeCrossInfos;
@@ -284,6 +293,8 @@ export function validationCrossingWays(context) {
                 } else if (!way1IsCrossingPath) {
                     return;
                 }
+
+                if (!isInteriorNode(pathWay, node.id)) return;
 
                 var entity1IsPath = osmPathHighwayTagValues[pathFeature.tags.highway];
                 var entity2IsPath = osmPathHighwayTagValues[roadFeature.tags.highway];

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -542,6 +542,35 @@ describe('iD.validations.crossing_ways', function () {
         expect(validate()).to.have.lengthOf(0);
     });
 
+    // a link/path that only touches the road at one end (a T-junction) merges
+    // into it rather than crossing over it, so it needs no crossing tags
+    [
+        { highway: 'footway', footway: 'crossing' },
+        { highway: 'footway', crossing: 'unmarked' },
+        { highway: 'cycleway', crossing: 'unmarked' }
+    ].forEach(function(pathTags) {
+        it('ignores ' + JSON.stringify(pathTags) + ' link ending at a shared road node without crossing through', function() {
+            var n1 = new iD.osmNode({ id: 'n-1', loc: [1, 1] });
+            var nMid = new iD.osmNode({ id: 'n-mid', loc: [1.5, 1] });
+            var n2 = new iD.osmNode({ id: 'n-2', loc: [3, 1] });
+            var wRoad = new iD.osmWay({ id: 'w-road', nodes: ['n-1', 'n-mid', 'n-2'], tags: { highway: 'residential' } });
+
+            var n3 = new iD.osmNode({ id: 'n-3', loc: [1.5, 0.5] });
+            var wLink = new iD.osmWay({ id: 'w-link', nodes: ['n-mid', 'n-3'], tags: pathTags });
+
+            context.perform(
+                iD.actionAddEntity(n1),
+                iD.actionAddEntity(nMid),
+                iD.actionAddEntity(n2),
+                iD.actionAddEntity(n3),
+                iD.actionAddEntity(wRoad),
+                iD.actionAddEntity(wLink)
+            );
+
+            expect(validate()).to.have.lengthOf(0);
+        });
+    });
+
     it('flags road crossing road twice', function() {
         createWaysWithTwoCrossingPoint();
         var issues = validate();


### PR DESCRIPTION
## Summary
- `findSharedVertexCrossings` (in `crossing_ways` validation) flagged any tagged crossing path/link that shares a node with a road, even when that node is the path's own endpoint (a T-junction where the path just merges into the road, not a through-crossing).
- A cycleway/footway link that dead-ends at an intersection is not actually crossing the road, so it shouldn't be suggested `highway=crossing` node tags.
- Added `isInteriorNode` check: the shared node must be an interior node of the path way (i.e. the path continues past it on both sides) for the pair to be flagged.

## Test plan
- [x] `npx vitest run test/spec/validations/crossing_ways.js` — 3 new tests (footway=crossing, footway+crossing, cycleway+crossing, all ending at the shared node) fail against the old code and pass with the fix; all 88 tests pass
- [x] `npx vitest run` — full suite passes (3041 passed)