### PR TITLE
Presets: add disused service road (disused:highway=service)

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -427,18 +427,19 @@ path.line.casing.tag-highway-track.tag-tunnel.tag-tracktype-grade3 { stroke-dash
 path.line.casing.tag-highway-track.tag-tunnel.tag-tracktype-grade4 { stroke-dasharray: 6, 6; }
 path.line.casing.tag-highway-track.tag-tunnel.tag-tracktype-grade5 { stroke-dasharray: 4, 8; }
 
-/* Status (e.g. proposed, abandoned) */
-path.area.stroke.tag-status:not(.tag-status-disused),
-path.line.stroke.tag-status:not(.tag-status-disused),
-path.area.casing.tag-status:not(.tag-status-disused),
-path.line.casing.tag-status:not(.tag-status-disused) {
+/* Status (e.g. proposed, abandoned, disused) - v5 parity: disused features
+   are dashed like any other status, unlike upstream which excludes them. */
+path.area.stroke.tag-status,
+path.line.stroke.tag-status,
+path.area.casing.tag-status,
+path.line.casing.tag-status {
     stroke-linecap: butt;
     stroke-dasharray: 7, 3;
 }
-.low-zoom path.area.stroke.tag-status:not(.tag-status-disused),
-.low-zoom path.line.stroke.tag-status:not(.tag-status-disused),
-.low-zoom path.area.casing.tag-status:not(.tag-status-disused),
-.low-zoom path.line.casing.tag-status:not(.tag-status-disused) {
+.low-zoom path.area.stroke.tag-status,
+.low-zoom path.line.stroke.tag-status,
+.low-zoom path.area.casing.tag-status,
+.low-zoom path.line.casing.tag-status {
     stroke-dasharray: 5, 2;
 }
 

--- a/data/custom-tagging/src/presets/highway/service_disused.ts
+++ b/data/custom-tagging/src/presets/highway/service_disused.ts
@@ -1,0 +1,21 @@
+import type { CustomPreset } from '../../types';
+import { presetNameEn } from '../../preset_name_en';
+
+// Disused service road (v5 parity: `disused:highway=service`). Picking this
+// preset always starts from a blank tag set - see RESET_TAGS_PRESET_IDS in
+// modules/actions/change_preset.js - since a disused road shouldn't keep
+// leftover surface/lit/lanes/name tags from whatever it used to be.
+const ID = 'highway/service/disused';
+
+export const serviceDisusedPreset: CustomPreset = {
+    icon: 'iD-highway-service',
+    geometry: ['line'],
+    tags: { 'disused:highway': 'service' },
+    matchScore: 2,
+    reference: { key: 'disused:highway', value: 'service' },
+    name: presetNameEn(ID)
+};
+
+export const serviceDisusedPresets: Record<string, CustomPreset> = {
+    [ID]: serviceDisusedPreset
+};

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -14,6 +14,7 @@ import { sidewalkVariantPresets } from './presets/highway/footway/sidewalk_varia
 import { restrictedFootwayVariantPresets } from './presets/highway/footway/restricted_footway_variants';
 import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_variants';
 import { serviceVariantPresets } from './presets/highway/service_variants';
+import { serviceDisusedPresets } from './presets/highway/service_disused';
 import { motorwayLinkTransitionPresets } from './presets/highway/motorway_link_transition';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
@@ -68,6 +69,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...footwayCrossingVariantPresets,
     ...streetSidewalkVariantPresets,
     ...serviceVariantPresets,
+    ...serviceDisusedPresets,
     ...motorwayLinkTransitionPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -906,6 +906,11 @@
         "terms": "sdo, destination, service, road, sidewalk, sidepath, divided, dual carriageway, opposite, use_sidepath",
         "aliases": "sdo"
     },
+    "highway/service/disused": {
+        "name": "Disused service road",
+        "terms": "sdis, disused, service, road, abandoned",
+        "aliases": "sdis"
+    },
     "highway/track_private": {
         "name": "Private unmaintained track",
         "terms": "put, track, private, woods road, forest road, logging road, fire road, farm road, agricultural road, unmaintained, offroad, 4wd, 4x4",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -906,6 +906,11 @@
         "terms": "sdo, desserte locale, destination, voie de service, chaussées séparées, trottoir, sidepath, côté opposé, use_sidepath",
         "aliases": "sdo"
     },
+    "highway/service/disused": {
+        "name": "Voie de service désaffectée",
+        "terms": "sdis, désaffectée, voie de service, abandonnée",
+        "aliases": "sdis"
+    },
     "highway/track_private": {
         "name": "Chemin non entretenu privé",
         "terms": "put, chemin, piste, privé, chemin forestier, chemin de ferme, non entretenu, hors route, 4x4",

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -1,11 +1,22 @@
 import { utilArrayDifference, utilObjectOmit } from '../util';
 
+// Presets that always start from a blank tag set when picked, instead of
+// preserving leftover tags from whatever the entity used to be. Used for
+// "fresh start" presets (e.g. a disused road) where surviving subtags like
+// surface/lit/lanes/name from the old preset would be misleading.
+const RESET_TAGS_PRESET_IDS = new Set(['highway/service/disused']);
+
 export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefaults) {
     return function action(graph) {
         const entity = graph.entity(entityID);
         const geometry = entity.geometry(graph);
         let tags = entity.tags;
         const loc = entity.extent(graph).center();
+
+        if (newPreset && RESET_TAGS_PRESET_IDS.has(newPreset.id)) {
+            tags = newPreset.setTags({}, geometry, skipFieldDefaults, loc);
+            return graph.replace(entity.update({tags: tags}));
+        }
 
         // preserve tags that the new preset might care about, if any
         let preserveKeys;

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -331,4 +331,20 @@ describe('iD.actionChangePreset', function() {
         const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
         expect(action(graph).entity(entity.id).tags).to.eql({highway: 'service', name: 'foo bar'});
     });
+
+    // fork-specific: "fresh start" presets (e.g. disused service road) discard
+    // every leftover tag instead of preserving fields/tags from the old preset
+    it('discards all other tags when changing to a reset-tags preset', () => {
+        const entity = new iD.osmWay({
+            tags: {highway: 'service', service: 'driveway', surface: 'asphalt', name: 'foo bar'}
+        });
+        const graph = new iD.coreGraph([entity]);
+        const oldPreset = iD.presetPreset('highway/service/driveway', {
+            tags: {highway: 'service', service: 'driveway'},
+            fields: ['name']
+        }, undefined, {name: iD.presetField('name', {key: 'name'})});
+        const newPreset = iD.presetPreset('highway/service/disused', {tags: {'disused:highway': 'service'}});
+        const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
+        expect(action(graph).entity(entity.id).tags).to.eql({'disused:highway': 'service'});
+    });
 });

--- a/test/spec/presets/custom/service.js
+++ b/test/spec/presets/custom/service.js
@@ -115,4 +115,12 @@ describe('custom presets — service roads', function() {
         expect(preset.tags).to.eql({ highway: 'track', access: 'private' });
         expect(preset.addTags.surface).to.equal('unpaved');
     });
+
+    it('defines the disused service road preset', function() {
+        const preset = iD.presetManager.item('highway/service/disused');
+        expect(preset).to.exist;
+        expect(preset.name()).to.equal('Disused service road');
+        expect(preset.tags).to.eql({ 'disused:highway': 'service' });
+        expect(preset.geometry).to.eql(['line']);
+    });
 });


### PR DESCRIPTION
## Summary
- New preset `highway/service/disused` (`disused:highway=service`), v5 parity.
- Picking it always starts from a blank tag set: added an opt-in `RESET_TAGS_PRESET_IDS` list in `actionChangePreset` since `removeTags` can only drop specific known keys, not "everything".
- Restored v5's dashed rendering for disused-status features in `css/50_misc.css` (upstream excluded `disused` from the generic status dash rule in 2020; this fork's v5 branch never picked that change up).

## Test plan
- [x] `npm run build:presets:custom`
- [x] `npx vitest run test/spec/presets/custom/ test/spec/actions/` (813 tests pass)
- [x] `npx tsc --noEmit` / `npx eslint` on touched files (clean)