### PR TITLE
Presets: add motorway lane-change/transition and motorway_link advisory-speed presets

### DIFF
--- a/data/custom-tagging/src/presets/highway/motorway_lane_change.ts
+++ b/data/custom-tagging/src/presets/highway/motorway_lane_change.ts
@@ -1,0 +1,37 @@
+import type { CustomPreset } from '../../types';
+import { buildRemoveTags } from '../../lib/tag_helpers';
+import { presetNameEn } from '../../preset_name_en';
+
+// Motorway lane drop: 3 lanes, way drawn offset left of the 2 through lanes
+// (`placement=left_of:2`), where the leftmost lane may change either way, the
+// middle lane may not merge right, and the rightmost (dropped) lane may not
+// change at all (`change:lanes=yes|not_right|no`).
+const ID = 'highway/motorway/left_of_2_lanes_3_change_yes_not_right_no';
+
+const MOTORWAY_FIELDS = ['{highway/motorway}'] as const;
+const REFERENCE = { key: 'highway', value: 'motorway' } as const;
+
+const TAGS = {
+    highway: 'motorway',
+    lanes: '3',
+    oneway: 'yes',
+    placement: 'left_of:2',
+    'change:lanes': 'yes|not_right|no'
+} as const;
+
+const motorwayLaneChangePreset: CustomPreset = {
+    icon: 'iD-highway-motorway',
+    geometry: ['line'],
+    fields: [...MOTORWAY_FIELDS],
+    moreFields: [...MOTORWAY_FIELDS],
+    tags: { ...TAGS },
+    addTags: { ...TAGS },
+    removeTags: buildRemoveTags({ ...TAGS }),
+    matchScore: 2,
+    reference: REFERENCE,
+    name: presetNameEn(ID)
+};
+
+export const motorwayLaneChangePresets: Record<string, CustomPreset> = {
+    [ID]: motorwayLaneChangePreset
+};

--- a/data/custom-tagging/src/presets/highway/motorway_lane_transition.ts
+++ b/data/custom-tagging/src/presets/highway/motorway_lane_transition.ts
@@ -1,0 +1,69 @@
+import type { CustomPreset } from '../../types';
+import { buildRemoveTags } from '../../lib/tag_helpers';
+import { presetNameEn } from '../../preset_name_en';
+
+// Motorway lane-count transition: a lane appears or disappears on the right,
+// tapering to/from 0 width. A gain tapers in from `width:lanes:start` (the
+// lane grows across the way); a loss tapers out via `width:lanes:end` (the
+// lane shrinks away). `lanes` is always the higher of the two counts, since
+// that's the number of lane stripes present along the way.
+const MOTORWAY_FIELDS = ['{highway/motorway}'] as const;
+const REFERENCE = { key: 'highway', value: 'motorway' } as const;
+
+interface TransitionVariant {
+    fromLanes: number;
+    toLanes: number;
+}
+
+const GAIN_VARIANTS: TransitionVariant[] = [
+    { fromLanes: 2, toLanes: 3 },
+    { fromLanes: 3, toLanes: 4 }
+];
+
+const LOSS_VARIANTS: TransitionVariant[] = [
+    { fromLanes: 3, toLanes: 2 },
+    { fromLanes: 4, toLanes: 3 }
+];
+
+function transitionId(v: TransitionVariant): string {
+    return `highway/motorway/placement_transition_lanes_${v.fromLanes}_to_${v.toLanes}`;
+}
+
+/** `lanes` tag value: the higher lane count, i.e. how many stripes exist along the way. */
+function laneCount(v: TransitionVariant): number {
+    return Math.max(v.fromLanes, v.toLanes);
+}
+
+/** One taper slot per unaffected lane, then the affected lane tapering to/from width 0. */
+function widthLanesValue(v: TransitionVariant): string {
+    return '|'.repeat(laneCount(v) - 1) + '0';
+}
+
+function transitionPreset(v: TransitionVariant, widthKey: 'width:lanes:start' | 'width:lanes:end'): CustomPreset {
+    const id = transitionId(v);
+    const tags: Record<string, string> = {
+        highway: 'motorway',
+        lanes: String(laneCount(v)),
+        oneway: 'yes',
+        placement: 'transition',
+        [widthKey]: widthLanesValue(v)
+    };
+
+    return {
+        icon: 'iD-highway-motorway',
+        geometry: ['line'],
+        fields: [...MOTORWAY_FIELDS],
+        moreFields: [...MOTORWAY_FIELDS],
+        tags,
+        addTags: { ...tags },
+        removeTags: buildRemoveTags(tags),
+        matchScore: 2,
+        reference: REFERENCE,
+        name: presetNameEn(id)
+    };
+}
+
+export const motorwayLaneTransitionPresets: Record<string, CustomPreset> = {
+    ...Object.fromEntries(GAIN_VARIANTS.map((v) => [transitionId(v), transitionPreset(v, 'width:lanes:start')] as const)),
+    ...Object.fromEntries(LOSS_VARIANTS.map((v) => [transitionId(v), transitionPreset(v, 'width:lanes:end')] as const))
+};

