### PR TITLE
Fix: keep imprecise-surface warnings out of changeset warnings tags

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -492,6 +492,7 @@ A feature does not conform to the limits and rules imposed by the OSM API, such 
 A feature has nonstandard tags.
 
 * `deprecated_tags`: the feature has tags that should be replaced or removed, as specified in `deprecated.json` or the `replacement` property of a preset
+* `imprecise_surface` (v5 fork): the feature is missing `surface` or has `surface=paved`, which is too imprecise; this is a local convention, not a real OSM tagging error, so it's excluded from the changeset `warnings:*` tags (see `modules/ui/commit.js`)
 * `incomplete_tags`: the feature has tags that indicate it should also have some other tags
 * `noncanonical_brand`: the feature indicates it should match a name-suggestion-index entry but does not have all of the given tags
 * `old_multipolygon`: the feature is a multipolygon relation with its defining tags set on its outer member way

--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -181,7 +181,13 @@ export function uiCommit(context) {
         const warnings = context.validator()
             .getIssuesBySeverity({ what: 'edited', where: 'all', includeIgnored: true, includeDisabledRules: true })
             .warning
-            .filter(function(issue) { return issue.type !== 'help_request'; });    // exclude 'fixme' and similar - #8603
+            .filter(function(issue) {
+                if (issue.type === 'help_request') return false;    // exclude 'fixme' and similar - #8603
+                // v5 fork: missing/imprecise surface is a local convention, not a real
+                // OSM tagging error - keep it out of the changeset, it's for the user only
+                if (issue.type === 'outdated_tags' && issue.subtype === 'imprecise_surface') return false;
+                return true;
+            });
 
         // also include "incompatible_source" warnings caused by changeset tags
         [   ...getIncompatibleSources(tags.comment),

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -120,10 +120,14 @@ export function validationOutdatedTags() {
     if (deprecationDiff.length) {
       const isOnlyAddingTags = !deprecationDiff.some(d => d.type === '-');
       const prefix = isOnlyAddingTags ? 'incomplete.' : '';
+      // v5 fork: missing/imprecise `surface` (including surface=paved -> asphalt) is
+      // an opinionated local convention, not a real OSM tagging error, so give it its
+      // own subtype - it's excluded from the changeset `warnings:*` tags (see commit.js)
+      const isSurfaceOnly = deprecationDiff.every(d => d.key === 'surface');
 
       issues.push(new validationIssue({
         type: type,
-        subtype: isOnlyAddingTags ? 'incomplete_tags' : 'deprecated_tags',
+        subtype: isSurfaceOnly ? 'imprecise_surface' : (isOnlyAddingTags ? 'incomplete_tags' : 'deprecated_tags'),
         severity: 'warning',
         message: (context) => {
           const currEntity = context.hasEntity(entity.id);

--- a/test/spec/validations/outdated_tags.js
+++ b/test/spec/validations/outdated_tags.js
@@ -119,9 +119,9 @@ describe('iD.validations.outdated_tags', function () {
     });
 
     it.each([
-        ['missing surface', { highway: 'residential' }, 'incomplete_tags', { highway: 'residential', surface: 'asphalt' }],
-        ['surface=paved', { highway: 'primary', surface: 'paved' }, 'deprecated_tags', { highway: 'primary', surface: 'asphalt' }]
-    ])('flags imprecise surface (%s)', async (_label, tags, subtype, expected) => {
+        ['missing surface', { highway: 'residential' }, { highway: 'residential', surface: 'asphalt' }],
+        ['surface=paved', { highway: 'primary', surface: 'paved' }, { highway: 'primary', surface: 'asphalt' }]
+    ])('flags imprecise surface (%s) with its own subtype, excluded from changeset warnings', async (_label, tags, expected) => {
         createWay(tags);
         const validator = iD.validationOutdatedTags(context);
         await setTimeout(20);
@@ -129,7 +129,7 @@ describe('iD.validations.outdated_tags', function () {
         expect(issues).toHaveLength(1);
         expect(issues[0]).toMatchObject({
             type: 'outdated_tags',
-            subtype,
+            subtype: 'imprecise_surface',
             severity: 'warning',
             entityIds: ['w-1']
         });


### PR DESCRIPTION
## Summary
- Missing/imprecise `surface` (including the `surface=paved -> asphalt` upgrade suggestion) is a local convention added in the v5 fork (`shouldApplyPresetAddTag`), not a real OSM tagging error, but it was sharing the generic `incomplete_tags`/`deprecated_tags` outdated_tags subtypes, so it got counted into the changeset's `warnings:*` tags like any other real tagging issue.
- Gave it its own subtype `imprecise_surface` (only when the whole diff is about the `surface` key) and excluded that subtype from the changeset warnings tag derivation in `commit.js`. It still shows up in the issues panel for the user.
- Documented the new subtype in `ARCHITECTURE.md`.

## Test plan
- [x] `npx vitest run test/spec/validations/outdated_tags.js` — 14 tests pass, updated to expect `imprecise_surface`
- [x] `npx vitest run` — full suite passes (3041 passed)