### PR TITLE
Presets: default emergency access road to access=no + emergency=designated

### DIFF
--- a/modules/presets/custom_fields.js
+++ b/modules/presets/custom_fields.js
@@ -281,6 +281,7 @@ export function applyCustomFields(presetManager) {
     customizeBusStopBench(presetManager);
     setCycleFootPathDefaultSurface(presetManager);
     setCarHighwayDefaultSurface(presetManager);
+    setEmergencyAccessDefaultTags(presetManager);
     markSmallFields(presetManager, SMALL_FIELDS);
     registerCustomStrings(localizer);
 
@@ -598,6 +599,21 @@ function setCarHighwayDefaultSurface(presetManager) {
         if (!preset) continue;
         preset.addTags = Object.assign({}, preset.addTags, { surface: 'asphalt' });
     }
+}
+
+/**
+ * Default the Emergency Access service road preset (upstream
+ * `highway/service/emergency_access`) to access=no + emergency=designated
+ * (v5 fork parity): only emergency vehicles are allowed through. Added to
+ * `addTags` so it's written when the preset is chosen, without affecting
+ * matching (which uses `tags`). Idempotent.
+ *
+ * @param {Object} presetManager - the preset system (`presetManager`)
+ */
+function setEmergencyAccessDefaultTags(presetManager) {
+    const preset = presetManager.item('highway/service/emergency_access');
+    if (!preset) return;
+    preset.addTags = Object.assign({}, preset.addTags, { access: 'no', emergency: 'designated' });
 }
 
 const FLATS_FIELD = 'flats';

--- a/test/spec/presets/custom/emergency_access.js
+++ b/test/spec/presets/custom/emergency_access.js
@@ -1,0 +1,32 @@
+import { loadCustomDistJson } from './setup.js';
+
+/** Minimal upstream Emergency Access preset for the addTags test below. */
+const UPSTREAM_EMERGENCY_ACCESS_PRESET = {
+    'highway/service/emergency_access': {
+        icon: 'iD-highway-service',
+        fields: ['name'],
+        geometry: ['line'],
+        tags: { highway: 'service', service: 'emergency_access' },
+        name: 'Emergency Access'
+    }
+};
+
+describe('custom emergency access default tags (v5 parity)', function() {
+    beforeAll(async function() {
+        const { customFields, customPresets } = await loadCustomDistJson();
+        iD.fileFetcher.cache().preset_presets = UPSTREAM_EMERGENCY_ACCESS_PRESET;
+        iD.fileFetcher.cache().preset_fields = {};
+        iD.fileFetcher.cache().preset_custom_fields = customFields;
+        iD.fileFetcher.cache().preset_custom_presets = customPresets;
+        await iD.presetManager.ensureLoaded(true);
+    });
+
+    it('addTags default access=no and emergency=designated', function() {
+        const preset = iD.presetManager.item('highway/service/emergency_access');
+        expect(preset).to.exist;
+        expect(preset.addTags.access).to.equal('no');
+        expect(preset.addTags.emergency).to.equal('designated');
+        // matching tags are untouched
+        expect(preset.tags).to.eql({ highway: 'service', service: 'emergency_access' });
+    });
+});


### PR DESCRIPTION
## Summary
- Upstream `highway/service/emergency_access` doesn't tag `access`/`emergency`, so a fresh way just had `highway=service` + `service=emergency_access` until manually filled in.
- Patches its `addTags` (same pattern as `setCarHighwayDefaultSurface`) to write `access=no` + `emergency=designated` when the preset is chosen; matching (`tags`) is untouched.

## Test plan
- [x] `npx vitest run test/spec/presets/custom/` (240 tests pass)
- [x] `npx eslint modules/presets/custom_fields.js test/spec/presets/custom/emergency_access.js` (clean)