--- a/data/custom-tagging/src/presets/highway/motorway_link_advisory.ts
+++ b/data/custom-tagging/src/presets/highway/motorway_link_advisory.ts
@@ -1,0 +1,42 @@
+import type { CustomPreset } from '../../types';
+import { buildRemoveTags } from '../../lib/tag_helpers';
+import { presetNameEn } from '../../preset_name_en';
+
+// motorway_link ramp with a curve advisory speed lower than the legal
+// maxspeed=100 through the ramp. One preset per advisory speed.
+const MOTORWAY_LINK_FIELDS = ['{highway/motorway}'] as const;
+const REFERENCE = { key: 'highway', value: 'motorway_link' } as const;
+
+const ADVISORY_SPEEDS = [25, 35, 45, 55, 65, 75];
+
+function advisoryId(speed: number): string {
+    return `highway/motorway_link/oneway_1_100_advisory_${speed}`;
+}
+
+function advisoryPreset(speed: number): CustomPreset {
+    const id = advisoryId(speed);
+    const tags: Record<string, string> = {
+        highway: 'motorway_link',
+        lanes: '1',
+        oneway: 'yes',
+        maxspeed: '100',
+        'maxspeed:advisory': String(speed)
+    };
+
+    return {
+        icon: 'iD-highway-motorway-link',
+        geometry: ['line'],
+        fields: [...MOTORWAY_LINK_FIELDS],
+        moreFields: [...MOTORWAY_LINK_FIELDS],
+        tags,
+        addTags: { ...tags },
+        removeTags: buildRemoveTags(tags),
+        matchScore: 2,
+        reference: REFERENCE,
+        name: presetNameEn(id)
+    };
+}
+
+export const motorwayLinkAdvisoryPresets: Record<string, CustomPreset> = Object.fromEntries(
+    ADVISORY_SPEEDS.map((speed) => [advisoryId(speed), advisoryPreset(speed)] as const)
+);

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -16,6 +16,7 @@ import { streetSidewalkVariantPresets } from './presets/highway/street_sidewalk_
 import { serviceVariantPresets } from './presets/highway/service_variants';
 import { serviceDisusedPresets } from './presets/highway/service_disused';
 import { motorwayLinkTransitionPresets } from './presets/highway/motorway_link_transition';
