### PR TITLE
Fix: restore maxspeed as a default field on motorway_link (US/CA)

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -386,6 +386,17 @@ export function applyCustomFields(presetManager) {
         removeField(moreFields, 'maxspeed/advisory');
         removeField(fields, 'maxspeed_advisory');
         removeField(moreFields, 'maxspeed_advisory');
+
+        // some US/CA `_link` presets (e.g. motorway_link) hide legal `maxspeed`
+        // in moreFields, showing only advisory by default; promote it back so
+        // both are visible together, like the base (non-US/CA) presets.
+        if (fields.indexOf('maxspeed') === -1 && moreFields.indexOf('maxspeed') !== -1) {
+            removeField(moreFields, 'maxspeed');
+            const onewayIndex = fields.indexOf('oneway');
+            const insertAt = onewayIndex === -1 ? fields.indexOf('structure') : onewayIndex + 1;
+            fields.splice(insertAt < 0 ? fields.length : insertAt, 0, 'maxspeed');
+        }
+
         const maxspeedIndex = fields.indexOf('maxspeed');
         if (maxspeedIndex === -1) moreFields.push('maxspeed_advisory');
         else fields.splice(maxspeedIndex + 1, 0, 'maxspeed_advisory');

--- a/test/spec/presets/custom/motorway_link.js
+++ b/test/spec/presets/custom/motorway_link.js
@@ -1,4 +1,4 @@
-import { loadCustomPresets } from './setup.js';
+import { loadCustomDistJson, loadCustomPresets } from './setup.js';
 
 const ID = 'highway/motorway_link/placement_transition_oneway_1_100';
 
@@ -26,5 +26,43 @@ describe('custom presets — motorway link transition', function() {
         const pool = iD.presetManager.matchAllGeometry(['line']);
         const ids = pool.search('mlt1', 'line').collection.map((p) => p.id);
         expect(ids).to.include(ID);
+    });
+});
+
+// Regression: the US/CA regional variant of `highway/motorway_link` lists
+// `maxspeed/advisory` in `fields` but legal `maxspeed` only in `moreFields`
+// (upstream shows advisory-only by default on ramps there). Our advisory-speed
+// field injection anchors on `maxspeed` being a default field, so it silently
+// dropped both to moreFields. See modules/presets/custom_fields.js.
+describe('custom fields — motorway_link maxspeed defaults (US/CA regional shape)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = {
+            'highway/motorway_link': {
+                icon: 'fas-road',
+                fields: ['name', 'oneway', 'maxspeed/advisory', 'lanes', 'surface', 'structure', 'access'],
+                moreFields: ['maxspeed', 'sidewalk'],
+                geometry: ['line'],
+                tags: { highway: 'motorway_link' },
+                name: 'Motorway Link'
+            }
+        };
+        iD.fileFetcher.cache().preset_fields = {};
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    it('shows both maxspeed and maxspeed_advisory as default fields, maxspeed_advisory right after maxspeed', function() {
+        const preset = iD.presetManager.item('highway/motorway_link');
+        expect(preset).to.exist;
+
+        const fields = preset.originalFields;
+        const maxspeedIndex = fields.indexOf('maxspeed');
+        expect(maxspeedIndex, 'maxspeed in fields').to.be.at.least(0);
+        expect(fields[maxspeedIndex + 1]).to.equal('maxspeed_advisory');
+
+        expect(preset.originalMoreFields.indexOf('maxspeed')).to.equal(-1);
+        expect(preset.originalMoreFields.indexOf('maxspeed_advisory')).to.equal(-1);
     });
 });


### PR DESCRIPTION
## Summary
- Root cause: the US/CA regional variant of `highway/motorway_link` lists `maxspeed/advisory` in `fields` but legal `maxspeed` only in `moreFields`. Our advisory-speed field injection anchors on `maxspeed` being a default field; when it isn't, it silently pushed `maxspeed_advisory` to `moreFields` too, so both ended up hidden behind "+ add field".
- Fix: promote `maxspeed` back into default fields (right after `oneway`, else before `structure`) when this happens, before positioning `maxspeed_advisory` right after it.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/motorway_link.js` (new test reproduces the US/CA regional shape; confirmed it fails without the fix)
- [x] `npx vitest run test/spec/` (full suite, no regressions)