### PR TITLE
Fix: default public gate preset shortcut to node, not line

### DIFF
--- a/data/custom-tagging/src/presets/barrier/access_barriers.ts
+++ b/data/custom-tagging/src/presets/barrier/access_barriers.ts
@@ -2,7 +2,7 @@ import type { CustomPreset, PresetGeometry } from '../../types';
 import { ANY, buildRemoveTags } from '../../lib/tag_helpers';
 import { presetNameEn } from '../../preset_name_en';
 import { blockMotorVehicleNo } from './block_motor_vehicle_no';
-import { gateFootBicycleYes } from './gate_foot_bicycle_yes';
+import { gateFootBicycleYes, gateFootBicycleYesLine } from './gate_foot_bicycle_yes';
 
 type AccessKind = 'customers' | 'private';
 
@@ -53,5 +53,6 @@ function accessBarrierPresetsForVariant(variant: AccessBarrierVariant): [string,
 export const accessBarrierPresets: Record<string, CustomPreset> = {
     ...Object.fromEntries(ACCESS_BARRIERS.flatMap(accessBarrierPresetsForVariant)),
     'barrier/gate_foot_bicycle_yes': gateFootBicycleYes,
+    'barrier/gate_foot_bicycle_yes_line': gateFootBicycleYesLine,
     'barrier/block_motor_vehicle_no': blockMotorVehicleNo
 };

--- a/data/custom-tagging/src/presets/barrier/gate_foot_bicycle_yes.ts
+++ b/data/custom-tagging/src/presets/barrier/gate_foot_bicycle_yes.ts
@@ -1,4 +1,4 @@
-import type { CustomPreset } from '../../types';
+import type { CustomPreset, PresetGeometry } from '../../types';
 import { buildRemoveTags } from '../../lib/tag_helpers';
 import { presetNameEn } from '../../preset_name_en';
 
@@ -9,15 +9,25 @@ const GATE_FOOT_BICYCLE_TAGS = {
     motor_vehicle: 'no'
 } as const;
 
-/** v5 `barrier/gate_foot_bicycle_yes` (public foot and bicycle, no motor vehicles). */
-export const gateFootBicycleYes: CustomPreset = {
-    icon: 'temaki-gate',
-    geometry: ['vertex', 'line'],
-    fields: ['access', 'wheelchair', 'opening_hours', 'height', 'material'],
-    moreFields: ['colour', 'manufacturer', 'operator', 'ref'],
-    tags: { ...GATE_FOOT_BICYCLE_TAGS },
-    addTags: { ...GATE_FOOT_BICYCLE_TAGS },
-    removeTags: buildRemoveTags({ ...GATE_FOOT_BICYCLE_TAGS }),
-    matchScore: 2,
-    name: presetNameEn('barrier/gate_foot_bicycle_yes')
-};
+/**
+ * v5 `barrier/gate_foot_bicycle_yes` (public foot and bicycle, no motor
+ * vehicles). Built once per geometry, like the private/customers gates
+ * (`access_barriers.ts`), so the vertex variant - not `['vertex', 'line']` -
+ * is what a preset shortcut defaults to drawing (see `presetShortcutDrawingGeometry`).
+ */
+function gateFootBicycleYesPreset(presetId: string, geometry: PresetGeometry[]): CustomPreset {
+    return {
+        icon: 'temaki-gate',
+        geometry,
+        fields: ['access', 'wheelchair', 'opening_hours', 'height', 'material'],
+        moreFields: ['colour', 'manufacturer', 'operator', 'ref'],
+        tags: { ...GATE_FOOT_BICYCLE_TAGS },
+        addTags: { ...GATE_FOOT_BICYCLE_TAGS },
+        removeTags: buildRemoveTags({ ...GATE_FOOT_BICYCLE_TAGS }),
+        matchScore: 2,
+        name: presetNameEn(presetId)
+    };
+}
+
+export const gateFootBicycleYes: CustomPreset = gateFootBicycleYesPreset('barrier/gate_foot_bicycle_yes', ['vertex']);
+export const gateFootBicycleYesLine: CustomPreset = gateFootBicycleYesPreset('barrier/gate_foot_bicycle_yes_line', ['line']);

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -73,6 +73,10 @@
         "terms": "pugfb, pubg, gate, foot, bicycle, pedestrian, cycling, no motor vehicles",
         "aliases": "pugfb"
     },
+    "barrier/gate_foot_bicycle_yes_line": {
+        "name": "Public gate (foot and bicycle, no motor vehicles) (line)",
+        "terms": "public gate foot bicycle barrier line"
+    },
     "barrier/private_gate": {
         "name": "Private gate",
         "terms": "pg, gate, private",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -73,6 +73,10 @@
         "terms": "pugfb, bppv, barrière, piéton, vélo, cyclisme, pas de véhicules motorisés",
         "aliases": "pugfb"
     },
+    "barrier/gate_foot_bicycle_yes_line": {
+        "name": "Barrière Publique (piétons et vélos, pas de véhicules motorisés) (ligne)",
+        "terms": "barrière publique piéton vélo ligne"
+    },
     "barrier/private_gate": {
         "name": "Barrière Privée",
         "terms": "pg, bp, barrière, privée",

--- a/test/spec/presets/custom/barrier.js
+++ b/test/spec/presets/custom/barrier.js
@@ -39,6 +39,13 @@ describe('custom presets — barrier', function() {
             bicycle: 'yes',
             motor_vehicle: 'no'
         });
+        expect(publicGate.geometry).to.eql(['vertex']);
+        expect(presetShortcutDrawingGeometry(publicGate)).to.equal('point');
+
+        const publicGateLine = iD.presetManager.item('barrier/gate_foot_bicycle_yes_line');
+        expect(publicGateLine, 'public foot/bicycle gate line').to.exist;
+        expect(publicGateLine.geometry).to.eql(['line']);
+        expect(presetShortcutDrawingGeometry(publicGateLine)).to.equal('line');
 
         const customersLiftgate = iD.presetManager.item('barrier/customers_liftgate');
         expect(customersLiftgate, 'customers lift gate').to.exist;


### PR DESCRIPTION
## Summary
- `barrier/gate_foot_bicycle_yes` (public gate) had `geometry: ['vertex', 'line']`; `presetShortcutDrawingGeometry()` prefers `'line'` whenever it's present, so its shortcut started drawing a way instead of a node.
- Split it the same way private/customers gates already are: base preset is now vertex-only, and a new sibling `barrier/gate_foot_bicycle_yes_line` (`geometry: ['line']`) handles the way case with the same tags.
- All three gate shortcuts (private/customers/public) now default to node.

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/` (284 tests pass)
- [x] `npx vitest run test/spec/core/preset_shortcut_format.js`
- [x] `npx tsc --noEmit` (no new errors)