+import { motorwayLinkAdvisoryPresets } from './presets/highway/motorway_link_advisory';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { tactilePavingYesPresets } from './presets/highway/crossing/tactile_paving_yes';
@@ -71,6 +72,7 @@ export const customPresets: Record<string, CustomPreset> = {
     ...serviceVariantPresets,
     ...serviceDisusedPresets,
     ...motorwayLinkTransitionPresets,
+    ...motorwayLinkAdvisoryPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,
     ...tactilePavingYesPresets,

--- a/data/custom-tagging/src/registry.ts
+++ b/data/custom-tagging/src/registry.ts
@@ -17,6 +17,8 @@ import { serviceVariantPresets } from './presets/highway/service_variants';
 import { serviceDisusedPresets } from './presets/highway/service_disused';
 import { motorwayLinkTransitionPresets } from './presets/highway/motorway_link_transition';
 import { motorwayLinkAdvisoryPresets } from './presets/highway/motorway_link_advisory';
+import { motorwayLaneChangePresets } from './presets/highway/motorway_lane_change';
+import { motorwayLaneTransitionPresets } from './presets/highway/motorway_lane_transition';
 import { trackPrivatePresets } from './presets/highway/track_private';
 import { stepsVariantPresets } from './presets/highway/steps_variants';
 import { tactilePavingYesPresets } from './presets/highway/crossing/tactile_paving_yes';
@@ -73,6 +75,8 @@ export const customPresets: Record<string, CustomPreset> = {
     ...serviceDisusedPresets,
     ...motorwayLinkTransitionPresets,
     ...motorwayLinkAdvisoryPresets,
+    ...motorwayLaneChangePresets,
+    ...motorwayLaneTransitionPresets,
     ...trackPrivatePresets,
     ...stepsVariantPresets,
     ...tactilePavingYesPresets,

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -921,6 +921,36 @@
         "terms": "mlt1, motorway link, ramp, transition, placement transition, oneway, one lane, 1 lane, asphalt, 100, maxspeed 100",
         "aliases": "mlt1"
     },
+    "highway/motorway_link/oneway_1_100_advisory_25": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 25 km/h)",
+        "terms": "mla25, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 25",
+        "aliases": "mla25"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_35": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 35 km/h)",
+        "terms": "mla35, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 35",
+        "aliases": "mla35"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_45": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 45 km/h)",
+        "terms": "mla45, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 45",
+        "aliases": "mla45"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_55": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 55 km/h)",
+        "terms": "mla55, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 55",
+        "aliases": "mla55"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_65": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 65 km/h)",
+        "terms": "mla65, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 65",
+        "aliases": "mla65"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_75": {
+        "name": "Motorway link (1 lane, 100 km/h, advisory 75 km/h)",
+        "terms": "mla75, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 75",
+        "aliases": "mla75"
+    },
     "highway/steps_customers": {
         "name": "Customers steps",
         "terms": "stc, customers, steps, stairs, staircase, stairway",

--- a/data/locales/custom_presets/en.json
+++ b/data/locales/custom_presets/en.json
@@ -951,6 +951,31 @@
         "terms": "mla75, motorway link, ramp, oneway, one lane, 1 lane, maxspeed 100, advisory speed, 75",
         "aliases": "mla75"
     },
+    "highway/motorway/left_of_2_lanes_3_change_yes_not_right_no": {
+        "name": "Motorway (3 lanes, offset left of 2, lane drop on the right)",
+        "terms": "m3lc, motorway, 3 lanes, placement, left_of, change lanes, lane drop, merge",
+        "aliases": "m3lc"
+    },
+    "highway/motorway/placement_transition_lanes_2_to_3": {
+        "name": "Motorway (lane gain, 2 to 3 lanes)",
+        "terms": "m23t, motorway, lanes, transition, placement transition, width, lane gain, added lane",
+        "aliases": "m23t"
+    },
+    "highway/motorway/placement_transition_lanes_3_to_4": {
+        "name": "Motorway (lane gain, 3 to 4 lanes)",
+        "terms": "m34t, motorway, lanes, transition, placement transition, width, lane gain, added lane",
+        "aliases": "m34t"
+    },
+    "highway/motorway/placement_transition_lanes_3_to_2": {
+        "name": "Motorway (lane loss, 3 to 2 lanes)",
+        "terms": "m32t, motorway, lanes, transition, placement transition, width, lane loss, dropped lane",
+        "aliases": "m32t"
+    },
+    "highway/motorway/placement_transition_lanes_4_to_3": {
+        "name": "Motorway (lane loss, 4 to 3 lanes)",
+        "terms": "m43t, motorway, lanes, transition, placement transition, width, lane loss, dropped lane",
+        "aliases": "m43t"
+    },
     "highway/steps_customers": {
         "name": "Customers steps",
         "terms": "stc, customers, steps, stairs, staircase, stairway",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -921,6 +921,36 @@
         "terms": "mlt1, lien autoroute, bretelle, transition, placement transition, sens unique, une voie, 1 voie, asphalt, 100, maxspeed 100",
         "aliases": "mlt1"
     },
