### PR TITLE
Feat: always show building levels fields, regardless of other tags

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -590,9 +590,10 @@ function setCarHighwayDefaultSurface(presetManager) {
 }
 
 const FLATS_FIELD = 'flats';
+const LEVELS_FIELD = 'building/levels';
 const UNDERGROUND_LEVELS_FIELD = 'building/levels/underground';
 const ROOF_LEVELS_FIELD = 'roof/levels';
-const VISIBLE_BUILDING_LEVEL_FIELDS = [UNDERGROUND_LEVELS_FIELD, ROOF_LEVELS_FIELD];
+const VISIBLE_BUILDING_LEVEL_FIELDS = [LEVELS_FIELD, UNDERGROUND_LEVELS_FIELD, ROOF_LEVELS_FIELD];
 
 /**
  * True when `preset` is a landuse preset (including subtypes under `landuse/`).
@@ -663,9 +664,10 @@ function inheritsBuildingDefaults(preset) {
 }
 
 /**
- * Move underground/roof level fields into default fields (after `building/levels`
- * when present, else after `height` or `building`, else at the end). Removes them
- * from moreFields so they are always visible, not hidden behind "+ add field".
+ * Move the levels/underground/roof level fields into default fields (after
+ * `building` when present, else after `height`, else at the end). Removes
+ * them from moreFields so they are always visible, not hidden behind
+ * "+ add field", regardless of the building's other tags.
  *
  * @param {string[]} fields
  * @param {string[]} moreFields
@@ -676,7 +678,7 @@ function promoteBuildingLevelFields(fields, moreFields) {
         removeField(moreFields, id);
     });
 
-    const anchors = ['building/levels', 'height', 'building'];
+    const anchors = ['building', 'height'];
     let anchorIndex = -1;
     for (const anchor of anchors) {
         anchorIndex = fields.indexOf(anchor);
@@ -694,9 +696,11 @@ function promoteBuildingLevelFields(fields, moreFields) {
 }
 
 /**
- * Show `building:levels:underground` and `roof:levels` on building presets.
- * Upstream keeps underground levels in moreFields; roof levels is a custom field.
- * Presets that inherit default fields from `{building}` pick up the base preset.
+ * Show `building:levels`, `building:levels:underground` and `roof:levels` on
+ * every building preset, regardless of its other tags. Upstream sometimes
+ * hides these behind "+ add field" (or omits `building:levels` entirely on
+ * presets like hangar/garages/roof); roof levels is a custom field. Presets
+ * that inherit default fields from `{building}` pick up the base preset.
  *
  * @param {Object} presetManager - the preset system (`presetManager`)
  */

--- a/test/spec/presets/custom/building_levels.js
+++ b/test/spec/presets/custom/building_levels.js
@@ -108,29 +108,40 @@ describe('building level fields (custom_fields)', function() {
         await iD.presetManager.ensureLoaded(true);
     });
 
+    const LEVEL_FIELDS = ['building/levels', 'building/levels/underground', 'roof/levels'];
+
     const expectLevelFieldsAfter = (id, anchor) => {
-        it(`${id} shows underground and roof levels after ${anchor}`, function() {
+        it(`${id} shows levels, underground and roof levels after ${anchor}`, function() {
             const preset = iD.presetManager.item(id);
             expect(preset, id).to.exist;
             const fields = preset.originalFields;
             const anchorIndex = fields.indexOf(anchor);
             expect(anchorIndex, `${id} fields`).to.be.at.least(0);
-            expect(fields[anchorIndex + 1]).to.equal('building/levels/underground');
-            expect(fields[anchorIndex + 2]).to.equal('roof/levels');
-            expect(preset.originalMoreFields.indexOf('building/levels/underground')).to.equal(-1);
-            expect(preset.originalMoreFields.indexOf('roof/levels')).to.equal(-1);
+            expect(fields[anchorIndex + 1]).to.equal('building/levels');
+            expect(fields[anchorIndex + 2]).to.equal('building/levels/underground');
+            expect(fields[anchorIndex + 3]).to.equal('roof/levels');
+            LEVEL_FIELDS.forEach(fieldID => {
+                expect(preset.originalMoreFields.indexOf(fieldID), `${id} moreFields ${fieldID}`).to.equal(-1);
+            });
         });
     };
 
-    expectLevelFieldsAfter('building', 'building/levels');
-    expectLevelFieldsAfter('building/roof', 'height');
-    expectLevelFieldsAfter('building/garages', 'capacity');
+    expectLevelFieldsAfter('building', 'building');
+    expectLevelFieldsAfter('building/roof', 'building');
+
+    it('building/garages appends level fields to default fields (no building/height anchor there)', function() {
+        const preset = iD.presetManager.item('building/garages');
+        const fields = preset.originalFields;
+        expect(fields).to.eql(['capacity', 'building/levels', 'building/levels/underground', 'roof/levels']);
+        LEVEL_FIELDS.forEach(fieldID => {
+            expect(preset.originalMoreFields.indexOf(fieldID)).to.equal(-1);
+        });
+    });
 
     it('building/hangar appends level fields to default fields', function() {
         const preset = iD.presetManager.item('building/hangar');
         const fields = preset.originalFields;
-        expect(fields[fields.length - 2]).to.equal('building/levels/underground');
-        expect(fields[fields.length - 1]).to.equal('roof/levels');
+        expect(fields).to.eql(['name', 'building/levels', 'building/levels/underground', 'roof/levels']);
     });
 
     const inheritsFromBuilding = [
@@ -141,10 +152,12 @@ describe('building level fields (custom_fields)', function() {
     inheritsFromBuilding.forEach(function(id) {
         it(`${id} inherits level fields from {building}`, function() {
             const preset = iD.presetManager.item(id);
-            expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
-            expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+            LEVEL_FIELDS.forEach(fieldID => {
+                expect(preset.originalFields.indexOf(fieldID)).to.equal(-1);
+            });
             const resolved = preset.fields();
             const keys = resolved.map(f => f.key);
+            expect(keys.indexOf('building:levels')).to.be.at.least(0);
             expect(keys.indexOf('building:levels:underground')).to.be.at.least(0);
             expect(keys.indexOf('roof:levels')).to.be.at.least(0);
         });
@@ -152,13 +165,15 @@ describe('building level fields (custom_fields)', function() {
 
     it('does not add level fields to non-building presets', function() {
         const preset = iD.presetManager.item('highway/residential');
-        expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
-        expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+        LEVEL_FIELDS.forEach(fieldID => {
+            expect(preset.originalFields.indexOf(fieldID)).to.equal(-1);
+        });
     });
 
     it('skips building presets that only inherit fields from a parent', function() {
         const preset = iD.presetManager.item('building/garage');
-        expect(preset.originalFields.indexOf('building/levels/underground')).to.equal(-1);
-        expect(preset.originalFields.indexOf('roof/levels')).to.equal(-1);
+        LEVEL_FIELDS.forEach(fieldID => {
+            expect(preset.originalFields.indexOf(fieldID)).to.equal(-1);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- `building:levels` was sometimes hidden behind "+ add field" (or missing entirely) on presets like hangar, garages, roof, construction, etc.
- Extend the existing underground/roof level field promotion (`customizeBuildingLevels`) to also force `building:levels` into the default fields on every building preset, regardless of its other tags.
- The three fields now always render together in a consistent order: levels, underground levels, roof levels.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/building_levels.js` (updated/new cases for building, roof, garages, hangar, and inheriting presets)
- [x] `npx vitest run test/spec/` (full suite, no regressions)