### PR TITLE
Feat: show copyable OSM id and centroid-based location links for any entity

### DIFF
--- a/modules/ui/sections/location_links.ts
+++ b/modules/ui/sections/location_links.ts
@@ -1,3 +1,5 @@
+import { geoPath as d3_geoPath } from 'd3-geo';
+
 import { t } from '../../core/localizer';
 import { prefs } from '../../core/preferences';
 import { svgIcon } from '../../svg/icon';
@@ -11,26 +13,41 @@ import {
 /** Map zoom level used in street-level imagery permalinks. */
 const IMAGERY_ZOOM = 18;
 
-/** A copyable coordinate representation of a node. */
-interface CoordinateFormat {
+/** A copyable value shown as one row (an id or a coordinate format). */
+interface CopyableRow {
     id: string;
     value: string;
 }
 
 /**
- * Build the copyable coordinate strings for a node, mirroring the legacy v5
- * formats: `lat,lon`, `[lon,lat]` and (when a stable OSM id exists) `osmId,lat,lon`.
- * @param loc Node location as `[lon, lat]` (iD convention).
- * @param osmId Numeric OSM id of the node, or `null` for an unsaved node.
+ * Build the copyable long (`way/1234`) and short (`w/1234`) id of an entity.
+ * @param entity A saved OSM entity (not new - `entity.isNew()` is `false`).
  * @returns Ordered list of `{ id, value }` formats.
  */
-export function formatCoordinates(loc: [number, number], osmId: number | null): CoordinateFormat[] {
+export function formatOsmIds(entity: any): CopyableRow[] {
+    const osmId = entity.osmId();
+    return [
+        { id: 'id_long', value: `${entity.type}/${osmId}` },
+        { id: 'id_short', value: `${entity.type[0]}/${osmId}` }
+    ];
+}
+
+/**
+ * Build the copyable coordinate strings for a location, mirroring the legacy
+ * v5 formats: `lat,lon`, `[lon,lat]` and (when a stable OSM id exists)
+ * `osmId,lat,lon`.
+ * @param loc A location as `[lon, lat]` (iD convention) - a node's own
+ *   location, or another entity's centroid.
+ * @param osmId Numeric OSM id of the entity, or `null` if it's unsaved.
+ * @returns Ordered list of `{ id, value }` formats.
+ */
+export function formatCoordinates(loc: [number, number], osmId: number | null): CopyableRow[] {
     const [lon, lat] = loc;
-    const formats: CoordinateFormat[] = [
+    const formats: CopyableRow[] = [
         { id: 'latlon', value: `${lat},${lon}` },
         { id: 'lonlat', value: `[${lon},${lat}]` }
     ];
-    // a brand-new node only has a temporary negative id, which is not useful
+    // a brand-new entity only has a temporary negative id, which is not useful
     if (osmId !== null) {
         formats.push({ id: 'id_latlon', value: `${osmId},${lat},${lon}` });
     }
@@ -41,7 +58,7 @@ export function formatCoordinates(loc: [number, number], osmId: number | null): 
  * Fill an imagery URL template, replacing the `{lat}`, `{lon}` and `{zoom}`
  * placeholders.
  * @param template URL template, e.g. `https://.../?map={zoom}/{lat}/{lon}`.
- * @param loc Node location as `[lon, lat]` (iD convention).
+ * @param loc Location as `[lon, lat]` (iD convention).
  * @param zoom Map zoom level to embed in the permalink.
  * @returns The resolved URL.
  */
@@ -54,30 +71,58 @@ export function fillImageryUrl(template: string, loc: [number, number], zoom: nu
 }
 
 /**
- * Entity editor section shown below the tag form for a single existing node:
- * street-level imagery links (Panoramax, Mapillary) and copyable coordinates.
+ * The location to use for street-level imagery links and copyable
+ * coordinates: a node's own location, or another entity's centroid (properly
+ * accounting for multipolygon holes via the projected path centroid, the same
+ * way the measurement panel computes it), falling back to the bounding box
+ * center if the projected centroid is degenerate.
+ * @param context The global iD context.
+ * @param entity Any single selected entity.
+ * @returns A `[lon, lat]` location, or `null` if none could be computed
+ *   (e.g. an entity with no geometry yet).
+ */
+export function representativeLoc(context: any, entity: any): [number, number] | null {
+    if (entity.type === 'node') return entity.loc;
+
+    const graph = context.graph();
+    let centroid = d3_geoPath(context.projection).centroid(entity.asGeoJSON(graph));
+    centroid = centroid && context.projection.invert(centroid);
+    if (!centroid || !isFinite(centroid[0]) || !isFinite(centroid[1])) {
+        centroid = entity.extent(graph).center();
+    }
+    return (centroid && isFinite(centroid[0]) && isFinite(centroid[1])) ? centroid : null;
+}
+
+/**
+ * Entity editor section shown below Relations for a single selected entity:
+ * its copyable OSM id, street-level imagery links (Panoramax, Mapillary) and
+ * copyable coordinates. For entities other than nodes, the coordinates and
+ * imagery links use the entity's centroid.
  * @param context The global iD context.
  */
 export function uiSectionLocationLinks(context: any) {
     let _entityIDs: string[] = [];
 
     const section: any = (uiSection('location-links', context) as any)
-        .shouldDisplay(() => selectedNode() !== null)
+        .shouldDisplay(() => selectedLoc() !== null)
         .label(() => t.append('inspector.location_links.title'))
         .disclosureContent(render);
 
-    // A single selected node (saved or not); unsaved nodes still have a location.
-    function selectedNode() {
+    // A single selected entity (saved or not) with a computable location.
+    function selectedEntity() {
         if (_entityIDs.length !== 1) return null;
-        const entity = context.hasEntity(_entityIDs[0]);
-        return (entity && entity.type === 'node') ? entity : null;
+        return context.hasEntity(_entityIDs[0]) || null;
+    }
+
+    function selectedLoc() {
+        const entity = selectedEntity();
+        return entity ? representativeLoc(context, entity) : null;
     }
 
     function render(selection: any) {
-        const node = selectedNode();
-        if (!node) return;
-
-        const loc = node.loc as [number, number];
+        const entity = selectedEntity();
+        const loc = entity && representativeLoc(context, entity);
+        if (!entity || !loc) return;
 
         let container = selection.selectAll('.location-links-container').data([0]);
         const containerEnter = container.enter()
@@ -87,9 +132,12 @@ export function uiSectionLocationLinks(context: any) {
         containerEnter.append('ul').attr('class', 'location-coordinates');
         container = containerEnter.merge(container);
 
-        const osmId = node.isNew() ? null : node.osmId();
+        // a brand-new entity only has a temporary negative id, which is not useful
+        const osmId = entity.isNew() ? null : entity.osmId();
+        const rows = (osmId !== null ? formatOsmIds(entity) : []).concat(formatCoordinates(loc, osmId));
+
         renderImageryLinks(container.select('.street-level-imagery-links'), loc);
-        renderCoordinates(container.select('.location-coordinates'), loc, osmId);
+        renderCopyableRows(container.select('.location-coordinates'), rows);
     }
 
     function renderImageryLinks(selection: any, loc: [number, number]) {
@@ -111,27 +159,27 @@ export function uiSectionLocationLinks(context: any) {
             .text((d: any) => d.name || t('inspector.location_links.custom'));
     }
 
-    function renderCoordinates(selection: any, loc: [number, number], osmId: number | null) {
-        const rows = selection.selectAll('li.location-coordinate')
-            .data(formatCoordinates(loc, osmId), (d: CoordinateFormat) => d.id);
-        rows.exit().remove();
+    function renderCopyableRows(selection: any, rows: CopyableRow[]) {
+        const items = selection.selectAll('li.location-coordinate')
+            .data(rows, (d: CopyableRow) => d.id);
+        items.exit().remove();
 
-        const rowsEnter = rows.enter()
+        const itemsEnter = items.enter()
             .append('li')
             .attr('class', 'location-coordinate');
-        rowsEnter.append('span').attr('class', 'location-coordinate-value');
-        rowsEnter.append('button')
+        itemsEnter.append('span').attr('class', 'location-coordinate-value');
+        itemsEnter.append('button')
             .attr('class', 'form-field-button location-coordinate-copy')
             .attr('title', t('icons.copy'))
             .call(svgIcon('#iD-operation-copy'))
-            .on('click', (d3_event: Event, d: CoordinateFormat) => {
+            .on('click', (d3_event: Event, d: CopyableRow) => {
                 d3_event.preventDefault();
                 navigator.clipboard?.writeText(d.value);
             });
 
-        rowsEnter.merge(rows)
+        itemsEnter.merge(items)
             .select('.location-coordinate-value')
-            .text((d: CoordinateFormat) => d.value);
+            .text((d: CopyableRow) => d.value);
     }
 
     section.entityIDs = function(val: string[]) {

--- a/test/spec/ui/sections/location_links.js
+++ b/test/spec/ui/sections/location_links.js
@@ -1,0 +1,106 @@
+describe('iD.uiSectionLocationLinks', function () {
+    var context;
+
+    beforeEach(function () {
+        context = iD.coreContext().assetPath('../dist/').init();
+    });
+
+    afterEach(function () {
+        d3.selectAll('.ui-wrap').remove();
+    });
+
+    function render(entityIDs) {
+        var section = iD.uiSectionLocationLinks(context).entityIDs(entityIDs);
+        var element = d3.select('body')
+            .append('div')
+            .attr('class', 'ui-wrap')
+            .call(section.render);
+        return { section: section, element: element };
+    }
+
+    function copyableValues(element) {
+        return element.selectAll('.location-coordinate-value').nodes().map(function (n) { return n.textContent; });
+    }
+
+    it('does not display for more than one selected entity', function () {
+        var n1 = new iD.osmNode({ id: 'n1', loc: [1, 2] });
+        var n2 = new iD.osmNode({ id: 'n2', loc: [3, 4] });
+        context.history().merge([n1, n2]);
+        var element = render([n1.id, n2.id]).element;
+
+        expect(element.select('.section-location-links').classed('hide')).to.be.true;
+    });
+
+    it('shows a new node\'s lat/lon but not its id (no permanent id yet)', function () {
+        var node = new iD.osmNode({ loc: [11, 22] });
+        context.history().merge([node]);
+        var element = render([node.id]).element;
+
+        expect(copyableValues(element)).to.eql(['22,11', '[11,22]']);
+    });
+
+    it('shows a saved node\'s id (long/short) and coordinates including the combined id,lat,lon format', function () {
+        var node = new iD.osmNode({ id: 'n1234', loc: [11, 22] });
+        context.history().merge([node]);
+        var element = render([node.id]).element;
+
+        expect(copyableValues(element)).to.eql(['node/1234', 'n/1234', '22,11', '[11,22]', '1234,22,11']);
+    });
+
+    it('uses the centroid of a saved way (not a node) for its coordinates', function () {
+        var a = new iD.osmNode({ id: 'n-a', loc: [0, 0] });
+        var b = new iD.osmNode({ id: 'n-b', loc: [10, 0] });
+        var c = new iD.osmNode({ id: 'n-c', loc: [10, 10] });
+        var d = new iD.osmNode({ id: 'n-d', loc: [0, 10] });
+        var w = new iD.osmWay({ id: 'w5678', nodes: ['n-a', 'n-b', 'n-c', 'n-d', 'n-a'], tags: { area: 'yes' } });
+        context.history().merge([a, b, c, d, w]);
+        var element = render([w.id]).element;
+
+        var values = copyableValues(element);
+        expect(values[0]).to.eql('way/5678');
+        expect(values[1]).to.eql('w/5678');
+        // centroid of the 10x10 square is its center (5,5); allow a small
+        // tolerance since the projection/inversion round-trip isn't exact
+        var latlon = values[2].split(',').map(Number);
+        expect(latlon[0]).to.be.closeTo(5, 0.1);
+        expect(latlon[1]).to.be.closeTo(5, 0.1);
+    });
+
+    it('pulls the centroid of a multipolygon relation away from a hole (not just the bbox center)', function () {
+        // outer: 20x10 rectangle (0,0)-(20,0)-(20,10)-(0,10); bbox/naive center is (10,5)
+        var oa = new iD.osmNode({ id: 'n-oa', loc: [0, 0] });
+        var ob = new iD.osmNode({ id: 'n-ob', loc: [20, 0] });
+        var oc = new iD.osmNode({ id: 'n-oc', loc: [20, 10] });
+        var od = new iD.osmNode({ id: 'n-od', loc: [0, 10] });
+        var outer = new iD.osmWay({ id: 'w-outer', nodes: ['n-oa', 'n-ob', 'n-oc', 'n-od', 'n-oa'] });
+
+        // inner hole: small 2x2 square in the corner (0,0)-(2,0)-(2,2)-(0,2)
+        var ia = new iD.osmNode({ id: 'n-ia', loc: [0, 0] });
+        var ib = new iD.osmNode({ id: 'n-ib', loc: [2, 0] });
+        var ic = new iD.osmNode({ id: 'n-ic', loc: [2, 2] });
+        var id_ = new iD.osmNode({ id: 'n-id', loc: [0, 2] });
+        var inner = new iD.osmWay({ id: 'w-inner', nodes: ['n-ia', 'n-ib', 'n-ic', 'n-id', 'n-ia'] });
+
+        var r = new iD.osmRelation({
+            id: 'r42',
+            tags: { type: 'multipolygon' },
+            members: [
+                { id: outer.id, type: 'way', role: 'outer' },
+                { id: inner.id, type: 'way', role: 'inner' }
+            ]
+        });
+        context.history().merge([oa, ob, oc, od, outer, ia, ib, ic, id_, inner, r]);
+        var element = render([r.id]).element;
+
+        var values = copyableValues(element);
+        expect(values[0]).to.eql('relation/42');
+        expect(values[1]).to.eql('r/42');
+
+        var latlon = values[2].split(',').map(Number);
+        var lat = latlon[0], lon = latlon[1];
+        // the hole is in the (0,0)-(2,2) corner, so the true area centroid is
+        // pulled away from it on both axes, unlike the naive bbox center (10,5)
+        expect(lat).to.be.above(5);
+        expect(lon).to.be.above(10);
+    });
+});


### PR DESCRIPTION
## Summary
- Extend the "Location & imagery" sidebar section to any entity type (not just nodes): street-level imagery links and copyable coordinates now use the entity's centroid for ways/relations, computed the same way as the measurement panel (`d3.geoPath(projection).centroid`), so multipolygon holes are handled correctly, with a fallback to the extent center if degenerate.
- Add copyable long (`way/1234`) and short (`w/1234`) OSM id rows in the same section, shown only for saved entities (new elements have no permanent id yet, but their centroid/coordinates still show).

## Test plan
- [x] `npx vitest run test/spec/ui/sections/location_links.js` (new tests: node with/without id, way centroid, multipolygon-with-hole centroid pulled away from the hole)
- [x] `npx vitest run test/spec/` (full suite, no regressions)