### PR TITLE
Fix: temporary default Bing offset for Greater Montreal

### DIFF
--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -18,6 +18,38 @@ import { patchHash } from '../behavior';
 
 let _imageryIndex = null;
 
+// TEMPORARY (v6 fork, 2020 Bing aerial vintage): Bing's imagery is
+// noticeably misaligned in the Greater Montreal area, so nudge it back into
+// place by default when editing there. Remove once Bing refreshes its
+// Montreal-area orthophotos.
+export const BING_MONTREAL_DEFAULT_OFFSET_METERS = [0.6, -1.54];
+const GREATER_MONTREAL_EXTENT = new geoExtent([-74.3, 45.2], [-73.0, 45.9]);
+
+/**
+ * Whether `loc` falls within the Greater Montreal area affected by the
+ * temporary Bing default offset (see {@link BING_MONTREAL_DEFAULT_OFFSET_METERS}).
+ * @param {[number, number]} loc `[lon, lat]`
+ * @returns {boolean}
+ */
+export function isGreaterMontreal(loc) {
+  return GREATER_MONTREAL_EXTENT.contains(loc);
+}
+
+/**
+ * Nudge a freshly-selected Bing source to {@link BING_MONTREAL_DEFAULT_OFFSET_METERS}
+ * when editing in the Greater Montreal area, unless it already has a
+ * (presumably manually-set) non-zero offset.
+ * @param {ReturnType<typeof rendererBackgroundSource>} source
+ * @param {[number, number]} mapCenter `[lon, lat]`
+ */
+export function applyBingMontrealDefaultOffset(source, mapCenter) {
+  if (!source || source.id !== 'Bing') return;
+  const [x, y] = source.offset();
+  if (x !== 0 || y !== 0) return;  // already nudged/offset - don't override
+  if (!isGreaterMontreal(mapCenter)) return;
+  source.offset(geoMetersToOffset(BING_MONTREAL_DEFAULT_OFFSET_METERS));
+}
+
 export function rendererBackground(context) {
   const dispatch = d3_dispatch('change');
   const baseLayer = rendererTileLayer(context).projection(context.projection);
@@ -325,6 +357,7 @@ export function rendererBackground(context) {
     }
 
     baseLayer.source(!fail ? d : background.findSource('none'));
+    applyBingMontrealDefaultOffset(baseLayer.source(), context.map().center());
     dispatch.call('change');
     background.updateImagery();
     return background;

--- a/modules/renderer/index.js
+++ b/modules/renderer/index.js
@@ -1,5 +1,10 @@
 export { rendererBackgroundSource } from './background_source';
-export { rendererBackground } from './background';
+export {
+  rendererBackground,
+  applyBingMontrealDefaultOffset,
+  isGreaterMontreal,
+  BING_MONTREAL_DEFAULT_OFFSET_METERS
+} from './background';
 export { rendererFeatures } from './features';
 export { rendererMap } from './map';
 export { rendererPhotos } from './photos';

--- a/test/spec/renderer/background.js
+++ b/test/spec/renderer/background.js
@@ -1,0 +1,54 @@
+describe('iD.rendererBackground - Montreal Bing default offset', function () {
+
+    // Montreal, QC - inside the Greater Montreal area
+    const MONTREAL_LOC = [-73.6, 45.5];
+    // Quebec City, QC - outside it (the fix is Montreal-only)
+    const QUEBEC_CITY_LOC = [-71.2, 46.8];
+
+    describe('#isGreaterMontreal', function () {
+        it('is true for Montreal', function () {
+            expect(iD.isGreaterMontreal(MONTREAL_LOC)).to.be.true;
+        });
+
+        it('is false for Quebec City', function () {
+            expect(iD.isGreaterMontreal(QUEBEC_CITY_LOC)).to.be.false;
+        });
+    });
+
+    describe('#applyBingMontrealDefaultOffset', function () {
+        function bingSource() {
+            return iD.rendererBackgroundSource({ id: 'Bing' });
+        }
+
+        it('applies the default offset to Bing in the Greater Montreal area', function () {
+            const source = bingSource();
+            iD.applyBingMontrealDefaultOffset(source, MONTREAL_LOC);
+
+            const [x, y] = iD.geoOffsetToMeters(source.offset());
+            expect(x).to.be.closeTo(iD.BING_MONTREAL_DEFAULT_OFFSET_METERS[0], 0.01);
+            expect(y).to.be.closeTo(iD.BING_MONTREAL_DEFAULT_OFFSET_METERS[1], 0.01);
+        });
+
+        it('does not apply the default offset outside the Greater Montreal area', function () {
+            const source = bingSource();
+            iD.applyBingMontrealDefaultOffset(source, QUEBEC_CITY_LOC);
+
+            expect(source.offset()).to.eql([0, 0]);
+        });
+
+        it('does not apply the default offset to a non-Bing source', function () {
+            const source = iD.rendererBackgroundSource({ id: 'none' });
+            iD.applyBingMontrealDefaultOffset(source, MONTREAL_LOC);
+
+            expect(source.offset()).to.eql([0, 0]);
+        });
+
+        it('does not override an already-nudged Bing offset', function () {
+            const source = bingSource();
+            source.offset([5, 5]);
+            iD.applyBingMontrealDefaultOffset(source, MONTREAL_LOC);
+
+            expect(source.offset()).to.eql([5, 5]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Bing's 2020 aerial imagery is visibly misaligned in the Greater Montreal area.
- When Bing is selected while editing there, apply a default offset of `0.6, -1.54` m, unless the source already has a non-zero (manually-set) offset.
- Marked as temporary in code comments: this is a region/vintage-specific workaround, to be removed once Bing refreshes its Montreal-area orthophotos.

## Test plan
- [x] `npx vitest run test/spec/renderer/background.js` (new tests: applies in Montreal, not outside it, not for non-Bing sources, doesn't override an existing manual offset)
- [x] `npx vitest run test/spec/` (full suite, no regressions)