+    "highway/motorway_link/oneway_1_100_advisory_25": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 25 km/h)",
+        "terms": "mla25, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 25",
+        "aliases": "mla25"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_35": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 35 km/h)",
+        "terms": "mla35, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 35",
+        "aliases": "mla35"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_45": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 45 km/h)",
+        "terms": "mla45, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 45",
+        "aliases": "mla45"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_55": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 55 km/h)",
+        "terms": "mla55, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 55",
+        "aliases": "mla55"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_65": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 65 km/h)",
+        "terms": "mla65, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 65",
+        "aliases": "mla65"
+    },
+    "highway/motorway_link/oneway_1_100_advisory_75": {
+        "name": "Lien autoroute (1 voie, 100 km/h, vitesse conseillée 75 km/h)",
+        "terms": "mla75, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 75",
+        "aliases": "mla75"
+    },
     "highway/steps_customers": {
         "name": "Escalier clients",
         "terms": "stc, clients, escalier, escaliers, marches",

--- a/data/locales/custom_presets/fr.json
+++ b/data/locales/custom_presets/fr.json
@@ -951,6 +951,31 @@
         "terms": "mla75, lien autoroute, bretelle, sens unique, une voie, 1 voie, maxspeed 100, vitesse conseillée, 75",
         "aliases": "mla75"
     },
+    "highway/motorway/left_of_2_lanes_3_change_yes_not_right_no": {
+        "name": "Autoroute (3 voies, décalée à gauche de 2, perte de voie à droite)",
+        "terms": "m3lc, autoroute, 3 voies, placement, left_of, changement de voie, perte de voie, fusion",
+        "aliases": "m3lc"
+    },
+    "highway/motorway/placement_transition_lanes_2_to_3": {
+        "name": "Autoroute (gain de voie, 2 à 3 voies)",
+        "terms": "m23t, autoroute, voies, transition, placement transition, largeur, gain de voie, voie ajoutée",
+        "aliases": "m23t"
+    },
+    "highway/motorway/placement_transition_lanes_3_to_4": {
+        "name": "Autoroute (gain de voie, 3 à 4 voies)",
+        "terms": "m34t, autoroute, voies, transition, placement transition, largeur, gain de voie, voie ajoutée",
+        "aliases": "m34t"
+    },
+    "highway/motorway/placement_transition_lanes_3_to_2": {
+        "name": "Autoroute (perte de voie, 3 à 2 voies)",
+        "terms": "m32t, autoroute, voies, transition, placement transition, largeur, perte de voie, voie supprimée",
+        "aliases": "m32t"
+    },
+    "highway/motorway/placement_transition_lanes_4_to_3": {
+        "name": "Autoroute (perte de voie, 4 à 3 voies)",
+        "terms": "m43t, autoroute, voies, transition, placement transition, largeur, perte de voie, voie supprimée",
+        "aliases": "m43t"
+    },
     "highway/steps_customers": {
         "name": "Escalier clients",
         "terms": "stc, clients, escalier, escaliers, marches",

--- a/test/spec/presets/custom/motorway_lanes.js
+++ b/test/spec/presets/custom/motorway_lanes.js
@@ -1,0 +1,42 @@
+import { loadCustomPresets } from './setup.js';
+
+describe('custom presets — motorway lane change / transition', function() {
+    loadCustomPresets();
+
+    it('defines the 3-lane, offset left_of:2, lane-drop-right preset', function() {
+        const id = 'highway/motorway/left_of_2_lanes_3_change_yes_not_right_no';
+        const preset = iD.presetManager.item(id);
+        expect(preset, id).to.exist;
+        expect(preset.tags).to.eql({
+            highway: 'motorway',
+            lanes: '3',
+            oneway: 'yes',
+            placement: 'left_of:2',
+            'change:lanes': 'yes|not_right|no'
+        });
+        const pool = iD.presetManager.matchAllGeometry(['line']);
+        expect(pool.search('m3lc', 'line').collection.map((p) => p.id)).to.include(id);
+    });
+
+    [
+        { from: 2, to: 3, lanes: 3, widthKey: 'width:lanes:start', width: '||0', alias: 'm23t' },
+        { from: 3, to: 4, lanes: 4, widthKey: 'width:lanes:start', width: '|||0', alias: 'm34t' },
+        { from: 3, to: 2, lanes: 3, widthKey: 'width:lanes:end', width: '||0', alias: 'm32t' },
+        { from: 4, to: 3, lanes: 4, widthKey: 'width:lanes:end', width: '|||0', alias: 'm43t' }
+    ].forEach(function({ from, to, lanes, widthKey, width, alias }) {
+        it(`defines the ${from}-to-${to} lane transition preset`, function() {
+            const id = `highway/motorway/placement_transition_lanes_${from}_to_${to}`;
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql({
+                highway: 'motorway',
+                lanes: String(lanes),
+                oneway: 'yes',
+                placement: 'transition',
+                [widthKey]: width
+            });
+            const pool = iD.presetManager.matchAllGeometry(['line']);
+            expect(pool.search(alias, 'line').collection.map((p) => p.id)).to.include(id);
+        });
+    });
+});

--- a/test/spec/presets/custom/motorway_link.js
+++ b/test/spec/presets/custom/motorway_link.js
@@ -29,6 +29,36 @@ describe('custom presets — motorway link transition', function() {
     });
 });
 
+const ADVISORY_CASES = [25, 35, 45, 55, 65, 75].map((speed) => ({
+    id: `highway/motorway_link/oneway_1_100_advisory_${speed}`,
+    alias: `mla${speed}`,
+    speed
+}));
+
+describe('custom presets — motorway link advisory speed', function() {
+    loadCustomPresets();
+
+    ADVISORY_CASES.forEach(function({ id, alias, speed }) {
+        it(`defines ${id} with expected tags`, function() {
+            const preset = iD.presetManager.item(id);
+            expect(preset, id).to.exist;
+            expect(preset.tags).to.eql({
+                highway: 'motorway_link',
+                lanes: '1',
+                oneway: 'yes',
+                maxspeed: '100',
+                'maxspeed:advisory': String(speed)
+            });
+        });
+
+        it(`finds ${id} via search alias ${alias}`, function() {
+            const pool = iD.presetManager.matchAllGeometry(['line']);
+            const ids = pool.search(alias, 'line').collection.map((p) => p.id);
+            expect(ids).to.include(id);
+        });
+    });
+});
+
 // Regression: the US/CA regional variant of `highway/motorway_link` lists
 // `maxspeed/advisory` in `fields` but legal `maxspeed` only in `moreFields`
 // (upstream shows advisory-only by default on ramps there). Our advisory-speed


### PR DESCRIPTION
## Summary
- `highway/motorway_link/oneway_1_100_advisory_{25,35,45,55,65,75}`: one preset per curve advisory speed (`highway=motorway_link lanes=1 oneway=yes maxspeed=100 maxspeed:advisory=<speed>`).
- `highway/motorway/left_of_2_lanes_3_change_yes_not_right_no`: 3-lane motorway drawn offset left of 2 through lanes, with `change:lanes=yes|not_right|no`.
- `highway/motorway/placement_transition_lanes_{2_to_3,3_to_4}`: lane-gain transitions (`width:lanes:start`).
- `highway/motorway/placement_transition_lanes_{3_to_2,4_to_3}`: their inverse, lane-loss transitions (`width:lanes:end`).

## Test plan
- [x] `npm run build:presets:custom`, inspected compiled tags for all 9 new presets
- [x] `npx vitest run test/spec/presets/custom/` (257 tests pass)
- [x] `npx tsc --noEmit` / `npx eslint` on touched files (clean)